### PR TITLE
create reusable modal alert

### DIFF
--- a/src/common/store.ts
+++ b/src/common/store.ts
@@ -1,10 +1,12 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { combineReducers } from 'redux';
 
+import alert from '../reducers/AlertSlice';
 import search from '../reducers/SearchSlice';
 import selectedRevisions from '../reducers/SelectedRevisions';
 
 const reducer = combineReducers({
+  alert,
   search,
   selectedRevisions,
 });

--- a/src/components/Shared/HeaderAlert.tsx
+++ b/src/components/Shared/HeaderAlert.tsx
@@ -1,0 +1,34 @@
+import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
+import { connect } from 'react-redux';
+
+import useAlert from '../../hooks/useAlert';
+import type { AlertType, State } from '../../types/state';
+
+function HeaderAlert(props: HeaderAlertProps) {
+  const { alert } = props;
+  const { dispatchClearAlert } = useAlert();
+  return (
+    <Alert
+      severity={alert.severity}
+      onClose={(e: React.SyntheticEvent) => {
+        dispatchClearAlert(e);
+      }}
+    >
+      {alert.title && <AlertTitle>{alert.title}</AlertTitle>}
+      {alert.message}
+    </Alert>
+  );
+}
+
+interface HeaderAlertProps {
+  alert: AlertType;
+}
+
+function mapStateToProps(state: State) {
+  return {
+    alert: state.alert.alert,
+  };
+}
+
+export default connect(mapStateToProps)(HeaderAlert);

--- a/src/components/Shared/PerfCompareHeader.tsx
+++ b/src/components/Shared/PerfCompareHeader.tsx
@@ -1,9 +1,22 @@
 import Box from '@mui/material/Box';
+import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
+import { connect } from 'react-redux';
 
