### PR TITLE
fix popover width so that it becomes equal to table width

### DIFF
--- a/src/components/CompareResults/EditRevisionButton.tsx
+++ b/src/components/CompareResults/EditRevisionButton.tsx
@@ -35,7 +35,7 @@ function EditRevisionButton(props: EditRevisionButtonProps) {
           vertical: 'bottom',
           horizontal: 'left',
         }}
-        PaperProps={{ style: { maxWidth: '1245px' } }}
+        PaperProps={{ style: { maxWidth: '81.5%' }  }}
       >
         <RevisionSearch
           view="compare-results"

--- a/src/components/CompareResults/EditRevisionButton.tsx
+++ b/src/components/CompareResults/EditRevisionButton.tsx
@@ -35,7 +35,7 @@ function EditRevisionButton(props: EditRevisionButtonProps) {
           vertical: 'bottom',
           horizontal: 'left',
         }}
-        PaperProps={{ style: { maxWidth: "1245px" } }}
+        PaperProps={{ style: { maxWidth: '1245px' } }}
       >
         <RevisionSearch
           view="compare-results"

--- a/src/components/CompareResults/EditRevisionButton.tsx
+++ b/src/components/CompareResults/EditRevisionButton.tsx
@@ -35,6 +35,7 @@ function EditRevisionButton(props: EditRevisionButtonProps) {
           vertical: 'bottom',
           horizontal: 'left',
         }}
+        PaperProps={{ style: { maxWidth: "1245px" } }}
       >
         <RevisionSearch
           view="compare-results"


### PR DESCRIPTION
## Fixed the popover width! Screenshot below shows the output !
![Screenshot (432)](https://user-images.githubusercontent.com/69195262/223392535-9dd4354b-90ef-4359-abe1-d847ce2fc18c.png)

- I am a outreachy participant !

## Implementation 
- Used  Paperprops to style the popover !

Resolves - #225 