### PR TITLE
ignore tests in coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,10 @@
     "typescript": "^4.6.3"
   },
   "jest": {
+    "coveragePathIgnorePatterns": [
+      "node_modules",
+      "src/tests"
+    ],
     "globalSetup": "./src/tests/utils/globalSetup.ts",
     "preset": "ts-jest",
     "setupFilesAfterEnv": [


### PR DESCRIPTION
`npm run test:coverage` was failing due to `export * from '@testing-library/react';` in `test-utils.tsx` not being covered by tests. added ignore paths to exclude tests from coverage