### PR TITLE
print warnings of tests that pass

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
     "globalSetup": "<rootDir>/src/__tests__/utils/globalSetup.ts",
     "preset": "ts-jest",
     "setupFilesAfterEnv": [
-      "<rootDir>/src/__tests__/utils/setupTests.ts"
+      "<rootDir>/src/__tests__/utils/setupTests.ts",
+      "<rootDir>/src/__tests__/utils/jest.setup.js"
     ],
     "testEnvironment": "jsdom",
     "modulePathIgnorePatterns": [

--- a/src/__tests__/utils/jest.setup.js
+++ b/src/__tests__/utils/jest.setup.js
@@ -1,0 +1,11 @@
+const CONSOLE_FAIL_TYPES = ['error', 'warn'];
+
+// Throw errors when a `console.error` or `console.warn` happens
+// by overriding the functions
+CONSOLE_FAIL_TYPES.forEach((type) => {
+  console[type] = (message) => {
+    throw new Error(
+      `Failing due to console.${type} while running test!\n\n${message}`,
+    );
+  };
+});


### PR DESCRIPTION
I ran into this issue while updating to React 18. if a test passes, jest will not print out any warnings that are emitted. 

I added this as a javascript file instead of including it in `setupTests.ts` because I was running into type errors I was unsure how to resolve.