### PR TITLE
add circleci badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # PerfCompare
+[![CircleCI](https://circleci.com/gh/mozilla/perfcompare/tree/master.svg?style=svg&circle-token=0e469081c107bb9544086a649c703dfc02ab178b)](https://circleci.com/gh/mozilla/perfcompare/tree/master)
 
 Performance Comparison Tool
 


### PR DESCRIPTION
private repositories require an API access token for this badge: https://circleci.com/docs/2.0/status-badges/#creating-badges-for-private-repositories

we can replace this when the repository goes public