### PR TITLE
Fix inconsistent width issue in results view. Issue #267

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/CompareResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/CompareResultsTable.test.tsx.snap
@@ -9,7 +9,37 @@ exports[`Compare Results Table Should match snapshot 1`] = `
       <table
         aria-label="a dense table"
         class="MuiTable-root css-d8sagy-MuiTable-root"
-      />
+      >
+        <colgroup>
+          <col
+            style="width: 10%;"
+          />
+          <col
+            style="width: 10%;"
+          />
+          <col
+            style="width: 20%;"
+          />
+          <col
+            style="width: 10%;"
+          />
+          <col
+            style="width: 10%;"
+          />
+          <col
+            style="width: 10%;"
+          />
+          <col
+            style="width: 10%;"
+          />
+          <col
+            style="width: 12%;"
+          />
+          <col
+            style="width: 8%;"
+          />
+        </colgroup>
+      </table>
     </div>
   </div>
 </body>

--- a/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
@@ -10,6 +10,35 @@ exports[`CompareResults View Should match snapshot 1`] = `
         aria-label="a dense table"
         class="MuiTable-root css-d8sagy-MuiTable-root"
       >
+        <colgroup>
+          <col
+            style="width: 10%;"
+          />
+          <col
+            style="width: 10%;"
+          />
+          <col
+            style="width: 20%;"
+          />
+          <col
+            style="width: 10%;"
+          />
+          <col
+            style="width: 10%;"
+          />
+          <col
+            style="width: 10%;"
+          />
+          <col
+            style="width: 10%;"
+          />
+          <col
+            style="width: 12%;"
+          />
+          <col
+            style="width: 8%;"
+          />
+        </colgroup>
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
         >

--- a/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
@@ -148,7 +148,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
               data-mui-internal-clone-element="true"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               <a
                 aria-label="Graph link"
@@ -176,27 +176,27 @@ exports[`CompareResults View Should match snapshot 1`] = `
               a11yr dhtml.html opt e10s fission stylo webrender
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               704.84
                
               ms
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               712.44
                
               ms
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               1.08
               %
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               <svg
                 aria-hidden="true"
@@ -213,11 +213,11 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon low css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall background-icon low css-1kd1sqa-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               1
               /
@@ -234,7 +234,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
               data-mui-internal-clone-element="true"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               <a
                 aria-label="Graph link"
@@ -262,27 +262,27 @@ exports[`CompareResults View Should match snapshot 1`] = `
               a11yr dhtml.html opt e10s fission stylo webrender
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               776.97
                
               ms
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               791.34
                
               ms
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               1.85
               %
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
                
               <svg
@@ -299,11 +299,11 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon med css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall background-icon med css-1kd1sqa-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               1
               /
@@ -320,7 +320,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
               data-mui-internal-clone-element="true"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               <a
                 aria-label="Graph link"
@@ -348,37 +348,37 @@ exports[`CompareResults View Should match snapshot 1`] = `
               a11yr dhtml.html opt e10s fission stylo webrender
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               643.54
                
               ms
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               628.09
                
               ms
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               -2.4
               %
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
                
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon high css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall background-icon high css-1kd1sqa-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               1
               /
@@ -395,7 +395,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
               data-mui-internal-clone-element="true"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               <a
                 aria-label="Graph link"
@@ -423,33 +423,33 @@ exports[`CompareResults View Should match snapshot 1`] = `
               a11yr dhtml.html opt e10s fission stylo webrender
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               643.54
                
               ms
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               628.09
                
               ms
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               -2.4
               %
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
                
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall unknown-confidence css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall unknown-confidence css-1kd1sqa-MuiTableCell-root"
               data-testid="confidence-icon"
             >
               <button
@@ -476,7 +476,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
               </button>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               1
               /

