### PR TITLE
cache dependencies in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,24 @@ jobs:
             tag: '16.13'
         steps:
             - checkout
-            - run: npm install
-            - run: npm run lint
-            - run: echo "npm run test"
+            - restore_cache: # special step to restore the dependency cache
+                # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
+                key: dependency-cache-{{ checksum "package.json" }}
+            - run: 
+                name: install
+                command: npm install
+            - save_cache: # special step to save the dependency cache
+                key: dependency-cache-{{ checksum "package.json" }}
+                paths:
+                    - ./node_modules
+            - run:
+                name: lint
+                command: npm run lint
+            - run: 
+                name: test
+                command: echo "npm run test"
+
+
 
 workflows:
     version: '2.1'


### PR DESCRIPTION
caches node_modules to use in next CI run, unless package-lock.json has changed