### PR TITLE
replace usage of useSelector with typed hook useAppSelector

### DIFF
--- a/src/components/CompareResults/CompareResultsTable.tsx
+++ b/src/components/CompareResults/CompareResultsTable.tsx
@@ -5,9 +5,8 @@ import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
-import { useSelector } from 'react-redux';
 
-import type { RootState } from '../../common/store';
+import { useAppSelector } from '../../hooks/app';
 import type { CompareResultsItem } from '../../types/state';
 import type { CompareResultsTableHeaders } from '../../types/types';
 import CompareResultsTableRow from './CompareResultsTableRow';
@@ -26,8 +25,8 @@ const tableHeaders: CompareResultsTableHeaders[] = [
 
 function CompareResultsTable(props: CompareResultsProps) {
   const { mode } = props;
-  const compareResults: CompareResultsItem[] = useSelector(
-    (state: RootState) => state.compareResults,
+  const compareResults: CompareResultsItem[] = useAppSelector(
+    (state) => state.compareResults,
   );
   return (
     <TableContainer component={Paper}>

--- a/src/components/CompareResults/CompareResultsView.tsx
+++ b/src/components/CompareResults/CompareResultsView.tsx
@@ -2,7 +2,8 @@ import Container from '@mui/material/Container';
 import Grid from '@mui/material/Grid';
 import { connect } from 'react-redux';
 
-import { Revision, State } from '../../types/state';
+import type { RootState } from '../../common/store';
+import { Revision } from '../../types/state';
 import PerfCompareHeader from '../Shared/PerfCompareHeader';
 import SelectedRevisionsTable from '../Shared/SelectedRevisionsTable';
 import CompareResultsTable from './CompareResultsTable';
@@ -31,7 +32,7 @@ interface CompareResultsViewProps {
   mode: 'light' | 'dark';
 }
 
-function mapStateToProps(state: State) {
+function mapStateToProps(state: RootState) {
   return {
     revisions: state.selectedRevisions.revisions,
   };

--- a/src/components/CompareResults/EditSearchResultsTable.tsx
+++ b/src/components/CompareResults/EditSearchResultsTable.tsx
@@ -1,13 +1,12 @@
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableContainer from '@mui/material/TableContainer';
-import { useSelector } from 'react-redux';
 
-import { RootState } from '../../common/store';
+import { useAppSelector } from '../../hooks/app';
 import EditSearchResultsTableRow from './EditSearchResultsTableRow';
 
 function EditSearchResultsTable() {
-  const { searchResults } = useSelector((state: RootState) => state.search);
+  const { searchResults } = useAppSelector((state) => state.search);
   return (
     <TableContainer>
       <Table size="small">

--- a/src/components/Search/SearchDropdown.tsx
+++ b/src/components/Search/SearchDropdown.tsx
@@ -5,8 +5,8 @@ import Select from '@mui/material/Select';
 import { connect } from 'react-redux';
 
 import { repoMap } from '../../common/constants';
+import type { RootState } from '../../common/store';
 import useHandleChangeDropdown from '../../hooks/useHandleChangeDropdown';
-import type { State } from '../../types/state';
 
 function SearchDropdown(props: SearchDropdownProps) {
   const { repository, view } = props;
@@ -37,7 +37,7 @@ interface SearchDropdownProps {
   view: 'compare-results' | 'search';
 }
 
-function mapStateToProps(state: State) {
+function mapStateToProps(state: RootState) {
   return {
     repository: state.search.repository,
   };

--- a/src/components/Search/SearchInput.tsx
+++ b/src/components/Search/SearchInput.tsx
@@ -3,8 +3,8 @@ import type { Dispatch, SetStateAction } from 'react';
 import TextField from '@mui/material/TextField';
 import { connect } from 'react-redux';
 
+import type { RootState } from '../../common/store';
 import useHandleChangeSearch from '../../hooks/useHandleChangeSearch';
-import { State } from '../../types/state';
 
 function SearchInput(props: SearchInputProps) {
   const { setFocused, inputError, inputHelperText, view } = props;
@@ -32,7 +32,7 @@ interface SearchInputProps {
   view: 'compare-results' | 'search';
 }
 
-function mapStateToProps(state: State) {
+function mapStateToProps(state: RootState) {
   return {
     inputError: state.search.inputError,
     inputHelperText: state.search.inputHelperText,

--- a/src/components/Search/SearchResultsListItem.tsx
+++ b/src/components/Search/SearchResultsListItem.tsx
@@ -3,16 +3,15 @@ import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
-import { useSelector } from 'react-redux';
 
-import type { RootState } from '../../common/store';
+import { useAppSelector } from '../../hooks/app';
 import useCheckRevision from '../../hooks/useCheckRevision';
 import type { Revision } from '../../types/state';
 import { truncateHash, getLatestCommitMessage } from '../../utils/helpers';
 
 function SearchResultsListItem(props: SearchResultsListItemProps) {
   const { index, item } = props;
-  const isChecked: boolean = useSelector((state: RootState) =>
+  const isChecked: boolean = useAppSelector((state) =>
     state.checkedRevisions.revisions.includes(index),
   );
   const { handleToggle } = useCheckRevision();

--- a/src/components/Search/SearchView.tsx
+++ b/src/components/Search/SearchView.tsx
@@ -5,7 +5,8 @@ import Grid from '@mui/material/Grid';
 import { connect } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
-import { Revision, State } from '../../types/state';
+import type { RootState } from '../../common/store';
+import { Revision } from '../../types/state';
 import { truncateHash } from '../../utils/helpers';
 import PerfCompareHeader from '../Shared/PerfCompareHeader';
 import RevisionSearch from '../Shared/RevisionSearch';
@@ -60,7 +61,7 @@ interface SearchViewProps {
   selectedRevisions: Revision[];
 }
 
-function mapStateToProps(state: State) {
+function mapStateToProps(state: RootState) {
   return {
     searchResults: state.search.searchResults,
     selectedRevisions: state.selectedRevisions.revisions,

--- a/src/components/Search/SearchViewInit.tsx
+++ b/src/components/Search/SearchViewInit.tsx
@@ -2,9 +2,10 @@ import { useEffect } from 'react';
 
 import { connect } from 'react-redux';
 
+import type { RootState } from '../../common/store';
 import { useAppDispatch } from '../../hooks/app';
 import { fetchRecentRevisions } from '../../thunks/searchThunk';
-import type { Repository, State } from '../../types/state';
+import type { Repository } from '../../types/state';
 
 // component to fetch recent revisions when search view is loaded
 function SearchViewInit(props: SearchViewInitProps) {
@@ -20,7 +21,7 @@ interface SearchViewInitProps {
   repository: Repository['name'];
 }
 
-function mapStateToProps(state: State) {
+function mapStateToProps(state: RootState) {
   return {
     repository: state.search.repository,
   };

--- a/src/components/Shared/RevisionSearch.tsx
+++ b/src/components/Shared/RevisionSearch.tsx
@@ -6,9 +6,10 @@ import Button from '@mui/material/Button';
 import Grid from '@mui/material/Grid';
 import { connect } from 'react-redux';
 
+import type { RootState } from '../../common/store';
 import { useAppDispatch } from '../../hooks/app';
 import { clearCheckedRevisions } from '../../reducers/CheckedRevisions';
-import type { Revision, State } from '../../types/state';
+import type { Revision } from '../../types/state';
 import EditSearchResultsTable from '../CompareResults/EditSearchResultsTable';
 import AddRevisionButton from '../Search/AddRevisionButton';
 import SearchDropdown from '../Search/SearchDropdown';
@@ -115,7 +116,7 @@ interface RevisionSearchProps {
   view: 'compare-results' | 'search';
 }
 
-function mapStateToProps(state: State) {
+function mapStateToProps(state: RootState) {
   return {
     searchResults: state.search.searchResults,
   };

--- a/src/components/Shared/SelectedRevisionsTable.tsx
+++ b/src/components/Shared/SelectedRevisionsTable.tsx
@@ -6,7 +6,8 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import { connect } from 'react-redux';
 
-import type { Revision, State } from '../../types/state';
+import type { RootState } from '../../common/store';
+import type { Revision } from '../../types/state';
 import type { SelectedRevisionsTableHeaders } from '../../types/types';
 import SelectedRevisionsTableRow from './SelectedRevisionsTableRow';
 
@@ -55,7 +56,7 @@ interface SelectedRevisionsProps {
   view: 'search' | 'compare-results';
 }
 
-function mapStateToProps(state: State) {
+function mapStateToProps(state: RootState) {
   return {
     revisions: state.selectedRevisions.revisions,
   };

--- a/src/hooks/useCheckRevision.ts
+++ b/src/hooks/useCheckRevision.ts
@@ -3,7 +3,6 @@ import React from 'react';
 import { useSnackbar, VariantType } from 'notistack';
 
 import { maxRevisionsError } from '../common/constants';
-import type { RootState } from '../common/store';
 import { setCheckedRevisions } from '../reducers/CheckedRevisions';
 import { useAppDispatch, useAppSelector } from './app';
 
@@ -12,7 +11,7 @@ const useCheckRevision = () => {
   const dispatch = useAppDispatch();
 
   const checkedRevisions: number[] = useAppSelector(
-    (state: RootState) => state.checkedRevisions.revisions,
+    (state) => state.checkedRevisions.revisions,
   );
 
   const handleToggle = (e: React.MouseEvent) => {

--- a/src/hooks/useHandleChangeSearch.ts
+++ b/src/hooks/useHandleChangeSearch.ts
@@ -10,16 +10,14 @@ import {
   fetchRevisionByID,
   fetchRevisionsByAuthor,
 } from '../thunks/searchThunk';
-import type { Repository, State } from '../types/state';
+import type { Repository } from '../types/state';
 import { useAppDispatch, useAppSelector } from './app';
 
 let timeout: null | ReturnType<typeof setTimeout> = null;
 
 const useHandleChangeSearch = () => {
   const dispatch = useAppDispatch();
-  const getRepository = useAppSelector(
-    (state: State) => state.search.repository,
-  );
+  const getRepository = useAppSelector((state) => state.search.repository);
 
   const searchByRevisionOrEmail = async (
     repository: Repository['name'],

--- a/src/hooks/useSelectRevision.ts
+++ b/src/hooks/useSelectRevision.ts
@@ -1,7 +1,6 @@
 import { useSnackbar, VariantType } from 'notistack';
 
 import { maxRevisionsError } from '../common/constants';
-import type { RootState } from '../common/store';
 import { clearCheckedRevisions } from '../reducers/CheckedRevisions';
 import { setSelectedRevisions } from '../reducers/SelectedRevisions';
 import { truncateHash } from '../utils/helpers';
@@ -11,16 +10,14 @@ const useSelectRevision = () => {
   const dispatch = useAppDispatch();
   const { enqueueSnackbar } = useSnackbar();
 
-  const searchResults = useAppSelector(
-    (state: RootState) => state.search.searchResults,
-  );
+  const searchResults = useAppSelector((state) => state.search.searchResults);
 
   const checkedRevisions = useAppSelector(
-    (state: RootState) => state.checkedRevisions.revisions,
+    (state) => state.checkedRevisions.revisions,
   );
 
   const selectedRevisions = useAppSelector(
-    (state: RootState) => state.selectedRevisions.revisions,
+    (state) => state.selectedRevisions.revisions,
   );
 
   const addSelectedRevisions = () => {

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -79,8 +79,3 @@ export type SelectedRevisionsState = {
 };
 
 export type CompareResultsState = CompareResultsItem[];
-
-export type State = {
-  search: SearchState;
-  selectedRevisions: SelectedRevisionsState;
-};


### PR DESCRIPTION
in #198 I added typed hooks for useDispatch and useSelector, so I have replaced usage of useSelector with the typed hook useAppSelector

Also removed `State` type and replaced with `RootState`