### PR TITLE
fix input focus

### DIFF
--- a/src/components/Shared/RevisionSearch.tsx
+++ b/src/components/Shared/RevisionSearch.tsx
@@ -20,11 +20,16 @@ function RevisionSearch(props: RevisionSearchProps) {
       (e.target as HTMLElement).matches(
         `#search-revision-input, 
           #search-results-list, 
-          #search-results-list *,
-          #add-revision-button`,
+          #search-results-list *`,
       )
     ) {
       setFocused(true);
+    } else if (
+      (e.target as HTMLElement).matches(
+        '#add-revision-button,#add-revision-button *',
+      )
+    ) {
+      return;
     } else {
       setFocused(false);
       dispatch(clearCheckedRevisions());


### PR DESCRIPTION
when clicking the add revision button, sometimes the checked revisions would be cleared before the add revision action was dispatch. this was an error in the focus handling logic, so I added an if condition to do nothing if the target of a mouse click is `#add-revision-button` or a child of it.