--- a/src/components/CompareResults/CompareResultsTable.tsx
+++ b/src/components/CompareResults/CompareResultsTable.tsx
@@ -29,6 +29,17 @@ function CompareResultsTable(props: CompareResultsProps) {
               size="small"
               aria-label="a dense table"
             >
+              <colgroup>
+      <col style={{width:'10%'}}/>
+      <col style={{width:'10%'}}/>
+      <col style={{width:'20%'}}/>
+      <col style={{width:'10%'}}/>
+      <col style={{width:'10%'}}/>
+      <col style={{width:'10%'}}/>
+      <col style={{width:'10%'}}/>
+      <col style={{width:'12%'}}/>
+      <col style={{width:'8%'}}/>
+   </colgroup>
               <PaginatedCompareResults mode={mode} />
             </Table>
           </TableContainer>

--- a/src/components/CompareResults/CompareResultsTable.tsx
+++ b/src/components/CompareResults/CompareResultsTable.tsx
@@ -30,15 +30,15 @@ function CompareResultsTable(props: CompareResultsProps) {
               aria-label="a dense table"
             >
               <colgroup>
-      <col style={{width:'10%'}}/>
-      <col style={{width:'10%'}}/>
-      <col style={{width:'20%'}}/>
-      <col style={{width:'10%'}}/>
-      <col style={{width:'10%'}}/>
-      <col style={{width:'10%'}}/>
-      <col style={{width:'10%'}}/>
-      <col style={{width:'12%'}}/>
-      <col style={{width:'8%'}}/>
+      <col style={{ width:'10%' }}/>
+      <col style={{ width:'10%' }}/>
+      <col style={{ width:'20%' }}/>
+      <col style={{ width:'10%' }}/>
+      <col style={{ width:'10%' }}/>
+      <col style={{ width:'10%' }}/>
+      <col style={{ width:'10%' }}/>
+      <col style={{ width:'12%' }}/>
+      <col style={{ width:'8%' }}/>
    </colgroup>
               <PaginatedCompareResults mode={mode} />
             </Table>

--- a/src/components/CompareResults/CompareResultsTableRow.tsx
+++ b/src/components/CompareResults/CompareResultsTableRow.tsx
@@ -25,7 +25,7 @@ function CompareResultsTableRow(props: ResultsTableRowProps) {
           )}`}
         ></TableCell>
       </Tooltip>
-      <TableCell>
+      <TableCell align="center">
         <Link
           href={result.graphs_link}
           className={`background-icon ${mode}-mode graph-icon-color`}
@@ -36,27 +36,27 @@ function CompareResultsTableRow(props: ResultsTableRowProps) {
           <TimelineIcon />
         </Link>
       </TableCell>
-      <TableCell>{result.header_name}</TableCell>
-      <TableCell>
+      <TableCell >{result.header_name}</TableCell>
+      <TableCell align="center">
         {result.base_median_value} {result.base_measurement_unit}
       </TableCell>
-      <TableCell>
+      <TableCell align="center">
         {result.new_median_value} {result.new_measurement_unit}
       </TableCell>
-      <TableCell>{result.delta_percentage}%</TableCell>
-      <TableCell>
+      <TableCell align="center">{result.delta_percentage}%</TableCell>
+      <TableCell align="center">
         {result.is_improvement && <ThumbUpAltIcon color="success" />}{' '}
         {result.is_regression && <WarningIcon color="error" />}{' '}
       </TableCell>
       {result.confidence_text ? (
-        <TableCell
+        <TableCell align="center"
           data-testid="confidence-icon"
           className={`background-icon ${setConfidenceClassName(
             result.confidence_text,
           )}`}
         ></TableCell>
       ) : (
-        <TableCell
+        <TableCell align="center"
           data-testid="confidence-icon"
           className={`${setConfidenceClassName(result.confidence_text)}`}
         >
@@ -68,7 +68,7 @@ function CompareResultsTableRow(props: ResultsTableRowProps) {
         </TableCell>
       )}
 
-      <TableCell>
+      <TableCell align="center">
         {result.base_runs.length}/{result.new_runs.length}
       </TableCell>
     </TableRow>


### PR DESCRIPTION
# Hi There ✋ 

This Pull Request is for Issue #267 

### In this pull request following changes were introduced.

- Defined widths in percentages so that the data is contained within the specified width and the width of the column stays the same and independent of the data.

- Specified the `align` prop for the table cells of the  `CompareResultsTableRow.tsx` and made the values for `align` consistent with values (left, center, right) specified in the `tableHead` array in `CompareResultsTableHead.tsx`.


Before             |  This PR
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/60618877/223681021-0041feff-d38c-4964-92b6-a75607675a52.png)  |  ![image](https://user-images.githubusercontent.com/60618877/223757565-7d110945-fc53-46bc-bd32-a032ba952ab9.png)