### PR TITLE
reject thunks that return no results

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,15 +19,6 @@ module.exports = {
   },
   plugins: ['react'],
   rules: {
-    // require line break after operator
-    'operator-linebreak': ['error', 'after'],
-    // error on prettier lint issues
-    'prettier/prettier': 'error',
-    // ignore rule for reducers updating state
-    'no-param-reassign': [
-      'error',
-      { props: true, ignorePropertyModificationsFor: ['state'] },
-    ],
     'import/order': [
       'error',
       {
@@ -47,6 +38,25 @@ module.exports = {
         },
       },
     ],
+    // ignore rule for reducers updating state
+    'no-param-reassign': [
+      'error',
+      { props: true, ignorePropertyModificationsFor: ['state'] },
+    ],
+    // this rule prevents using identifiers such as '_foo' or '__bar__',
+    // which indicate to those contributing that this should not be
+    // used outside the context in which it is defined
+    'no-underscore-dangle': 'off',
+    // require line breaks between curly braces in imports
+    // only if there are line breaks between properties
+    'object-curly-newline': [
+      'error',
+      { ImportDeclaration: { multiline: true } },
+    ],
+    // require line break after operator
+    'operator-linebreak': ['error', 'after'],
+    // error on prettier lint issues
+    'prettier/prettier': 'error',
   },
   overrides: [
     {

--- a/src/reducers/SearchSlice.jsx
+++ b/src/reducers/SearchSlice.jsx
@@ -7,20 +7,21 @@ import {
 } from '../thunks/searchThunk';
 
 const initialState = {
-  recentRevisions: [],
   repository: '',
   searchResults: [],
   searchValue: '',
-  loading: 'idle',
+  errorMessage: null,
 };
 
 const search = createSlice({
   name: 'search',
   initialState,
   reducers: {
-    updateLoadingState(state, action) {
-      state.loading = action.payload;
+    // BEGIN used for testing only
+    updateErrorMessage(state, action) {
+      state.errorMessage = action.payload;
     },
+    // END used for testing only
     updateSearchValue(state, action) {
       state.searchValue = action.payload;
     },
@@ -34,43 +35,31 @@ const search = createSlice({
   extraReducers: (builder) => {
     builder
       // fetchRecentRevisions
-      .addCase(fetchRecentRevisions.pending, (state) => {
-        state.loading = 'pending';
-      })
       .addCase(fetchRecentRevisions.fulfilled, (state, action) => {
-        state.loading = 'succeeded';
-        state.recentRevisions = action.payload;
+        state.searchResults = action.payload;
       })
-      .addCase(fetchRecentRevisions.rejected, (state) => {
-        state.loading = 'failed';
+      .addCase(fetchRecentRevisions.rejected, (state, action) => {
+        state.errorMessage = action.payload;
       })
       // fetchRevisionByID
-      .addCase(fetchRevisionByID.pending, (state) => {
-        state.loading = 'pending';
-      })
       .addCase(fetchRevisionByID.fulfilled, (state, action) => {
-        state.loading = 'succeeded';
         state.searchResults = action.payload;
       })
-      .addCase(fetchRevisionByID.rejected, (state) => {
-        state.loading = 'failed';
+      .addCase(fetchRevisionByID.rejected, (state, action) => {
+        state.errorMessage = action.payload;
       })
       // fetchRevisionsByAuthor
-      .addCase(fetchRevisionsByAuthor.pending, (state) => {
-        state.loading = 'pending';
-      })
       .addCase(fetchRevisionsByAuthor.fulfilled, (state, action) => {
-        state.loading = 'succeeded';
         state.searchResults = action.payload;
       })
-      .addCase(fetchRevisionsByAuthor.rejected, (state) => {
-        state.loading = 'failed';
+      .addCase(fetchRevisionsByAuthor.rejected, (state, action) => {
+        state.errorMessage = action.payload;
       });
   },
 });
 
 export const {
-  updateLoadingState,
+  updateErrorMessage,
   updateSearchValue,
   updateSearchResults,
   updateRepository,

--- a/src/tests/SearchView.test.jsx
+++ b/src/tests/SearchView.test.jsx
@@ -10,14 +10,8 @@ import store from '../common/store';
 import SearchInput from '../components/Search/SearchInput';
 import SearchResultsList from '../components/Search/SearchResultsList';
 import SearchView from '../components/Search/SearchView';
-import {
-  updateRepository,
-  updateSearchResults,
-  updateSearchValue,
-} from '../reducers/SearchSlice';
-import { render, fireEvent, screen } from './utils/test-utils';
-
-const unmockedFetch = global.fetch;
+import { updateSearchResults } from '../reducers/SearchSlice';
+import { act, render, fireEvent, screen } from './utils/test-utils';
 
 beforeEach(() => {
   global.fetch = () =>
@@ -26,16 +20,6 @@ beforeEach(() => {
         json: () => [],
       }),
     );
-});
-
-afterEach(() => {
-  global.fetch = unmockedFetch;
-  store.dispatch(updateSearchValue(''));
-  store.dispatch(updateSearchResults([]));
-  store.dispatch(updateRepository(''));
-  jest.clearAllMocks();
-  jest.resetAllMocks();
-  jest.restoreAllMocks();
 });
 
 describe('Search View', () => {
@@ -114,7 +98,9 @@ describe('Search Results List', () => {
         repository_id: 3,
       },
     ];
-    store.dispatch(updateSearchResults(results));
+    act(() => {
+      store.dispatch(updateSearchResults(results));
+    });
 
     const searchResultsList = render(<SearchResultsList store={store} />);
 

--- a/src/tests/searchViewHelpers.test.js
+++ b/src/tests/searchViewHelpers.test.js
@@ -9,20 +9,12 @@ import searchViewHelper from '../utils/searchViewHelper';
 const { searchByRevisionOrEmail, handleChangeDropdown, handleChangeSearch } =
   searchViewHelper;
 
-const unmockedFetch = global.fetch;
-
 beforeEach(() => {
-  global.fetch = jest.fn();
+  jest.useFakeTimers();
 });
 
 afterEach(() => {
-  store.dispatch(updateSearchValue(''));
-  store.dispatch(updateSearchResults([]));
-  store.dispatch(updateRepository(''));
-  global.fetch = unmockedFetch;
-  jest.clearAllMocks();
-  jest.resetAllMocks();
-  jest.restoreAllMocks();
+  jest.useRealTimers();
 });
 
 describe('handleChangeDropdown', () => {
@@ -32,6 +24,7 @@ describe('handleChangeDropdown', () => {
 
     // Ensure state has been reset in between tests
     expect(store.getState().search.repository).toBe('');
+    expect(store.getState().search.searchValue).toBe('');
 
     handleChangeDropdown(event);
 
@@ -44,6 +37,10 @@ describe('handleChangeDropdown', () => {
   });
 
   it('should call fetch with correct URL', () => {
+    // Ensure state has been reset in between tests
+    expect(store.getState().search.repository).toBe('');
+    expect(store.getState().search.searchValue).toBe('');
+
     const spyOnFetch = jest.spyOn(global, 'fetch');
     const event = { target: { innerText: 'coconut' } };
     handleChangeDropdown(event);
@@ -95,6 +92,7 @@ describe('handleChangeSearch', () => {
     expect(store.getState().search.searchValue).toBe('');
 
     handleChangeSearch(event);
+    jest.runAllTimers();
 
     expect(spyOnLog).toHaveBeenCalled();
     expect(store.getState().search.searchValue).toBe('spam');
@@ -112,6 +110,7 @@ describe('handleChangeSearch', () => {
     store.dispatch(updateRepository('coconut'));
 
     handleChangeSearch(event);
+    jest.runAllTimers();
 
     expect(spyOnDispatch).toHaveBeenCalledTimes(2);
     expect(spyOnDispatch).toHaveBeenNthCalledWith(2, {

--- a/src/tests/setupTests.js
+++ b/src/tests/setupTests.js
@@ -5,3 +5,37 @@
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 import '@testing-library/jest-dom';
+
+import store from '../common/store';
+import {
+  updateErrorMessage,
+  updateRepository,
+  updateSearchResults,
+  updateSearchValue,
+} from '../reducers/SearchSlice';
+import { act } from './utils/test-utils';
+
+const unmockedFetch = global.fetch;
+
+beforeAll(() => {
+  global.fetch = jest.fn();
+});
+
+afterAll(() => {
+  global.fetch = unmockedFetch;
+});
+
+beforeEach(() => {
+  act(() => {
+    store.dispatch(updateErrorMessage(null));
+    store.dispatch(updateSearchValue(''));
+    store.dispatch(updateSearchResults([]));
+    store.dispatch(updateRepository(''));
+  });
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+  jest.resetAllMocks();
+  jest.restoreAllMocks();
+});

--- a/src/thunks/searchThunk.js
+++ b/src/thunks/searchThunk.js
@@ -9,13 +9,16 @@ export const fetchRecentRevisions = createAsyncThunk(
     try {
       response = await fetch(
         `${treeherderBaseURL}/api/project/${repository}/push/`,
-      )
-        .then((res) => res.json())
-        .then((res) => res.results);
+      );
     } catch (err) {
-      return rejectWithValue(err.response.data);
+      return rejectWithValue(err.message);
     }
-    return response;
+    const json = await response.json();
+    if (json.results.length > 0) {
+      return json.results;
+    }
+
+    return rejectWithValue('No results found');
   },
 );
 
@@ -26,29 +29,35 @@ export const fetchRevisionByID = createAsyncThunk(
     try {
       response = await fetch(
         `${treeherderBaseURL}/api/project/${repository}/push/?revision=${search}`,
-      )
-        .then((res) => res.json())
-        .then((res) => res.results);
+      );
     } catch (err) {
-      return rejectWithValue(err.response.data);
+      return rejectWithValue(err.message);
     }
-    return response;
+    const json = await response.json();
+    if (json.results.length > 0) {
+      return json.results;
+    }
+
+    return rejectWithValue('No results found');
   },
 );
 
 export const fetchRevisionsByAuthor = createAsyncThunk(
   'search/fetchRevisionsByAuthor',
-  async ({ repository, search }, rejectWithValue) => {
+  async ({ repository, search }, { rejectWithValue }) => {
     let response;
     try {
       response = await fetch(
         `${treeherderBaseURL}/api/project/${repository}/push/?author=${search}`,
-      )
-        .then((res) => res.json())
-        .then((res) => res.results);
+      );
     } catch (err) {
-      return rejectWithValue(err.response.data);
+      return rejectWithValue(err.message);
     }
-    return response;
+    const json = await response.json();
+    if (json.results.length > 0) {
+      return json.results;
+    }
+
+    return rejectWithValue('No results found');
   },
 );


### PR DESCRIPTION
the api call to fetch recent revisions or search results is called whenever a value is entered that matches a search hash or email. 

so, if typing "ksereduck@mozilla.com", the api call will be made at `ksereduck@mozilla.c` `ksereduck@mozilla.co`, and `ksereduck@mozilla.com`

I found that the results for the complete email would appear, then disappear, because one of the previous API calls completed after the valid one, and would overwrite the search results with an empty array