### PR TITLE
Add parameters to url routing

### DIFF
--- a/src/components/Search/SearchView.tsx
+++ b/src/components/Search/SearchView.tsx
@@ -9,6 +9,7 @@ import { useNavigate } from 'react-router-dom';
 
 import useFocusInput from '../../hooks/useFocusInput';
 import { Revision, State } from '../../types/state';
+import { truncateHash } from '../../utils/helpers';
 import PerfCompareHeader from '../Shared/PerfCompareHeader';
 import SelectedRevisionsTable from '../Shared/SelectedRevisionsTable';
 import AddRevisionButton from './AddRevisionButton';
@@ -22,8 +23,14 @@ function SearchView(props: SearchViewProps) {
     useFocusInput();
 
   const navigate = useNavigate();
-  const goToCompareResultsPage = () => {
-    navigate('/compare-results', { replace: false });
+
+  const goToCompareResultsPage = (selectedRevisions: Revision[]) => {
+    const revisions = selectedRevisions.map(rev => truncateHash(rev.revision));
+    const repos = selectedRevisions.map(rev => rev.repository_id);
+    navigate({
+      pathname: '/compare-results', 
+      search: `?revs=${revisions.join(',')}&repos=${repos.join(',')}`,
+    });
   };
 
   const { searchResults, selectedRevisions } = props;
@@ -47,7 +54,7 @@ function SearchView(props: SearchViewProps) {
           <Button
             className="compare-button"
             variant="contained"
-            onClick={goToCompareResultsPage}
+            onClick={() => goToCompareResultsPage(selectedRevisions)}
           >
             compare
             <ArrowForward className="compare-icon" />

--- a/src/tests/Search/SearchView.test.tsx
+++ b/src/tests/Search/SearchView.test.tsx
@@ -216,7 +216,7 @@ describe('Search View', () => {
     );
   });
 
-  it('should have compare button and once clicked should redirect to results page', async () => {
+  it('should have compare button and once clicked should redirect to results page with the right query params', async () => {
     const { testData } = getTestData();
     store.dispatch(setSelectedRevisions(testData.slice(0, 2)));
     const { history } = renderWithRouter(<SearchView />);
@@ -228,5 +228,7 @@ describe('Search View', () => {
     await user.click(compareButton as HTMLElement);
 
     expect(history.location.pathname).toEqual('/compare-results');
+    expect(history.location.search).toEqual('?revs=coconut,spam&repos=4,1');
+
   });
 });


### PR DESCRIPTION
Sample url query params currently generated.
Need to confirm with kim how to generate the short code version of revisions

http://localhost:3000/compare-results?revs=0396329b7d2e5e15a0841736625cc89ceadb4cf4,451c34fdf54bf79c705e058531314baaac7e49e7,dc608e935c5901a6404e9c58a5f73084b396f318,9ab74fb00e731757852c19495351b9f15357c5d4&repos=4,4,4,4

after truncating the url looks more like this:
http://localhost:3000/compare-results?revs=65e579f52525,229fa0fcb904,401c2d7e80fb,c4f1589aaaf5&repos=1,1,1,1