### PR TITLE
Add warning message when comparing builds from different projects #169

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Performance Comparison Tool
 
 ![screenshot](screenshot.png)
 
+[Outreachy contributor information](https://docs.google.com/document/d/1NLKAR5B2Rc80lRUYWzU2ISrQCQhR4VsW5Qkz1hxE5n8/edit?usp=sharing)
+
 ## Deployments
 
 PerfCompare is hosted on heroku, and is updated every time commits are pushed to the following branches:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ PerfCompare is hosted on heroku, and is updated every time commits are pushed to
 ## Setup
 
 ### Requirements
-
+- [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [nodejs](https://nodejs.org/en/download/)
 
 ### Installation

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # PerfCompare
 
+**[Outreachy contributor information](https://docs.google.com/document/d/1NLKAR5B2Rc80lRUYWzU2ISrQCQhR4VsW5Qkz1hxE5n8/edit?usp=sharing)**
+_____
+
 [![CircleCI](https://circleci.com/gh/mozilla/perfcompare/tree/master.svg?style=shield)](https://circleci.com/gh/mozilla/perfcompare/tree/master)
 [![codecov](https://codecov.io/gh/mozilla/perfcompare/branch/master/graph/badge.svg?token=XHP440JFDQ)](https://codecov.io/gh/mozilla/perfcompare)
 ![GitHub issues](https://img.shields.io/github/issues/mozilla/perfcompare)
@@ -8,8 +11,6 @@
 Performance Comparison Tool
 
 ![screenshot](screenshot.png)
-
-[Outreachy contributor information](https://docs.google.com/document/d/1NLKAR5B2Rc80lRUYWzU2ISrQCQhR4VsW5Qkz1hxE5n8/edit?usp=sharing)
 
 ## Deployments
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **[Outreachy contributor information](https://docs.google.com/document/d/1NLKAR5B2Rc80lRUYWzU2ISrQCQhR4VsW5Qkz1hxE5n8/edit?usp=sharing)**
 _____
 
-[![CircleCI](https://circleci.com/gh/mozilla/perfcompare/tree/master.svg?style=shield)](https://circleci.com/gh/mozilla/perfcompare/tree/master)
+[![CircleCI](https://circleci.com/gh/mozilla/perfcompare/tree/master.svg?style=shield)](https://circleci.com/gh/mozilla/perfcompare/tree/beta)
 [![codecov](https://codecov.io/gh/mozilla/perfcompare/branch/master/graph/badge.svg?token=XHP440JFDQ)](https://codecov.io/gh/mozilla/perfcompare)
 ![GitHub issues](https://img.shields.io/github/issues/mozilla/perfcompare)
 ![GitHub pull requests](https://img.shields.io/github/issues-pr/mozilla/perfcompare)

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -9,6 +9,9 @@ export const maxRevisionsError = 'Maximum 4 revision(s).';
 export const featureNotSupportedError =
   'This feature is not supported yet. Please compare two revisions only.';
 
+export const selectionNotSupportedError = 
+  'Please select items from the same repository.';
+
 export const userFeedbackMessage =
   'For any kind of suggestions please contact us at ';
 export const perfCompareEmail = 'perfcompare-user-feedback@mozilla.com';

--- a/src/components/Search/SearchView.tsx
+++ b/src/components/Search/SearchView.tsx
@@ -6,7 +6,7 @@ import { useSnackbar, VariantType } from 'notistack';
 import { connect } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
-import { repoMap, featureNotSupportedError } from '../../common/constants';
+import { repoMap, featureNotSupportedError, selectionNotSupportedError } from '../../common/constants';
 import type { RootState } from '../../common/store';
 import useFilterCompareResults from '../../hooks/useFilterCompareResults';
 import { Revision } from '../../types/state';
@@ -22,6 +22,18 @@ function SearchView(props: SearchViewProps) {
   const warningVariant: VariantType = 'warning';
 
   const goToCompareResultsPage = (selectedRevisions: Revision[]) => {
+    
+    // Creating a Set to keep track of the repository IDs
+    const repositoryIds = new Set(selectedRevisions.map(rev => rev.repository_id));
+
+    // Checking if there are revisions from different repositories
+    if (repositoryIds.size > 1) {
+      enqueueSnackbar(selectionNotSupportedError as string, {
+        variant: warningVariant,
+      });
+      return;
+    }
+    
     // TODO: remove this check once comparing without a base
     //  and comparing multiple revisions against a base is enabled
     if (selectedRevisions.length === 1 || selectedRevisions.length > 2) {


### PR DESCRIPTION
I've added the feature that warns users while they try to compare revisions from different repositories.