### PR TITLE
Feat/set selected revisions

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -44,7 +44,7 @@ function App() {
           <Routes>
             <Route path="/" element={<SearchView />} />
             <Route
-              path="/compare-results"
+              path="/compare-results/repos/:repos/revs/:revs"
               element={<CompareResultsView mode={mode} />}
             />
           </Routes>

--- a/src/components/CompareResults/CompareResultsView.tsx
+++ b/src/components/CompareResults/CompareResultsView.tsx
@@ -11,6 +11,7 @@ import { Repository, Revision } from '../../types/state';
 import PerfCompareHeader from '../Shared/PerfCompareHeader';
 import SelectedRevisionsTable from '../Shared/SelectedRevisionsTable';
 import CompareResultsTable from './CompareResultsTable';
+import CompareResultsViewInit from './CompareResultsViewInit';
 
 function CompareResultsView(props: CompareResultsViewProps) {
   const { revisions, mode } = props;
@@ -20,19 +21,20 @@ function CompareResultsView(props: CompareResultsViewProps) {
 
   // TODO: if the revisions in the URL parameters are different from
   // currently selected revisions, set selected revisions to those parameters
-  useEffect(() => {
-    const searchParams = new URLSearchParams(location.search);
-    const repos = searchParams.get('repos')?.split(',');
-    const revs = searchParams.get('revs')?.split(',');
-    void dispatchFetchCompareResults(repos as Repository['name'][], revs);
-  });
+  // useEffect(() => {
+  //   const searchParams = new URLSearchParams(location.search);
+  //   const repos = searchParams.get('repos')?.split(',');
+  //   const revs = searchParams.get('revs')?.split(',');
+  //   void dispatchFetchCompareResults(repos as Repository['name'][], revs);
+  // });
 
   return (
     <Container maxWidth="xl">
+      <CompareResultsViewInit />
       <PerfCompareHeader />
       <Grid container alignItems="center" justifyContent="center">
         <Grid item xs={10}>
-          {revisions.length > 0 && (
+          {revisions && revisions.length > 0 && (
             <SelectedRevisionsTable view="compare-results" />
           )}
         </Grid>

--- a/src/components/CompareResults/CompareResultsViewInit.tsx
+++ b/src/components/CompareResults/CompareResultsViewInit.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+
+import { useParams } from 'react-router-dom';
+
+import { useAppDispatch, useAppSelector } from '../../hooks/app';
+import useFetchCompareResults from '../../hooks/useFetchCompareResults';
+import { clearSelectedRevisions } from '../../reducers/SelectedRevisions';
+import { Revision } from '../../types/state';
+
+// component to fetch set selected revisions when Compare View is loaded
+function CompareResultsViewInit() {
+  const dispatch = useAppDispatch();
+
+  const selectedRevisions = useAppSelector(
+    (state) => state.selectedRevisions.revisions,
+  );
+
+  const { repos, revs } = useParams();
+
+  useEffect(() => {
+    if (repos && revs) {
+      const paramRepos: string[] = repos.split(',');
+      const paramRevs: string[] = revs.split(',');
+      const currentRevs: string[] = selectedRevisions.map(
+        (item) => item.revision,
+      );
+      dispatch(clearSelectedRevisions());
+
+      let newSelected: Revision[];
+      if (paramRevs !== currentRevs) {
+        paramRepos.forEach((item) => {
+          const newRevision = fetch();
+        });
+      }
+    }
+  });
+
+  return null;
+}
+
+export default CompareResultsViewInit;

--- a/src/components/CompareResults/CompareResultsViewInit.tsx
+++ b/src/components/CompareResults/CompareResultsViewInit.tsx
@@ -1,41 +1,82 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
+import { useSnackbar, VariantType } from 'notistack';
 import { useParams } from 'react-router-dom';
 
 import { useAppDispatch, useAppSelector } from '../../hooks/app';
 import useFetchCompareResults from '../../hooks/useFetchCompareResults';
-import { clearSelectedRevisions } from '../../reducers/SelectedRevisions';
-import { Revision } from '../../types/state';
-
+import {
+  clearSelectedRevisions,
+  setSelectedRevisions,
+} from '../../reducers/SelectedRevisions';
+import { fetchSelectedRevisions } from '../../thunks/selectedRevisionsThunk';
+import type { Revision } from '../../types/state';
+import { fetchCompareResults } from '../../thunks/compareResultsThunk';
+import { repoMap } from '../../common/constants';
 // component to fetch set selected revisions when Compare View is loaded
 function CompareResultsViewInit() {
   const dispatch = useAppDispatch();
-
   const selectedRevisions = useAppSelector(
     (state) => state.selectedRevisions.revisions,
   );
+  const selected = selectedRevisions.map((item) => item.revision);
 
   const { repos, revs } = useParams();
+  let paramRepos: string[];
+  let paramRevs: string[];
+  if (repos && revs) {
+    paramRepos = repos.split(',');
+    paramRevs = revs.split(',');
+  }
+
+  const { enqueueSnackbar } = useSnackbar();
+
+  const { useFetchSelectedRevisions } = useFetchCompareResults();
+
+  const [newSelected, setNewSelected] = useState([]);
 
   useEffect(() => {
-    if (repos && revs) {
-      const paramRepos: string[] = repos.split(',');
-      const paramRevs: string[] = revs.split(',');
-      const currentRevs: string[] = selectedRevisions.map(
-        (item) => item.revision,
-      );
-      dispatch(clearSelectedRevisions());
+    let isSubscribed = true;
 
-      let newSelected: Revision[];
-      if (paramRevs !== currentRevs) {
-        paramRepos.forEach((item) => {
-          const newRevision = fetch();
-        });
+    const fetchData = async (repo: string, rev: string) => {
+      const data = await dispatch(fetchSelectedRevisions({ repo, rev }));
+
+      if (isSubscribed) {
+        setNewSelected((prev) => [...prev, data.payload]);
       }
-    }
-  });
+    };
 
-  return null;
+    if (paramRevs !== selected) {
+      paramRepos.forEach((repo, index) => {
+        const rev = paramRevs[index];
+        fetchData(repo, rev).catch(console.error);
+      });
+    }
+
+    return () => {
+      isSubscribed = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    console.log(selectedRevisions);
+    console.log(newSelected);
+    if (
+      selected !== paramRevs &&
+      paramRevs.length > 0 &&
+      paramRevs.length === newSelected.length
+    ) {
+      dispatch(setSelectedRevisions(newSelected));
+    } else if (selectedRevisions === newSelected) {
+      const compareRepos = selectedRevisions.map(
+        (item) => repoMap[item.repository_id],
+      );
+      const compareRevs = selectedRevisions.map((item) => item.revision);
+      void dispatch(fetchCompareResults({ compareRepos, compareRevs }));
+    }
+  }, [newSelected]);
+
+  return <></>;
 }
 
 export default CompareResultsViewInit;

--- a/src/components/Search/SearchView.tsx
+++ b/src/components/Search/SearchView.tsx
@@ -23,23 +23,24 @@ function SearchView(props: SearchViewProps) {
     // TODO: remove this check once comparing without a base
     //  and comparing multiple revisions against a base is enabled
     if (selectedRevisions.length === 1 || selectedRevisions.length > 2) {
-    enqueueSnackbar(featureNotSupportedError as string, {
+      enqueueSnackbar(featureNotSupportedError as string, {
         variant: warningVariant,
-    });
-    return;
+      });
+      return;
     }
-    const revs = selectedRevisions.map((rev) => rev.revision);
-    const repos = selectedRevisions.map((rev) => repoMap[rev.repository_id]);
+    const revs = selectedRevisions.map((rev) => rev.revision).join(',');
+    const repos = selectedRevisions
+      .map((rev) => repoMap[rev.repository_id])
+      .join(',');
     navigate({
-      pathname: '/compare-results',
-      search: `?revs=${revs.join(',')}&repos=${repos.join(',')}`,
+      pathname: `/compare-results/repos/${repos}/revs/${revs}`,
     });
   };
 
   const { selectedRevisions } = props;
 
   return (
-    <Container maxWidth="lg" className='perfcompare-body'>
+    <Container maxWidth="lg" className="perfcompare-body">
       {/* Component to fetch recent revisions on mount */}
       <SearchViewInit />
       <PerfCompareHeader />

--- a/src/hooks/useFetchCompareResults.ts
+++ b/src/hooks/useFetchCompareResults.ts
@@ -1,31 +1,44 @@
+import {
+  clearSearchResults,
+  clearSelectedRevisions,
+  setSelectedRevisions,
+} from '../reducers/SelectedRevisions';
 import { fetchCompareResults } from '../thunks/compareResultsThunk';
-import type { Repository } from '../types/state';
-import { useAppDispatch } from './app';
+import { fetchSelectedRevisions } from '../thunks/selectedRevisionsThunk';
+import type { Repository, Revision } from '../types/state';
+import { useAppDispatch, useAppSelector } from './app';
 
 function useFetchCompareResults() {
   const dispatch = useAppDispatch();
+  const selectedRevisions = useAppSelector(
+    (state) => state.selectedRevisions.revisions,
+  );
+
+  const searchResults = useAppSelector(
+    (state) => state.selectedRevisions.searchResults,
+  );
 
   const dispatchFetchCompareResults = async (
-    repos: Repository['name'][] | null,
-    revs: string[] | undefined,
+    compareRepos: Repository['name'][] | null,
+    compareRevs: string[] | undefined,
   ) => {
     let baseRepo;
     let baseRev;
     let newRepo;
     let newRev;
-    if (repos && revs) {
+    if (compareRepos && compareRevs) {
       // If there is only one selected revision, base and new should be the same
-      if (revs.length == 1) {
-        baseRepo = newRepo = repos[0];
-        baseRev = newRev = revs[0];
+      if (compareRevs.length == 1) {
+        baseRepo = newRepo = compareRepos[0];
+        baseRev = newRev = compareRevs[0];
         void dispatch(
           fetchCompareResults({ baseRepo, baseRev, newRepo, newRev }),
         );
-      } else if (revs.length == 2) {
-        baseRepo = repos[0];
-        baseRev = revs[0];
-        newRepo = repos[1];
-        newRev = revs[1];
+      } else if (compareRevs.length == 2) {
+        baseRepo = compareRepos[0];
+        baseRev = compareRevs[0];
+        newRepo = compareRepos[1];
+        newRev = compareRevs[1];
         void dispatch(
           fetchCompareResults({ baseRepo, baseRev, newRepo, newRev }),
         );
@@ -33,6 +46,7 @@ function useFetchCompareResults() {
       // TODO: handle case for more than two selected revisions
     }
   };
+
   return { dispatchFetchCompareResults };
 }
 

--- a/src/reducers/SelectedRevisions.ts
+++ b/src/reducers/SelectedRevisions.ts
@@ -1,9 +1,13 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
+import { fetchSelectedRevisions } from '../thunks/selectedRevisionsThunk';
 import { Revision, SelectedRevisionsState } from '../types/state';
 
 const initialState: SelectedRevisionsState = {
   revisions: [],
+  errorMessage: '',
+  status: 'idle',
+  searchResults: [],
 };
 
 const selectedRevisions = createSlice({
@@ -20,9 +24,17 @@ const selectedRevisions = createSlice({
         ),
       };
     },
+    clearSelectedRevisions(state) {
+      state.revisions = initialState.revisions;
+    },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(fetchSelectedRevisions.fulfilled, (state, action) => {
+      state.searchResults.push(action.payload);
+    });
   },
 });
 
-export const { setSelectedRevisions, deleteRevision } =
+export const { setSelectedRevisions, deleteRevision, clearSelectedRevisions } =
   selectedRevisions.actions;
 export default selectedRevisions.reducer;

--- a/src/reducers/SelectedRevisions.ts
+++ b/src/reducers/SelectedRevisions.ts
@@ -18,11 +18,12 @@ const selectedRevisions = createSlice({
       state.revisions = action.payload;
     },
     deleteRevision(state, action) {
-      return {
-        revisions: state.revisions.filter(
-          (revision) => revision.id !== action.payload,
-        ),
-      };
+      state.revisions = state.revisions.filter(
+        (revision) => revision.id !== action.payload,
+      );
+    },
+    clearSearchResults(state) {
+      state.searchResults = initialState.searchResults;
     },
     clearSelectedRevisions(state) {
       state.revisions = initialState.revisions;
@@ -35,6 +36,10 @@ const selectedRevisions = createSlice({
   },
 });
 
-export const { setSelectedRevisions, deleteRevision, clearSelectedRevisions } =
-  selectedRevisions.actions;
+export const {
+  setSelectedRevisions,
+  deleteRevision,
+  clearSearchResults,
+  clearSelectedRevisions,
+} = selectedRevisions.actions;
 export default selectedRevisions.reducer;

--- a/src/thunks/selectedRevisionsThunk.ts
+++ b/src/thunks/selectedRevisionsThunk.ts
@@ -1,0 +1,31 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+
+import { treeherderBaseURL } from '../common/constants';
+import type { APIPushResponse } from '../types/api';
+import type { Revision } from '../types/state';
+
+export const fetchSelectedRevisions = createAsyncThunk<
+  Revision,
+  { repo: string; rev: string },
+  { rejectValue: string }
+>(
+  'selectedRevisions/fetchSelectedRevisions',
+  async ({ repo, rev }, { rejectWithValue }) => {
+    let response;
+
+    try {
+      response = await fetch(
+        `${treeherderBaseURL}/api/project/${repo}/push/?revision=${rev}`,
+      );
+    } catch (err) {
+      return rejectWithValue((err as Error).message);
+    }
+    const json = (await response.json()) as APIPushResponse;
+    if (json.results.length > 0) {
+      console.log(json.results);
+      return json.results[0];
+    }
+
+    return rejectWithValue('No results found');
+  },
+);

--- a/src/thunks/selectedRevisionsThunk.ts
+++ b/src/thunks/selectedRevisionsThunk.ts
@@ -22,7 +22,7 @@ export const fetchSelectedRevisions = createAsyncThunk<
     }
     const json = (await response.json()) as APIPushResponse;
     if (json.results.length > 0) {
-      console.log(json.results);
+      // console.log(json.results);
       return json.results[0];
     }
 

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -91,6 +91,9 @@ export type CheckedRevisionsState = {
 
 export type SelectedRevisionsState = {
   revisions: Revision[];
+  errorMessage: string;
+  status: 'idle' | 'loading';
+  searchResults: Revision[];
 };
 
 export type CompareResultsState = {


### PR DESCRIPTION
Taking a different approach here. I know the code is spaghetti but I at least have gotten it to work, sort of. One of the problems I'm facing is that when fetching the revisions from the API to set as `selectedRevisions`, the order of the revisions depends on which fetch call completes first.

This is an issue, because by default the first revision is `base` and any others are new. 

I appreciate any feedback, I know it's ugly but I had a hard time figuring out how best to implement this with our current structure.