### PR TITLE
Resolved accessibility issues in `SearchResultsListItem` component

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Performance Comparison Tool
 
 ![screenshot](screenshot.png)
 
+[Outreachy contributor information](https://docs.google.com/document/d/1NLKAR5B2Rc80lRUYWzU2ISrQCQhR4VsW5Qkz1hxE5n8/edit?usp=sharing)
+
 ## Deployments
 
 PerfCompare is hosted on heroku, and is updated every time commits are pushed to the following branches:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ PerfCompare is hosted on heroku, and is updated every time commits are pushed to
 ## Setup
 
 ### Requirements
-
+- [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [nodejs](https://nodejs.org/en/download/)
 
 ### Installation

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # PerfCompare
 
+**[Outreachy contributor information](https://docs.google.com/document/d/1NLKAR5B2Rc80lRUYWzU2ISrQCQhR4VsW5Qkz1hxE5n8/edit?usp=sharing)**
+_____
+
 [![CircleCI](https://circleci.com/gh/mozilla/perfcompare/tree/master.svg?style=shield)](https://circleci.com/gh/mozilla/perfcompare/tree/master)
 [![codecov](https://codecov.io/gh/mozilla/perfcompare/branch/master/graph/badge.svg?token=XHP440JFDQ)](https://codecov.io/gh/mozilla/perfcompare)
 ![GitHub issues](https://img.shields.io/github/issues/mozilla/perfcompare)
@@ -8,8 +11,6 @@
 Performance Comparison Tool
 
 ![screenshot](screenshot.png)
-
-[Outreachy contributor information](https://docs.google.com/document/d/1NLKAR5B2Rc80lRUYWzU2ISrQCQhR4VsW5Qkz1hxE5n8/edit?usp=sharing)
 
 ## Deployments
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **[Outreachy contributor information](https://docs.google.com/document/d/1NLKAR5B2Rc80lRUYWzU2ISrQCQhR4VsW5Qkz1hxE5n8/edit?usp=sharing)**
 _____
 
-[![CircleCI](https://circleci.com/gh/mozilla/perfcompare/tree/master.svg?style=shield)](https://circleci.com/gh/mozilla/perfcompare/tree/master)
+[![CircleCI](https://circleci.com/gh/mozilla/perfcompare/tree/master.svg?style=shield)](https://circleci.com/gh/mozilla/perfcompare/tree/beta)
 [![codecov](https://codecov.io/gh/mozilla/perfcompare/branch/master/graph/badge.svg?token=XHP440JFDQ)](https://codecov.io/gh/mozilla/perfcompare)
 ![GitHub issues](https://img.shields.io/github/issues/mozilla/perfcompare)
 ![GitHub pull requests](https://img.shields.io/github/issues-pr/mozilla/perfcompare)

--- a/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
@@ -157,13 +157,13 @@ exports[`SearchResultsList should match snapshot 1`] = `
             id="search-results-list"
           >
             <ul
-              class="MuiList-root MuiList-padding css-1fc0pkb-MuiList-root"
+              class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
             >
               <li
                 class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
               >
                 <div
-                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters f1ht8qkz css-1gopsaf-MuiButtonBase-root-MuiListItemButton-root"
+                  class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   role="group"
                   tabindex="0"
                 >
@@ -175,6 +175,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                       data-testid="checkbox-0"
                     >
                       <input
+                        aria-label="'you've got no arms left!' by 'johncleese@python.com'"
                         class="PrivateSwitchBase-input css-1m9pwf3"
                         data-indeterminate="false"
                         tabindex="-1"
@@ -213,7 +214,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                 class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
               >
                 <div
-                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters f1ht8qkz css-1gopsaf-MuiButtonBase-root-MuiListItemButton-root"
+                  class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   role="group"
                   tabindex="0"
                 >
@@ -225,6 +226,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                       data-testid="checkbox-1"
                     >
                       <input
+                        aria-label="'it's just a flesh wound' by 'ericidle@python.com'"
                         class="PrivateSwitchBase-input css-1m9pwf3"
                         data-indeterminate="false"
                         tabindex="-1"
@@ -263,7 +265,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                 class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
               >
                 <div
-                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters f1ht8qkz css-1gopsaf-MuiButtonBase-root-MuiListItemButton-root"
+                  class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   role="group"
                   tabindex="0"
                 >
@@ -275,6 +277,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                       data-testid="checkbox-2"
                     >
                       <input
+                        aria-label="'What, ridden on a horse?' by 'terrygilliam@python.com'"
                         class="PrivateSwitchBase-input css-1m9pwf3"
                         data-indeterminate="false"
                         tabindex="-1"
@@ -313,7 +316,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                 class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
               >
                 <div
-                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters f1ht8qkz css-1gopsaf-MuiButtonBase-root-MuiListItemButton-root"
+                  class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   role="group"
                   tabindex="0"
                 >
@@ -325,6 +328,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                       data-testid="checkbox-3"
                     >
                       <input
+                        aria-label="'You've got two empty 'alves of coconuts and you're bangin' 'em togetha!' by 'michaelpalin@python.com'"
                         class="PrivateSwitchBase-input css-1m9pwf3"
                         data-indeterminate="false"
                         tabindex="-1"
@@ -363,7 +367,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                 class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
               >
                 <div
-                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters f1ht8qkz css-1gopsaf-MuiButtonBase-root-MuiListItemButton-root"
+                  class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   role="group"
                   tabindex="0"
                 >
@@ -375,6 +379,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                       data-testid="checkbox-4"
                     >
                       <input
+                        aria-label="'It got better...' by 'grahamchapman@python.com'"
                         class="PrivateSwitchBase-input css-1m9pwf3"
                         data-indeterminate="false"
                         tabindex="-1"

--- a/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
@@ -157,15 +157,15 @@ exports[`SearchResultsList should match snapshot 1`] = `
             id="search-results-list"
           >
             <ul
-              class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
+              class="MuiList-root MuiList-padding css-1fc0pkb-MuiList-root"
             >
-              <div
-                class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                role="button"
-                tabindex="0"
+              <li
+                class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
               >
-                <li
-                  class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
+                <div
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters f1ht8qkz css-1gopsaf-MuiButtonBase-root-MuiListItemButton-root"
+                  role="group"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemIcon-root search-revision-item-icon search-revision css-cveggr-MuiListItemIcon-root"
@@ -207,15 +207,15 @@ exports[`SearchResultsList should match snapshot 1`] = `
                       johncleese@python.com - Thu Mar 29 1951 00:00:00 GMT+0000 (Coordinated Universal Time)
                     </p>
                   </div>
-                </li>
-              </div>
-              <div
-                class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                role="button"
-                tabindex="0"
+                </div>
+              </li>
+              <li
+                class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
               >
-                <li
-                  class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
+                <div
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters f1ht8qkz css-1gopsaf-MuiButtonBase-root-MuiListItemButton-root"
+                  role="group"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemIcon-root search-revision-item-icon search-revision css-cveggr-MuiListItemIcon-root"
@@ -257,15 +257,15 @@ exports[`SearchResultsList should match snapshot 1`] = `
                       ericidle@python.com - Sat Feb 22 1958 00:00:00 GMT+0000 (Coordinated Universal Time)
                     </p>
                   </div>
-                </li>
-              </div>
-              <div
-                class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                role="button"
-                tabindex="0"
+                </div>
+              </li>
+              <li
+                class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
               >
-                <li
-                  class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
+                <div
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters f1ht8qkz css-1gopsaf-MuiButtonBase-root-MuiListItemButton-root"
+                  role="group"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemIcon-root search-revision-item-icon search-revision css-cveggr-MuiListItemIcon-root"
@@ -307,15 +307,15 @@ exports[`SearchResultsList should match snapshot 1`] = `
                       terrygilliam@python.com - Wed Jul 29 1987 00:00:00 GMT+0000 (Coordinated Universal Time)
                     </p>
                   </div>
-                </li>
-              </div>
-              <div
-                class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                role="button"
-                tabindex="0"
+                </div>
+              </li>
+              <li
+                class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
               >
-                <li
-                  class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
+                <div
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters f1ht8qkz css-1gopsaf-MuiButtonBase-root-MuiListItemButton-root"
+                  role="group"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemIcon-root search-revision-item-icon search-revision css-cveggr-MuiListItemIcon-root"
@@ -357,15 +357,15 @@ exports[`SearchResultsList should match snapshot 1`] = `
                       michaelpalin@python.com - Sat Jul 04 2020 00:00:00 GMT+0000 (Coordinated Universal Time)
                     </p>
                   </div>
-                </li>
-              </div>
-              <div
-                class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                role="button"
-                tabindex="0"
+                </div>
+              </li>
+              <li
+                class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
               >
-                <li
-                  class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
+                <div
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters f1ht8qkz css-1gopsaf-MuiButtonBase-root-MuiListItemButton-root"
+                  role="group"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemIcon-root search-revision-item-icon search-revision css-cveggr-MuiListItemIcon-root"
@@ -407,8 +407,8 @@ exports[`SearchResultsList should match snapshot 1`] = `
                       grahamchapman@python.com - Wed Apr 13 2022 00:00:00 GMT+0000 (Coordinated Universal Time)
                     </p>
                   </div>
-                </li>
-              </div>
+                </div>
+              </li>
             </ul>
           </div>
         </div>

--- a/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
@@ -406,82 +406,177 @@ exports[`Search View should not hide search results when clicking search results
           <div
             class="MuiFormControl-root MuiTextField-root css-136h9lv-MuiFormControl-root-MuiTextField-root"
           >
-            <label
-              class="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary css-1dl35zc-MuiFormLabel-root-MuiInputLabel-root"
-              data-shrink="false"
-              for="search-revision-input"
-              id="search-revision-input-label"
-            >
-              Search By Revision ID or Author Email
-            </label>
             <div
-              class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl css-1cg28ds-MuiInputBase-root-MuiOutlinedInput-root"
+              class="MuiFormControl-root MuiTextField-root f1ci76mj f17k9m91 css-136h9lv-MuiFormControl-root-MuiTextField-root"
             >
-              <input
-                aria-invalid="false"
-                class="MuiOutlinedInput-input MuiInputBase-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id="search-revision-input"
-                type="text"
-                value=""
-              />
-              <fieldset
-                aria-hidden="true"
-                class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+              <label
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-mru796-MuiFormLabel-root-MuiInputLabel-root"
+                data-shrink="true"
+                for="search-revision-input"
+                id="search-revision-input-label"
               >
-                <legend
-                  class="css-1ftyaf0"
+                Search By Revision ID or Author Email
+              </label>
+              <div
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1695314-MuiInputBase-root-MuiOutlinedInput-root"
+              >
+                <div
+                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
                 >
-                  <span>
-                    Search By Revision ID or Author Email
-                  </span>
-                </legend>
-              </fieldset>
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                    data-testid="SearchIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                    />
+                  </svg>
+                </div>
+                <input
+                  aria-invalid="false"
+                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
+                  id="search-revision-input"
+                  placeholder="Search By Revision ID or Author Email"
+                  type="text"
+                  value=""
+                />
+                <fieldset
+                  aria-hidden="true"
+                  class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+                >
+                  <legend
+                    class="css-14lo706"
+                  >
+                    <span>
+                      Search By Revision ID or Author Email
+                    </span>
+                  </legend>
+                </fieldset>
+              </div>
             </div>
           </div>
-        </div>
-        <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-1 css-1t8rubm-MuiGrid-root"
-        >
-          <button
-            aria-label="add revisions"
-            class="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root add-revision-button css-6yg5eq-MuiButtonBase-root-MuiButton-root"
-            id="add-revision-button"
-            tabindex="0"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-              data-testid="AddIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-              />
-            </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
-          </button>
-        </div>
-        <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-z2teic-MuiGrid-root"
-        >
           <div
-            class="MuiBox-root css-l1oafp"
+            class="MuiBox-root css-jj0rrt"
             id="search-results-list"
           >
             <ul
-              class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
+              class="MuiList-root MuiList-padding css-1fc0pkb-MuiList-root"
             >
               <div
-                class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters f1ht8qkz css-1gopsaf-MuiButtonBase-root-MuiListItemButton-root"
                 role="button"
                 tabindex="0"
               >
                 <li
                   class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
+                >
+                  <div
+                    class="MuiListItemIcon-root search-revision-item-icon search-revision css-cveggr-MuiListItemIcon-root"
+                  >
+                    <span
+                      class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary Mui-checked PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorPrimary search-revision-item-checkbox css-zkqepn-MuiButtonBase-root-MuiCheckbox-root"
+                      data-testid="checkbox-0"
+                    >
+                      <input
+                        aria-label="'you've got no arms left!' by 'johncleese@python.com'"
+                        class="PrivateSwitchBase-input css-1m9pwf3"
+                        data-indeterminate="false"
+                        tabindex="-1"
+                        type="checkbox"
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                        data-testid="CheckBoxIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                        />
+                      </svg>
+                    </span>
+                  </div>
+                  <div
+                    class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ubpm07-MuiTypography-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body2 revision-hash css-1n4m7wi-MuiTypography-root"
+                      >
+                        coconut
+                      </span>
+                      <div
+                        class="info-caption"
+                      >
+                        <div
+                          class="info-caption-item item-author"
+                        >
+                           
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
+                            data-testid="MailOutlineOutlinedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
+                            />
+                          </svg>
+                           
+                          johncleese@python.com
+                        </div>
+                        <div
+                          class="info-caption-item item-time"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall time-icon css-1mecf1h-MuiSvgIcon-root"
+                            data-testid="AccessTimeOutlinedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"
+                            />
+                          </svg>
+                          03/29/51 00:00
+                        </div>
+                      </div>
+                    </span>
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-3a763r-MuiTypography-root"
+                    >
+              <li
+                class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
+              >
+                      you've got no arms left! 
+                    </p>
+                  </div>
+                </li>
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                >
+                  <span
+                    class="css-y4cjyz-MuiTouchRipple-ripple MuiTouchRipple-ripple MuiTouchRipple-rippleVisible"
+                    style="width: 2.8284271247461903px; height: 2.8284271247461903px; top: -1.4142135623730951px; left: -1.4142135623730951px;"
+                  >
+                    <span
+                      class="MuiTouchRipple-child MuiTouchRipple-childLeaving"
+                    />
+                  </span>
+                </span>
+              </div>
+                <div
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters f1ht8qkz css-1gopsaf-MuiButtonBase-root-MuiListItemButton-root"
+                  role="group"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemIcon-root search-revision-item-icon search-revision css-cveggr-MuiListItemIcon-root"
@@ -523,27 +618,27 @@ exports[`Search View should not hide search results when clicking search results
                       johncleese@python.com - Thu Mar 29 1951 00:00:00 GMT+0000 (Coordinated Universal Time)
                     </p>
                   </div>
-                </li>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                >
                   <span
-                    class="css-y4cjyz-MuiTouchRipple-ripple MuiTouchRipple-ripple MuiTouchRipple-rippleVisible"
-                    style="width: 2.8284271247461903px; height: 2.8284271247461903px; top: -1.4142135623730951px; left: -1.4142135623730951px;"
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                   >
                     <span
-                      class="MuiTouchRipple-child MuiTouchRipple-childLeaving"
-                    />
+                      class="css-y4cjyz-MuiTouchRipple-ripple MuiTouchRipple-ripple MuiTouchRipple-rippleVisible"
+                      style="width: 2.8284271247461903px; height: 2.8284271247461903px; top: -1.4142135623730951px; left: -1.4142135623730951px;"
+                    >
+                      <span
+                        class="MuiTouchRipple-child MuiTouchRipple-childLeaving"
+                      />
+                    </span>
                   </span>
-                </span>
-              </div>
-              <div
-                class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                role="button"
-                tabindex="0"
+                </div>
+              </li>
+              <li
+                class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
               >
-                <li
-                  class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
+                <div
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters f1ht8qkz css-1gopsaf-MuiButtonBase-root-MuiListItemButton-root"
+                  role="group"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemIcon-root search-revision-item-icon search-revision css-cveggr-MuiListItemIcon-root"
@@ -647,18 +742,18 @@ exports[`Search View should not hide search results when clicking search results
                       terrygilliam@python.com - Wed Jul 29 1987 00:00:00 GMT+0000 (Coordinated Universal Time)
                     </p>
                   </div>
-                </li>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
-              </div>
-              <div
-                class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                role="button"
-                tabindex="0"
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </div>
+              </li>
+              <li
+                class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
               >
-                <li
-                  class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
+                <div
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters f1ht8qkz css-1gopsaf-MuiButtonBase-root-MuiListItemButton-root"
+                  role="group"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemIcon-root search-revision-item-icon search-revision css-cveggr-MuiListItemIcon-root"
@@ -700,18 +795,18 @@ exports[`Search View should not hide search results when clicking search results
                       michaelpalin@python.com - Sat Jul 04 2020 00:00:00 GMT+0000 (Coordinated Universal Time)
                     </p>
                   </div>
-                </li>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
-              </div>
-              <div
-                class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                role="button"
-                tabindex="0"
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </div>
+              </li>
+              <li
+                class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
               >
-                <li
-                  class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
+                <div
+                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters f1ht8qkz css-1gopsaf-MuiButtonBase-root-MuiListItemButton-root"
+                  role="group"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemIcon-root search-revision-item-icon search-revision css-cveggr-MuiListItemIcon-root"
@@ -753,11 +848,11 @@ exports[`Search View should not hide search results when clicking search results
                       grahamchapman@python.com - Wed Apr 13 2022 00:00:00 GMT+0000 (Coordinated Universal Time)
                     </p>
                   </div>
-                </li>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
-              </div>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </div>
+              </li>
             </ul>
           </div>
         </div>

--- a/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
@@ -406,175 +406,80 @@ exports[`Search View should not hide search results when clicking search results
           <div
             class="MuiFormControl-root MuiTextField-root css-136h9lv-MuiFormControl-root-MuiTextField-root"
           >
-            <div
-              class="MuiFormControl-root MuiTextField-root f1ci76mj f17k9m91 css-136h9lv-MuiFormControl-root-MuiTextField-root"
+            <label
+              class="MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-root MuiFormLabel-colorPrimary css-1dl35zc-MuiFormLabel-root-MuiInputLabel-root"
+              data-shrink="false"
+              for="search-revision-input"
+              id="search-revision-input-label"
             >
-              <label
-                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-mru796-MuiFormLabel-root-MuiInputLabel-root"
-                data-shrink="true"
-                for="search-revision-input"
-                id="search-revision-input-label"
+              Search By Revision ID or Author Email
+            </label>
+            <div
+              class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl css-1cg28ds-MuiInputBase-root-MuiOutlinedInput-root"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiOutlinedInput-input MuiInputBase-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
+                id="search-revision-input"
+                type="text"
+                value=""
+              />
+              <fieldset
+                aria-hidden="true"
+                class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
               >
-                Search By Revision ID or Author Email
-              </label>
-              <div
-                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1695314-MuiInputBase-root-MuiOutlinedInput-root"
-              >
-                <div
-                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+                <legend
+                  class="css-1ftyaf0"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                    data-testid="SearchIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-                    />
-                  </svg>
-                </div>
-                <input
-                  aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
-                  id="search-revision-input"
-                  placeholder="Search By Revision ID or Author Email"
-                  type="text"
-                  value=""
-                />
-                <fieldset
-                  aria-hidden="true"
-                  class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-                >
-                  <legend
-                    class="css-14lo706"
-                  >
-                    <span>
-                      Search By Revision ID or Author Email
-                    </span>
-                  </legend>
-                </fieldset>
-              </div>
+                  <span>
+                    Search By Revision ID or Author Email
+                  </span>
+                </legend>
+              </fieldset>
             </div>
           </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-1 css-1t8rubm-MuiGrid-root"
+        >
+          <button
+            aria-label="add revisions"
+            class="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root add-revision-button css-6yg5eq-MuiButtonBase-root-MuiButton-root"
+            id="add-revision-button"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+              data-testid="AddIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+              />
+            </svg>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-z2teic-MuiGrid-root"
+        >
           <div
-            class="MuiBox-root css-jj0rrt"
+            class="MuiBox-root css-l1oafp"
             id="search-results-list"
           >
             <ul
-              class="MuiList-root MuiList-padding css-1fc0pkb-MuiList-root"
+              class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
             >
-              <div
-                class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters f1ht8qkz css-1gopsaf-MuiButtonBase-root-MuiListItemButton-root"
-                role="button"
-                tabindex="0"
-              >
-                <li
-                  class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
-                >
-                  <div
-                    class="MuiListItemIcon-root search-revision-item-icon search-revision css-cveggr-MuiListItemIcon-root"
-                  >
-                    <span
-                      class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary Mui-checked PrivateSwitchBase-edgeStart MuiCheckbox-root MuiCheckbox-colorPrimary search-revision-item-checkbox css-zkqepn-MuiButtonBase-root-MuiCheckbox-root"
-                      data-testid="checkbox-0"
-                    >
-                      <input
-                        aria-label="'you've got no arms left!' by 'johncleese@python.com'"
-                        class="PrivateSwitchBase-input css-1m9pwf3"
-                        data-indeterminate="false"
-                        tabindex="-1"
-                        type="checkbox"
-                      />
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                        data-testid="CheckBoxIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-                        />
-                      </svg>
-                    </span>
-                  </div>
-                  <div
-                    class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
-                  >
-                    <span
-                      class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ubpm07-MuiTypography-root"
-                    >
-                      <span
-                        class="MuiTypography-root MuiTypography-body2 revision-hash css-1n4m7wi-MuiTypography-root"
-                      >
-                        coconut
-                      </span>
-                      <div
-                        class="info-caption"
-                      >
-                        <div
-                          class="info-caption-item item-author"
-                        >
-                           
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
-                            data-testid="MailOutlineOutlinedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
-                            />
-                          </svg>
-                           
-                          johncleese@python.com
-                        </div>
-                        <div
-                          class="info-caption-item item-time"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall time-icon css-1mecf1h-MuiSvgIcon-root"
-                            data-testid="AccessTimeOutlinedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"
-                            />
-                          </svg>
-                          03/29/51 00:00
-                        </div>
-                      </div>
-                    </span>
-                    <p
-                      class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-3a763r-MuiTypography-root"
-                    >
               <li
                 class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
               >
-                      you've got no arms left! 
-                    </p>
-                  </div>
-                </li>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                >
-                  <span
-                    class="css-y4cjyz-MuiTouchRipple-ripple MuiTouchRipple-ripple MuiTouchRipple-rippleVisible"
-                    style="width: 2.8284271247461903px; height: 2.8284271247461903px; top: -1.4142135623730951px; left: -1.4142135623730951px;"
-                  >
-                    <span
-                      class="MuiTouchRipple-child MuiTouchRipple-childLeaving"
-                    />
-                  </span>
-                </span>
-              </div>
                 <div
-                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters f1ht8qkz css-1gopsaf-MuiButtonBase-root-MuiListItemButton-root"
+                  class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   role="group"
                   tabindex="0"
                 >
@@ -586,6 +491,7 @@ exports[`Search View should not hide search results when clicking search results
                       data-testid="checkbox-0"
                     >
                       <input
+                        aria-label="'you've got no arms left!' by 'johncleese@python.com'"
                         class="PrivateSwitchBase-input css-1m9pwf3"
                         data-indeterminate="false"
                         tabindex="-1"
@@ -636,7 +542,7 @@ exports[`Search View should not hide search results when clicking search results
                 class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
               >
                 <div
-                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters f1ht8qkz css-1gopsaf-MuiButtonBase-root-MuiListItemButton-root"
+                  class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   role="group"
                   tabindex="0"
                 >
@@ -648,6 +554,7 @@ exports[`Search View should not hide search results when clicking search results
                       data-testid="checkbox-1"
                     >
                       <input
+                        aria-label="'it's just a flesh wound' by 'ericidle@python.com'"
                         class="PrivateSwitchBase-input css-1m9pwf3"
                         data-indeterminate="false"
                         tabindex="-1"
@@ -680,27 +587,27 @@ exports[`Search View should not hide search results when clicking search results
                       ericidle@python.com - Sat Feb 22 1958 00:00:00 GMT+0000 (Coordinated Universal Time)
                     </p>
                   </div>
-                </li>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                >
                   <span
-                    class="css-y4cjyz-MuiTouchRipple-ripple MuiTouchRipple-ripple MuiTouchRipple-rippleVisible"
-                    style="width: 2.8284271247461903px; height: 2.8284271247461903px; top: -1.4142135623730951px; left: -1.4142135623730951px;"
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                   >
                     <span
-                      class="MuiTouchRipple-child MuiTouchRipple-childLeaving"
-                    />
+                      class="css-y4cjyz-MuiTouchRipple-ripple MuiTouchRipple-ripple MuiTouchRipple-rippleVisible"
+                      style="width: 2.8284271247461903px; height: 2.8284271247461903px; top: -1.4142135623730951px; left: -1.4142135623730951px;"
+                    >
+                      <span
+                        class="MuiTouchRipple-child MuiTouchRipple-childLeaving"
+                      />
+                    </span>
                   </span>
-                </span>
-              </div>
-              <div
-                class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
-                role="button"
-                tabindex="0"
+                </div>
+              </li>
+              <li
+                class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
               >
-                <li
-                  class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
+                <div
+                  class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
+                  role="group"
+                  tabindex="0"
                 >
                   <div
                     class="MuiListItemIcon-root search-revision-item-icon search-revision css-cveggr-MuiListItemIcon-root"
@@ -710,6 +617,7 @@ exports[`Search View should not hide search results when clicking search results
                       data-testid="checkbox-2"
                     >
                       <input
+                        aria-label="'What, ridden on a horse?' by 'terrygilliam@python.com'"
                         class="PrivateSwitchBase-input css-1m9pwf3"
                         data-indeterminate="false"
                         tabindex="-1"
@@ -751,7 +659,7 @@ exports[`Search View should not hide search results when clicking search results
                 class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
               >
                 <div
-                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters f1ht8qkz css-1gopsaf-MuiButtonBase-root-MuiListItemButton-root"
+                  class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   role="group"
                   tabindex="0"
                 >
@@ -763,6 +671,7 @@ exports[`Search View should not hide search results when clicking search results
                       data-testid="checkbox-3"
                     >
                       <input
+                        aria-label="'You've got two empty 'alves of coconuts and you're bangin' 'em togetha!' by 'michaelpalin@python.com'"
                         class="PrivateSwitchBase-input css-1m9pwf3"
                         data-indeterminate="false"
                         tabindex="-1"
@@ -804,7 +713,7 @@ exports[`Search View should not hide search results when clicking search results
                 class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-1nxmd3h-MuiListItem-root"
               >
                 <div
-                  class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters f1ht8qkz css-1gopsaf-MuiButtonBase-root-MuiListItemButton-root"
+                  class="MuiListItemButton-root MuiListItemButton-gutters MuiButtonBase-root css-16ac5r2-MuiButtonBase-root-MuiListItemButton-root"
                   role="group"
                   tabindex="0"
                 >
@@ -816,6 +725,7 @@ exports[`Search View should not hide search results when clicking search results
                       data-testid="checkbox-4"
                     >
                       <input
+                        aria-label="'It got better...' by 'grahamchapman@python.com'"
                         class="PrivateSwitchBase-input css-1m9pwf3"
                         data-indeterminate="false"
                         tabindex="-1"

--- a/src/components/Search/SearchResultsListItem.tsx
+++ b/src/components/Search/SearchResultsListItem.tsx
@@ -19,6 +19,7 @@ function SearchResultsListItem(props: SearchResultsListItemProps) {
   const revisionHash = truncateHash(item.revision);
   const commitMessage = getLatestCommitMessage(item);
   const maxRevisions = view == 'compare-results' ? 1 : 4;
+  const label = { inputProps: { 'aria-label': `'${commitMessage}' by '${item.author}'` } };
 
   return (
     <>
@@ -38,6 +39,7 @@ function SearchResultsListItem(props: SearchResultsListItemProps) {
               disableRipple
               data-testid={`checkbox-${index}`}
               checked={isChecked}
+              {...label}
             />
           </ListItemIcon>
           <ListItemText

--- a/src/components/Search/SearchResultsListItem.tsx
+++ b/src/components/Search/SearchResultsListItem.tsx
@@ -23,13 +23,13 @@ function SearchResultsListItem(props: SearchResultsListItemProps) {
 
   return (
     <>
-      <ListItemButton
-        key={item.id}
-        onClick={() => handleToggle(item, maxRevisions)}
+      <ListItem
+        className="search-revision-item search-revision"
+        disablePadding
       >
-        <ListItem
-          className="search-revision-item search-revision"
-          disablePadding
+        <ListItemButton
+          key={item.id}
+          onClick={() => handleToggle(item, maxRevisions)}
         >
           <ListItemIcon className="search-revision-item-icon search-revision">
             <Checkbox
@@ -51,8 +51,8 @@ function SearchResultsListItem(props: SearchResultsListItemProps) {
             primaryTypographyProps={{ noWrap: true }}
             secondaryTypographyProps={{ noWrap: true }}
           />
-        </ListItem>
-      </ListItemButton>
+        </ListItemButton>
+      </ListItem>
     </>
   );
 }

--- a/src/components/Search/SearchResultsListItem.tsx
+++ b/src/components/Search/SearchResultsListItem.tsx
@@ -30,6 +30,7 @@ function SearchResultsListItem(props: SearchResultsListItemProps) {
         <ListItemButton
           key={item.id}
           onClick={() => handleToggle(item, maxRevisions)}
+          role="group"
         >
           <ListItemIcon className="search-revision-item-icon search-revision">
             <Checkbox


### PR DESCRIPTION
# Summary
Some accessibility standards violations in the `SearchResultsList` component cause [tests](https://app.circleci.com/pipelines/github/mozilla/perfcompare/1103/workflows/8aaaeeb7-a7d5-422a-90fa-29257fe7c1e4/jobs/1107/parallel-runs/0/steps/0-107) to fail. These violations include:

1. Missing aria-label in certain `input`(checkbox) elements,
2. `li` element not being a direct descendant of `ul`, having other elements in-between,
3. and an interactive element(checkbox) nested within another interactive element(button).

## Before:
1. The content of the unlabeled checkboxes (rendered by [`Checkbox`](https://mui.com/material-ui/react-checkbox/) in `SearchResultsListItem` component) were unidentifiable to assistive technologies like screen readers and users who rely on them.
2. The structure of the list of revisions in the search results list was ambiguous to assistive technologies like screen readers and they may not be able to announce to users that they are reading a list.
3. Focusable elements (e.g checkboxes) with interactive elements (e.g buttons) as parents are not announced by screen readers and some users may face difficulty using them. 

## Changes: 
This pull request:
- Passes 'aria-label' attributes, in the format of "(commit-message) by (author)", down in a prop to the checkboxes, as recommended by the [MUI docs](https://mui.com/material-ui/react-checkbox/). For violation 1.
- Reverses the nesting order of the [`ListItemButton`](https://mui.com/material-ui/api/list-item-button/) and [`ListItem`](https://mui.com/material-ui/api/list-item/) in `SearchResultsListItem` component. For violation 2.
- Changes the role attribute of [`ListItemButton`](https://mui.com/material-ui/api/list-item-button/) which renders a `div` element from 'button' to ['group'](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/group_role). For violation 3.
- Updates snapshot files.
- Closes #302.