### PR TITLE
Add alignment to the table data that is consistent with the table head #327

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
@@ -148,7 +148,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
               data-mui-internal-clone-element="true"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               <a
                 aria-label="Graph link"
@@ -176,27 +176,27 @@ exports[`CompareResults View Should match snapshot 1`] = `
               a11yr dhtml.html opt e10s fission stylo webrender
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               704.84
                
               ms
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               712.44
                
               ms
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               1.08
               %
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               <svg
                 aria-hidden="true"
@@ -213,11 +213,11 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon low css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall background-icon low css-1kd1sqa-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               1
               /
@@ -234,7 +234,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
               data-mui-internal-clone-element="true"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               <a
                 aria-label="Graph link"
@@ -262,27 +262,27 @@ exports[`CompareResults View Should match snapshot 1`] = `
               a11yr dhtml.html opt e10s fission stylo webrender
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               776.97
                
               ms
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               791.34
                
               ms
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               1.85
               %
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
                
               <svg
@@ -299,11 +299,11 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon med css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall background-icon med css-1kd1sqa-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               1
               /
@@ -320,7 +320,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
               data-mui-internal-clone-element="true"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               <a
                 aria-label="Graph link"
@@ -348,37 +348,37 @@ exports[`CompareResults View Should match snapshot 1`] = `
               a11yr dhtml.html opt e10s fission stylo webrender
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               643.54
                
               ms
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               628.09
                
               ms
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               -2.4
               %
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
                
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon high css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall background-icon high css-1kd1sqa-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               1
               /
@@ -395,7 +395,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
               data-mui-internal-clone-element="true"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               <a
                 aria-label="Graph link"
@@ -423,33 +423,33 @@ exports[`CompareResults View Should match snapshot 1`] = `
               a11yr dhtml.html opt e10s fission stylo webrender
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               643.54
                
               ms
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               628.09
                
               ms
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               -2.4
               %
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
                
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall unknown-confidence css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall unknown-confidence css-1kd1sqa-MuiTableCell-root"
               data-testid="confidence-icon"
             >
               <button
@@ -476,7 +476,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
               </button>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1kd1sqa-MuiTableCell-root"
             >
               1
               /

--- a/src/components/CompareResults/CompareResultsTableRow.tsx
+++ b/src/components/CompareResults/CompareResultsTableRow.tsx
@@ -25,7 +25,7 @@ function CompareResultsTableRow(props: ResultsTableRowProps) {
           )}`}
         ></TableCell>
       </Tooltip>
-      <TableCell>
+      <TableCell align="center">
         <Link
           href={result.graphs_link}
           className={`background-icon ${mode}-mode graph-icon-color`}
@@ -36,27 +36,27 @@ function CompareResultsTableRow(props: ResultsTableRowProps) {
           <TimelineIcon />
         </Link>
       </TableCell>
-      <TableCell>{result.header_name}</TableCell>
-      <TableCell>
+      <TableCell >{result.header_name}</TableCell>
+      <TableCell align="center">
         {result.base_median_value} {result.base_measurement_unit}
       </TableCell>
-      <TableCell>
+      <TableCell align="center">
         {result.new_median_value} {result.new_measurement_unit}
       </TableCell>
-      <TableCell>{result.delta_percentage}%</TableCell>
-      <TableCell>
+      <TableCell align="center">{result.delta_percentage}%</TableCell>
+      <TableCell align="center">
         {result.is_improvement && <ThumbUpAltIcon color="success" />}{' '}
         {result.is_regression && <WarningIcon color="error" />}{' '}
       </TableCell>
       {result.confidence_text ? (
-        <TableCell
+        <TableCell align="center"
           data-testid="confidence-icon"
           className={`background-icon ${setConfidenceClassName(
             result.confidence_text,
           )}`}
         ></TableCell>
       ) : (
-        <TableCell
+        <TableCell align="center"
           data-testid="confidence-icon"
           className={`${setConfidenceClassName(result.confidence_text)}`}
         >
@@ -68,7 +68,7 @@ function CompareResultsTableRow(props: ResultsTableRowProps) {
         </TableCell>
       )}
 
-      <TableCell>
+      <TableCell align="center">
         {result.base_runs.length}/{result.new_runs.length}
       </TableCell>
     </TableRow>


### PR DESCRIPTION
# In this PR ✋ 
@Carla-Moz @kimberlythegeek 

I have added alignment for the data within the columns so that it stays consistent with table headings.

The goal of these changes is to add visual symmetry between the table heads and table data.

This includes adding the MUI `align` prop to `<TableCell>` component and specifying column widths in percentages.

**Before Changes**             |  **After Changes**
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/60618877/223985314-c8f2a013-d89f-4d1e-8ef6-35ea51cfc663.png)  |  ![image](https://user-images.githubusercontent.com/60618877/223985215-14118066-69eb-4ca9-ab5e-c6296cf5551f.png)


### Please feel free to add comments and suggestions.

### Issue
#327 