### PR TITLE
remove github pages URL from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # PerfCompare
+
 Performance Comparison Tool
 
 ![screenshot](screenshot.png)
-
-[PerfCompare](https://kimberlythegeek.github.io/perfcompare/)


### PR DESCRIPTION
I had a github pages deployment set up, it was still linking to my page, we could possibly set this up again in the future but for now I'm just removing it