### PR TITLE
store revision instead of index in checkedRevisions

### DIFF
--- a/src/__tests__/Search/SearchResultsList.test.tsx
+++ b/src/__tests__/Search/SearchResultsList.test.tsx
@@ -79,11 +79,9 @@ describe('SearchResultsList', () => {
     );
 
     await user.click(fleshWound);
-    expect(store.getState().checkedRevisions.revisions[0]).toBe(1);
+    expect(store.getState().checkedRevisions.revisions[0]).toBe(testData[1]);
     await user.click(fleshWound);
-    expect(
-      screen.getByTestId('checkbox-1').classList.contains('Mui-checked'),
-    ).toBe(false);
+    expect(fleshWound.classList.contains('Mui-checked')).toBe(false);
   });
 
   it('should not allow selecting more than four revisions', async () => {

--- a/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
@@ -169,7 +169,6 @@ exports[`SearchResultsList should match snapshot 1`] = `
             >
               <div
                 class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                id="0"
                 role="button"
                 tabindex="0"
               >
@@ -220,7 +219,6 @@ exports[`SearchResultsList should match snapshot 1`] = `
               </div>
               <div
                 class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                id="1"
                 role="button"
                 tabindex="0"
               >
@@ -271,7 +269,6 @@ exports[`SearchResultsList should match snapshot 1`] = `
               </div>
               <div
                 class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                id="2"
                 role="button"
                 tabindex="0"
               >
@@ -322,7 +319,6 @@ exports[`SearchResultsList should match snapshot 1`] = `
               </div>
               <div
                 class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                id="3"
                 role="button"
                 tabindex="0"
               >
@@ -373,7 +369,6 @@ exports[`SearchResultsList should match snapshot 1`] = `
               </div>
               <div
                 class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                id="4"
                 role="button"
                 tabindex="0"
               >

--- a/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
@@ -501,7 +501,6 @@ exports[`Search View should not hide search results when clicking search results
             >
               <div
                 class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                id="0"
                 role="button"
                 tabindex="0"
               >
@@ -564,7 +563,6 @@ exports[`Search View should not hide search results when clicking search results
               </div>
               <div
                 class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                id="1"
                 role="button"
                 tabindex="0"
               >
@@ -627,7 +625,6 @@ exports[`Search View should not hide search results when clicking search results
               </div>
               <div
                 class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                id="2"
                 role="button"
                 tabindex="0"
               >
@@ -681,7 +678,6 @@ exports[`Search View should not hide search results when clicking search results
               </div>
               <div
                 class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                id="3"
                 role="button"
                 tabindex="0"
               >
@@ -735,7 +731,6 @@ exports[`Search View should not hide search results when clicking search results
               </div>
               <div
                 class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                id="4"
                 role="button"
                 tabindex="0"
               >

--- a/src/components/Search/SearchResultsListItem.tsx
+++ b/src/components/Search/SearchResultsListItem.tsx
@@ -12,22 +12,16 @@ import { truncateHash, getLatestCommitMessage } from '../../utils/helpers';
 function SearchResultsListItem(props: SearchResultsListItemProps) {
   const { index, item } = props;
   const isChecked: boolean = useAppSelector((state) =>
-    state.checkedRevisions.revisions.includes(index),
+    state.checkedRevisions.revisions.includes(item),
   );
   const { handleToggle } = useCheckRevision();
-
-  const indexString = index.toString();
 
   const revisionHash = truncateHash(item.revision);
   const commitMessage = getLatestCommitMessage(item);
 
   return (
     <>
-      <ListItemButton
-        key={item.id}
-        id={indexString}
-        onClick={(e) => handleToggle(e)}
-      >
+      <ListItemButton key={item.id} onClick={() => handleToggle(item)}>
         <ListItem
           className="search-revision-item search-revision"
           disablePadding
@@ -38,7 +32,7 @@ function SearchResultsListItem(props: SearchResultsListItemProps) {
               edge="start"
               tabIndex={-1}
               disableRipple
-              data-testid={`checkbox-${indexString}`}
+              data-testid={`checkbox-${index}`}
               checked={isChecked}
             />
           </ListItemIcon>

--- a/src/hooks/useCheckRevision.ts
+++ b/src/hooks/useCheckRevision.ts
@@ -1,30 +1,28 @@
-import React from 'react';
-
 import { useSnackbar, VariantType } from 'notistack';
 
 import { maxRevisionsError } from '../common/constants';
 import { setCheckedRevisions } from '../reducers/CheckedRevisions';
+import { Revision } from '../types/state';
 import { useAppDispatch, useAppSelector } from './app';
 
 const useCheckRevision = () => {
   const { enqueueSnackbar } = useSnackbar();
   const dispatch = useAppDispatch();
 
-  const checkedRevisions: number[] = useAppSelector(
+  const checkedRevisions: Revision[] = useAppSelector(
     (state) => state.checkedRevisions.revisions,
   );
 
-  const handleToggle = (e: React.MouseEvent) => {
-    const revisionIndex = parseInt((e.currentTarget as HTMLElement).id, 10);
-    const isChecked = checkedRevisions.includes(revisionIndex);
+  const handleToggle = (revision: Revision) => {
+    const isChecked = checkedRevisions.includes(revision);
     const newChecked = [...checkedRevisions];
 
     // if item is not already checked, add to checked
     if (checkedRevisions.length < 4 && !isChecked) {
-      newChecked.push(revisionIndex);
+      newChecked.push(revision);
     } else if (isChecked) {
       // if item is already checked, remove from checked
-      newChecked.splice(checkedRevisions.indexOf(revisionIndex), 1);
+      newChecked.splice(checkedRevisions.indexOf(revision), 1);
     } else {
       // if there are already 4 checked revisions, print a warning
       const variant: VariantType = 'warning';

--- a/src/hooks/useSelectRevision.ts
+++ b/src/hooks/useSelectRevision.ts
@@ -10,8 +10,6 @@ const useSelectRevision = () => {
   const dispatch = useAppDispatch();
   const { enqueueSnackbar } = useSnackbar();
 
-  const searchResults = useAppSelector((state) => state.search.searchResults);
-
   const checkedRevisions = useAppSelector(
     (state) => state.checkedRevisions.revisions,
   );
@@ -25,8 +23,7 @@ const useSelectRevision = () => {
     const variant: VariantType = 'warning';
 
     checkedRevisions.every((item) => {
-      const revision = searchResults[item];
-      const isSelected = selectedRevisions.includes(revision);
+      const isSelected = selectedRevisions.includes(item);
 
       // Do not allow adding more than four revisions
       if (selectedRevisions.length == 4) {
@@ -35,10 +32,10 @@ const useSelectRevision = () => {
       }
 
       if (!isSelected) {
-        newSelected.push(revision);
+        newSelected.push(item);
       } else if (isSelected) {
         enqueueSnackbar(
-          `Revision ${truncateHash(revision.revision)} is already selected.`,
+          `Revision ${truncateHash(item.revision)} is already selected.`,
           {
             variant,
           },

--- a/src/reducers/CheckedRevisions.ts
+++ b/src/reducers/CheckedRevisions.ts
@@ -1,6 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import { CheckedRevisionsState } from '../types/state';
+import type { Revision } from '../types/state';
 
 const initialState: CheckedRevisionsState = {
   revisions: [],
@@ -13,7 +14,7 @@ const checkedRevisions = createSlice({
     clearCheckedRevisions(state) {
       state.revisions = initialState.revisions;
     },
-    setCheckedRevisions(state, action: PayloadAction<number[]>) {
+    setCheckedRevisions(state, action: PayloadAction<Revision[]>) {
       state.revisions = action.payload;
     },
   },

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -72,7 +72,7 @@ export type SearchState = {
 // contains the indices of currently checked revisions
 // in searchResults state
 export type CheckedRevisionsState = {
-  revisions: number[];
+  revisions: Revision[];
 };
 
 export type SelectedRevisionsState = {


### PR DESCRIPTION
I ran in to an implementation problem while working on editing a revision from results view. since we are replacing a revision instaed of just adding a new one, we need a reference to the revision we are replacing.

previously the checkedRevisions state held a revisions index from searchResults. I've updated the state to hold the actual revision, which should resolve this problem.