-function PerfCompareHeader() {
+import type { State } from '../../types/state';
+import HeaderAlert from './HeaderAlert';
+
+function PerfCompareHeader(props: PerfCompareHeaderProps) {
+  const { isAlert } = props;
   return (
     <Box>
+      <Grid container sx={{ height: '3rem' }}>
+        <Grid item xs={4} />
+        <Grid item xs={4}>
+          {isAlert && <HeaderAlert />}
+        </Grid>
+        <Grid item xs={4} />
+      </Grid>
       <Typography
         variant="h1"
         component="div"
@@ -17,4 +30,14 @@ function PerfCompareHeader() {
   );
 }
 
-export default PerfCompareHeader;
+interface PerfCompareHeaderProps {
+  isAlert: boolean;
+}
+
+function mapStateToProps(state: State) {
+  return {
+    isAlert: state.alert.isAlert,
+  };
+}
+
+export default connect(mapStateToProps)(PerfCompareHeader);

--- a/src/hooks/useAlert.ts
+++ b/src/hooks/useAlert.ts
@@ -1,0 +1,26 @@
+import { useDispatch } from 'react-redux';
+
+import type { AppDispatch } from '../common/store';
+import { clearAlert, setAlert } from '../reducers/AlertSlice';
+import type { AlertType } from '../types/state';
+
+const useAlert = () => {
+  const dispatch: AppDispatch = useDispatch();
+
+  const dispatchClearAlert = (e: React.SyntheticEvent) => {
+    e.stopPropagation();
+    dispatch(clearAlert());
+  };
+
+  const dispatchSetAlert = (
+    message: AlertType['message'],
+    severity: AlertType['severity'],
+    title: AlertType['title'] = undefined,
+  ) => {
+    dispatch(setAlert({ message, title, severity }));
+  };
+
+  return { dispatchClearAlert, dispatchSetAlert };
+};
+
+export default useAlert;

--- a/src/hooks/useCheckRevision.ts
+++ b/src/hooks/useCheckRevision.ts
@@ -1,28 +1,29 @@
 import React from 'react';
 
+import useAlert from './useAlert';
 import useFocusInput from './useFocusInput';
 
 const useCheckRevision = () => {
+  const { dispatchSetAlert } = useAlert();
   const { handleChildClick } = useFocusInput();
   const [checked, setChecked] = React.useState<string[]>([]);
 
   const handleToggle = (e: React.MouseEvent) => {
     const revisionID = (e.currentTarget as HTMLElement).id;
-    const currentIndex = checked.indexOf(revisionID);
+    const isChecked = checked.includes(revisionID);
     const newChecked = [...checked];
 
-    handleChildClick(e);
-
-    if (checked.length < 4) {
-      // if item is not already checked, add to checked
-      if (currentIndex === -1) newChecked.push(revisionID);
+    // if item is not already checked, add to checked
+    if (checked.length < 4 && !isChecked) {
+      newChecked.push(revisionID);
+    } else if (isChecked) {
       // if item is already checked, remove from checked
-      else newChecked.splice(currentIndex, 1);
+      newChecked.splice(checked.indexOf(revisionID), 1);
     } else {
       // if there are already 4 checked revisions, print a warning
-      // TODO: replace with pop up notification
-      console.log('maximum four revisions');
+      dispatchSetAlert('Maximum 4 Revisions', 'warning');
     }
+    handleChildClick(e);
 
     setChecked(newChecked);
   };

--- a/src/reducers/AlertSlice.tsx
+++ b/src/reducers/AlertSlice.tsx
@@ -1,0 +1,30 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import type { AlertState, AlertType } from '../types/state';
+
+const initialState: AlertState = {
+  isAlert: false,
+  alert: {
+    message: '',
+    title: undefined,
+    severity: undefined,
+  },
+};
+
+const alert = createSlice({
+  name: 'alert',
+  initialState,
+  reducers: {
+    clearAlert(state) {
+      state.isAlert = initialState.isAlert;
+      state.alert = initialState.alert;
+    },
+    setAlert(state, action: PayloadAction<AlertType>) {
+      state.isAlert = true;
+      state.alert = action.payload;
+    },
+  },
+});
+
+export const { clearAlert, setAlert } = alert.actions;
+export default alert.reducer;

--- a/src/tests/PerfCompareHeader.test.tsx
+++ b/src/tests/PerfCompareHeader.test.tsx
@@ -1,0 +1,44 @@
+import userEvent from '@testing-library/user-event';
+
+import PerfCompareHeader from '../components/Shared/PerfCompareHeader';
+import { setAlert } from '../reducers/AlertSlice';
+import type { AlertType } from '../types/state';
+import { render, screen, store } from './utils/test-utils';
+
+const message = 'Maximum 4 Revisions';
+const severity: AlertType['severity'] = 'error';
+let title;
+
+describe('PerfCompareHeader', () => {
+  it('renders correctly when there is no alert', () => {
+    render(<PerfCompareHeader />);
+
+    expect(document.body).toMatchSnapshot();
+  });
+
+  it('should hide alert when close button is clicked', async () => {
+    // set delay to null to prevent test time-out due to useFakeTimers
+    const user = userEvent.setup({ delay: null });
+    title = undefined;
+
+    store.dispatch(setAlert({ message, severity, title }));
+    render(<PerfCompareHeader />);
+
+    expect(screen.getByText('Maximum 4 Revisions')).toBeInTheDocument();
+    expect(document.body).toMatchSnapshot();
+
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    expect(screen.queryByText('Maximum 4 Revisions')).not.toBeInTheDocument();
+  });
+
+  it('should should show alert title', async () => {
+    title = 'This is a title';
+
+    store.dispatch(setAlert({ message, severity, title }));
+    render(<PerfCompareHeader />);
+
+    expect(screen.getByText('This is a title')).toBeInTheDocument();
+
+    expect(document.body).toMatchSnapshot();
+  });
+});

--- a/src/tests/Search/SearchResultsList.test.tsx
+++ b/src/tests/Search/SearchResultsList.test.tsx
@@ -75,7 +75,6 @@ describe('SearchResultsList', () => {
       }),
     ) as jest.Mock;
     jest.spyOn(global, 'fetch');
-    const spyOnConsole = jest.spyOn(console, 'log');
     // set delay to null to prevent test time-out due to useFakeTimers
     const user = userEvent.setup({ delay: null });
 
@@ -97,6 +96,12 @@ describe('SearchResultsList', () => {
       screen.getByTestId('checkbox-5').classList.contains('Mui-checked'),
     ).toBe(false);
 
-    expect(spyOnConsole).toHaveBeenCalledWith('maximum four revisions');
+    expect(screen.getByText('Maximum 4 Revisions')).toBeInTheDocument();
+
+    // Should allow unchecking revisions even after four have been selected
+    await user.click(screen.getByTestId('checkbox-1'));
+    expect(
+      screen.getByTestId('checkbox-1').classList.contains('Mui-checked'),
+    ).toBe(false);
   });
 });

