### PR TITLE
heroku deploy config

### DIFF
--- a/.github/workflows/heroku-deploy.yml
+++ b/.github/workflows/heroku-deploy.yml
@@ -1,0 +1,45 @@
+name: Heroku Deploy
+
+on:
+  push:
+    branches:
+      - 'staging'
+      - 'master'
+
+jobs:
+  deploy:
+    name: Deploy Heroku
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+        with:
+          # this means that it is a full history clone, not a shallow one
+          # heroku push fails with a shallow clone
+          fetch-depth: 0
+      - name: Set up git credentials
+        run: |
+          # doesn't matter the credentials here since we're not committing anything
+          # but git will complain if these are not set
+          git config --global user.email 'MozmarRobot@users.noreply.github.com'
+          git config --global user.name 'MozMEAO Bot'
+      - name: Set up Heroku CLI
+        env:
+          API_KEY: ${{ secrets.HEROKU_API_KEY }}
+          EMAIL: 'heroku-perfcompare-deployer@mozilla.com'
+        run: |
+          cat > ~/.netrc <<EOF
+          machine api.heroku.com
+              login ${EMAIL}
+              password ${API_KEY}
+          machine git.heroku.com
+              login ${EMAIL}
+              password ${API_KEY}
+          EOF
+      - name: Deploy
+        run: |
+          set -ex
+          # the call to xargs here just strips whitespace
+          export APP_NAME="perfcompare-${GITHUB_REF_NAME}"
+          heroku git:remote --app "$APP_NAME"
+          git push --force heroku "${GITHUB_REF_NAME}:master"


### PR DESCRIPTION
This github action will automatically deploy to heroku on every push to `staging` and `master`

in the heroku pipeline, the staging app is named `perfcompare-staging`, and production app is named `perfcompare-master`.

this action will run on every push to `staging` and `master`, to the appropriate heroku app--`perfcompare-${GITHUB_REF_NAME}`.
`staging` deploys to `perfcompare-staging` and `master` deploys to `perfcompare-master`

This is a successful test run: https://github.com/kimberlythegeek/perfcompare/runs/7259859820
The name of the branch was `demo-deploy` and successfully deployed to a test app named `perfcompare-demo-deploy`: https://perfcompare-demo-deploy.herokuapp.com/