### PR TITLE
Set the locale for tests to run the same accross the world

### DIFF
--- a/src/tests/utils/globalSetup.ts
+++ b/src/tests/utils/globalSetup.ts
@@ -2,4 +2,5 @@ import 'regenerator-runtime/runtime';
 
 module.exports = async () => {
   process.env.TZ = 'UTC';
+  process.env.LC_ALL = 'C';
 };


### PR DESCRIPTION
Setting the `LC_ALL` variable to the value `C` ensures that all developers will use the same base locale.