### PR TITLE
Fix- Columns in results view are not a consistent width #267

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/CompareResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/CompareResultsTable.test.tsx.snap
@@ -9,7 +9,37 @@ exports[`Compare Results Table Should match snapshot 1`] = `
       <table
         aria-label="a dense table"
         class="MuiTable-root css-d8sagy-MuiTable-root"
-      />
+      >
+        <colgroup>
+          <col
+            style="width: 10%;"
+          />
+          <col
+            style="width: 10%;"
+          />
+          <col
+            style="width: 20%;"
+          />
+          <col
+            style="width: 10%;"
+          />
+          <col
+            style="width: 10%;"
+          />
+          <col
+            style="width: 10%;"
+          />
+          <col
+            style="width: 10%;"
+          />
+          <col
+            style="width: 12%;"
+          />
+          <col
+            style="width: 8%;"
+          />
+        </colgroup>
+      </table>
     </div>
   </div>
 </body>

--- a/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
@@ -10,6 +10,35 @@ exports[`CompareResults View Should match snapshot 1`] = `
         aria-label="a dense table"
         class="MuiTable-root css-d8sagy-MuiTable-root"
       >
+        <colgroup>
+          <col
+            style="width: 10%;"
+          />
+          <col
+            style="width: 10%;"
+          />
+          <col
+            style="width: 20%;"
+          />
+          <col
+            style="width: 10%;"
+          />
+          <col
+            style="width: 10%;"
+          />
+          <col
+            style="width: 10%;"
+          />
+          <col
+            style="width: 10%;"
+          />
+          <col
+            style="width: 12%;"
+          />
+          <col
+            style="width: 8%;"
+          />
+        </colgroup>
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
         >

--- a/src/components/CompareResults/CompareResultsTable.tsx
+++ b/src/components/CompareResults/CompareResultsTable.tsx
@@ -29,6 +29,17 @@ function CompareResultsTable(props: CompareResultsProps) {
               size="small"
               aria-label="a dense table"
             >
+              <colgroup>
+      <col style={{ width:'10%' }}/>
+      <col style={{ width:'10%' }}/>
+      <col style={{ width:'20%' }}/>
+      <col style={{ width:'10%' }}/>
+      <col style={{ width:'10%' }}/>
+      <col style={{ width:'10%' }}/>
+      <col style={{ width:'10%' }}/>
+      <col style={{ width:'12%' }}/>
+      <col style={{ width:'8%' }}/>
+   </colgroup>
               <PaginatedCompareResults mode={mode} />
             </Table>
           </TableContainer>


### PR DESCRIPTION
# In this PR ✋ 
@Carla-Moz @kimberlythegeek 

I have specified widths for the columns so that the widths stay consistent and the layout remains responsive.

These changes are to ensure that the width of the columns stays consistent and does not change depending on the data contained within the columns.

This includes adding the MUI colgroup in CompareResultsTable.tsx component and specifying column widths in percentages.

**Before Changes**             |  **After Changes**
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/60618877/223970368-110213c8-40a3-4121-800d-1945713c24cd.png)  |  ![image](https://user-images.githubusercontent.com/60618877/223970005-c2a2ba26-40ae-490b-819d-46f9cb110408.png)


### Please Note: I would highly appreciate input over the values of the percentages that are used for specifying widths for the columns.

### Issue
#267