### PR TITLE
 #257 PerfCompare header underline resizes based on window size

### DIFF
--- a/src/theme/components.js
+++ b/src/theme/components.js
@@ -130,7 +130,7 @@ const components = {
             backgroundImage: `url(${zap})`,
             backgroundPosition: '55%',
             backgroundRepeat: 'no-repeat',
-            backgroundSize: '25%',
+            backgroundSize: '290px',
             content: '""',
             display: 'block',
             height: '0.3em',
@@ -204,7 +204,8 @@ const components = {
     styleOverrides: {
       root: {
         '&.feedback-alert': {
-            backgroundImage: 'linear-gradient( 45deg, rgb(138,35,135) 10%, rgb(233,64,87) 50%, rgb(242,113,33) 100% )',
+          backgroundImage:
+            'linear-gradient( 45deg, rgb(138,35,135) 10%, rgb(233,64,87) 50%, rgb(242,113,33) 100% )',
         },
       },
     },


### PR DESCRIPTION
Changed backgroundSize from "25%" to "290px". 

Does not change image size on screen resizing.
<img width="1512" alt="Screen Shot 2022-11-08 at 7 55 06 PM" src="https://user-images.githubusercontent.com/97716889/200871684-9f652c34-8df8-40f5-aa63-5a740e5b3b0c.png">
<img width="1512" alt="Screen Shot 2022-11-08 at 7 54 57 PM" src="https://user-images.githubusercontent.com/97716889/200871696-4a7f4285-9c48-481f-a94d-bf7c5f53bd24.png">
<img width="1512" alt="Screen Shot 2022-11-08 at 7 54 50 PM" src="https://user-images.githubusercontent.com/97716889/200871713-20d95f67-e8f0-4e98-a43a-c2221192fedd.png">

