### PR TITLE
fix: Search results list re rendering when checkbox is checked or unchecked

### DIFF
--- a/src/components/Search/SearchResultsList.tsx
+++ b/src/components/Search/SearchResultsList.tsx
@@ -1,4 +1,5 @@
-import { memo } from 'react'
+import { memo } from 'react';
+
 import Box from '@mui/material/Box';
 import List from '@mui/material/List';
 
@@ -45,6 +46,6 @@ interface SearchResultsListProps {
   view: 'compare-results' | 'search';
 }
 
-const SearchResultsListMemoized = memo(SearchResultsList)
+const SearchResultsListMemoized = memo(SearchResultsList);
 
 export default SearchResultsListMemoized;

--- a/src/components/Search/SearchResultsList.tsx
+++ b/src/components/Search/SearchResultsList.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react'
 import Box from '@mui/material/Box';
 import List from '@mui/material/List';
 
@@ -44,4 +45,6 @@ interface SearchResultsListProps {
   view: 'compare-results' | 'search';
 }
 
-export default SearchResultsList;
+const SearchResultsListMemoized = memo(SearchResultsList)
+
+export default SearchResultsListMemoized;


### PR DESCRIPTION
This pull request fixes #140 .

It prevents the unnecessary rerender of the `SearchResultsList` component by wrapping it in a `React.memo`. 