--- a/src/tests/Search/__snapshots__/SearchView.test.tsx.snap
+++ b/src/tests/Search/__snapshots__/SearchView.test.tsx.snap
@@ -10,6 +10,19 @@ exports[`Search View renders correctly when there are no results 1`] = `
         class="MuiBox-root css-0"
       >
         <div
+          class="MuiGrid-root MuiGrid-container css-5q2xqw-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+          />
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+          />
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+          />
+        </div>
+        <div
           class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-1bn4tuo-MuiTypography-root"
         >
           PerfCompare
@@ -357,6 +370,19 @@ exports[`Search View should hide search results when clicking outside of search 
         class="MuiBox-root css-0"
       >
         <div
+          class="MuiGrid-root MuiGrid-container css-5q2xqw-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+          />
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+          />
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+          />
+        </div>
+        <div
           class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-1bn4tuo-MuiTypography-root"
         >
           PerfCompare
@@ -703,6 +729,19 @@ exports[`Search View should not hide search results when clicking search results
       <div
         class="MuiBox-root css-0"
       >
+        <div
+          class="MuiGrid-root MuiGrid-container css-5q2xqw-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+          />
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+          />
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+          />
+        </div>
         <div
           class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-1bn4tuo-MuiTypography-root"
         >

--- a/src/tests/Search/__snapshots__/fetchRecentRevisions.test.tsx.snap
+++ b/src/tests/Search/__snapshots__/fetchRecentRevisions.test.tsx.snap
@@ -12,6 +12,19 @@ exports[`SearchView/fetchRecentRevisions should fetch and display recent results
         class="MuiBox-root css-0"
       >
         <div
+          class="MuiGrid-root MuiGrid-container css-5q2xqw-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+          />
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+          />
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+          />
+        </div>
+        <div
           class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-1bn4tuo-MuiTypography-root"
         >
           PerfCompare

--- a/src/tests/Search/__snapshots__/fetchRevisionByID.test.tsx.snap
+++ b/src/tests/Search/__snapshots__/fetchRevisionByID.test.tsx.snap
@@ -10,6 +10,19 @@ exports[`SearchView/fetchRevisionByID should fetch revisions by ID if searchValu
         class="MuiBox-root css-0"
       >
         <div
+          class="MuiGrid-root MuiGrid-container css-5q2xqw-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+          />
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+          />
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+          />
+        </div>
+        <div
           class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-1bn4tuo-MuiTypography-root"
         >
           PerfCompare

--- a/src/tests/Search/__snapshots__/fetchRevisionsByAuthor.test.tsx.snap
+++ b/src/tests/Search/__snapshots__/fetchRevisionsByAuthor.test.tsx.snap
@@ -10,6 +10,19 @@ exports[`SearchView/fetchRevisionsByAuthor should fetch revisions by author if s
         class="MuiBox-root css-0"
       >
         <div
+          class="MuiGrid-root MuiGrid-container css-5q2xqw-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+          />
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+          />
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+          />
+        </div>
+        <div
           class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-1bn4tuo-MuiTypography-root"
         >
           PerfCompare

--- a/src/tests/__snapshots__/PerfCompareHeader.test.tsx.snap
+++ b/src/tests/__snapshots__/PerfCompareHeader.test.tsx.snap
@@ -1,0 +1,197 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PerfCompareHeader renders correctly when there is no alert 1`] = `
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-0"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container css-5q2xqw-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+        />
+        <div
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+        />
+        <div
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+        />
+      </div>
+      <div
+        class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-1bn4tuo-MuiTypography-root"
+      >
+        PerfCompare
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`PerfCompareHeader should hide alert when close button is clicked 1`] = `
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-0"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container css-5q2xqw-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+        />
+        <div
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+        >
+          <div
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-standardError MuiAlert-standard css-xilmwd-MuiPaper-root-MuiAlert-root"
+            role="alert"
+          >
+            <div
+              class="MuiAlert-icon css-1ytlwq5-MuiAlert-icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1vooibu-MuiSvgIcon-root"
+                data-testid="ErrorOutlineIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+            </div>
+            <div
+              class="MuiAlert-message css-acap47-MuiAlert-message"
+            >
+              Maximum 4 Revisions
+            </div>
+            <div
+              class="MuiAlert-action css-ki1hdl-MuiAlert-action"
+            >
+              <button
+                aria-label="Close"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall css-1e0d89p-MuiButtonBase-root-MuiIconButton-root"
+                tabindex="0"
+                title="Close"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                  data-testid="CloseIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+        />
+      </div>
+      <div
+        class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-1bn4tuo-MuiTypography-root"
+      >
+        PerfCompare
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`PerfCompareHeader should should show alert title 1`] = `
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-0"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-container css-5q2xqw-MuiGrid-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+        />
+        <div
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+        >
+          <div
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-standardError MuiAlert-standard css-xilmwd-MuiPaper-root-MuiAlert-root"
+            role="alert"
+          >
+            <div
+              class="MuiAlert-icon css-1ytlwq5-MuiAlert-icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1vooibu-MuiSvgIcon-root"
+                data-testid="ErrorOutlineIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+            </div>
+            <div
+              class="MuiAlert-message css-acap47-MuiAlert-message"
+            >
+              <div
+                class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom MuiAlertTitle-root css-yslrua-MuiTypography-root-MuiAlertTitle-root"
+              >
+                This is a title
+              </div>
+              Maximum 4 Revisions
+            </div>
+            <div
+              class="MuiAlert-action css-ki1hdl-MuiAlert-action"
+            >
+              <button
+                aria-label="Close"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall css-1e0d89p-MuiButtonBase-root-MuiIconButton-root"
+                tabindex="0"
+                title="Close"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+                  data-testid="CloseIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4 css-gj1fbr-MuiGrid-root"
+        />
+      </div>
+      <div
+        class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-1bn4tuo-MuiTypography-root"
+      >
+        PerfCompare
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -1,3 +1,5 @@
+import type { AlertColor } from '@mui/material/Alert';
+
 export type Repository =
   | { id: 1; name: 'mozilla-central' }
   | { id: 4; name: 'try' }
@@ -21,6 +23,17 @@ export type Revision = {
   repository_id: Repository['id'];
 };
 
+export type AlertType = {
+  message: string;
+  title: string | undefined;
+  severity: AlertColor | undefined;
+};
+
+export type AlertState = {
+  isAlert: boolean;
+  alert: AlertType;
+};
+
 export type SearchState = {
   repository: Repository['name'];
   searchResults: Revision[];
@@ -34,6 +47,7 @@ export type SelectedRevisionsState = {
 };
 
 export type State = {
+  alert: AlertState;
   search: SearchState;
   selectedRevisions: SelectedRevisionsState;
 };


### PR DESCRIPTION
Added dismissable alert to Header component. This replaces the `console.log` statement when a user tries to select more than 4 revisions. Currently, because of the way the focus hook works, dismissing the notification will also hide the search results. I'd like to replace this with a timeout, or at least not hide the results somehow