### PR TITLE
fix width of edit revision popover #225

### DIFF
--- a/src/components/CompareResults/EditRevisionButton.tsx
+++ b/src/components/CompareResults/EditRevisionButton.tsx
@@ -27,23 +27,23 @@ function EditRevisionButton(props: EditRevisionButtonProps) {
       </IconButton>
 
       
-      <Popover
-        className="edit-revision-popover"
-        open={popoverIsOpen}
-        anchorEl={anchorEl}
-        onClose={() => setPopoverIsOpen(false)}
-        anchorOrigin={{
-          vertical: 'top',
-          horizontal: 'center',
-        }}
-        transformOrigin={{
-          vertical: 'top',
-          horizontal: 'center',
-        }}
-        PaperProps={{
-          style: { maxWidth: "81%" },
-        }}
-      >
+        <Popover
+          className="edit-revision-popover"
+          open={popoverIsOpen}
+          anchorEl={anchorEl}
+          onClose={() => setPopoverIsOpen(false)}
+          anchorOrigin={{
+            vertical: 'top',
+            horizontal: 'center',
+          }}
+          transformOrigin={{
+            vertical: 'top',
+            horizontal: 'center',
+          }}
+          PaperProps={{
+            style: { maxWidth: "81%" },
+          }}
+        >
         <RevisionSearch
           view="compare-results"
           prevRevision={item}

--- a/src/components/CompareResults/EditRevisionButton.tsx
+++ b/src/components/CompareResults/EditRevisionButton.tsx
@@ -27,22 +27,22 @@ function EditRevisionButton(props: EditRevisionButtonProps) {
       </IconButton>
 
       
-        <Popover
-          className="edit-revision-popover"
-          open={popoverIsOpen}
-          anchorEl={anchorEl}
-          onClose={() => setPopoverIsOpen(false)}
-          anchorOrigin={{
-            vertical: 'top',
-            horizontal: 'center',
-          }}
-          transformOrigin={{
-            vertical: 'top',
-            horizontal: 'center',
-          }}
-          PaperProps={{
-            style: { maxWidth: "81%" },
-          }}
+      <Popover
+        className="edit-revision-popover"
+        open={popoverIsOpen}
+        anchorEl={anchorEl}
+        onClose={() => setPopoverIsOpen(false)}
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: 'center',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'center',
+        }}
+        PaperProps={{
+          style: { maxWidth: '81%' },
+        }}
         >
         <RevisionSearch
           view="compare-results"

--- a/src/components/CompareResults/EditRevisionButton.tsx
+++ b/src/components/CompareResults/EditRevisionButton.tsx
@@ -26,14 +26,22 @@ function EditRevisionButton(props: EditRevisionButtonProps) {
         <EditIcon />
       </IconButton>
 
+      
       <Popover
         className="edit-revision-popover"
         open={popoverIsOpen}
         anchorEl={anchorEl}
         onClose={() => setPopoverIsOpen(false)}
         anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'left',
+          vertical: 'top',
+          horizontal: 'center',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'center',
+        }}
+        PaperProps={{
+          style: { maxWidth: "81%" },
         }}
       >
         <RevisionSearch


### PR DESCRIPTION
I've solved the width issue #225 with the popover using the PaperProps property.

Below are the screenshots of the before and after the bug fixing.
![app before](https://user-images.githubusercontent.com/109840351/223917595-a047118f-ca8a-480d-bb5f-5770e6e40f98.jpg)

![app after](https://user-images.githubusercontent.com/109840351/223917588-a8bdf05b-6eaf-42ad-b405-e80509ad29df.jpg)
