### PR TITLE
update circleci badge to public

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # PerfCompare
-[![CircleCI](https://circleci.com/gh/mozilla/perfcompare/tree/master.svg?style=svg&circle-token=0e469081c107bb9544086a649c703dfc02ab178b)](https://circleci.com/gh/mozilla/perfcompare/tree/master)
+
+[![CircleCI](https://circleci.com/gh/mozilla/perfcompare/tree/master.svg?style=svg)](https://circleci.com/gh/mozilla/perfcompare/tree/master)
 
 Performance Comparison Tool
 
@@ -9,9 +10,9 @@ Performance Comparison Tool
 
 ### Requirements
 
--   [nodejs](https://nodejs.org/en/download/)
--   [python](https://www.python.org/downloads/release/python-369/)
--   [pip](https://pip.pypa.io/en/stable/installation/)
+- [nodejs](https://nodejs.org/en/download/)
+- [python](https://www.python.org/downloads/release/python-369/)
+- [pip](https://pip.pypa.io/en/stable/installation/)
 
 ### Installation
 
@@ -27,8 +28,10 @@ npm install
 npm start
 ```
 
-### Validating JavaScript 
-We run our JavaScript code in the frontend through [ESLint](https://eslint.org/) to ensure that new code has a consistent style and doesn't suffer from common errors. 
+### Validating JavaScript
+
+We run our JavaScript code in the frontend through [ESLint](https://eslint.org/) to ensure that new code has a consistent style and doesn't suffer from common errors.
+
 ```
 # To run ESLint by itself, you may run the lint task:
 npm run lint


### PR DESCRIPTION
I spoke with a member of the dev ops team and was told I should not have been able to create a private repository :) this is something you have to submit a request for.

Generally this is used to prevent security leaks and other security related concerns.

I've submitted a bug to change the visibility of the repo to public: https://bugzilla.mozilla.org/show_bug.cgi?id=1762511

the circleci badge contains an access token and should be updated to use the public non-secret url