### PR TITLE
Resolved alignment issue with inconsistent table data and table head in results view #327

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
         class="MuiTable-root css-d8sagy-MuiTable-root"
       >
         <thead
-          class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+          class="MuiTableHead-root css-1i9hqo3-MuiTableHead-root"
         >
           <tr
             class="MuiTableRow-root MuiTableRow-head css-1eza0l0-MuiTableRow-root"
@@ -213,7 +213,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon low css-qof5ct-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon low css-1f80mop-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
@@ -300,7 +300,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon med css-qof5ct-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon med css-1f80mop-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
@@ -376,7 +376,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon high css-qof5ct-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon high css-1f80mop-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
@@ -452,7 +452,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall unknown-confidence css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall unknown-confidence css-z6pi6j-MuiTableCell-root"
               data-testid="confidence-icon"
             >
               <button

--- a/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
@@ -213,7 +213,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon low css-1ild2ts-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon low css-qof5ct-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
@@ -300,7 +300,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon med css-1ild2ts-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon med css-qof5ct-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
@@ -376,7 +376,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon high css-1ild2ts-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon high css-qof5ct-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td

--- a/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
         class="MuiTable-root css-d8sagy-MuiTable-root"
       >
         <thead
-          class="MuiTableHead-root css-1i9hqo3-MuiTableHead-root"
+          class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
         >
           <tr
             class="MuiTableRow-root MuiTableRow-head css-1eza0l0-MuiTableRow-root"
@@ -213,7 +213,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon low css-1f80mop-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon low css-qof5ct-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
@@ -300,7 +300,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon med css-1f80mop-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon med css-qof5ct-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
@@ -376,7 +376,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon high css-1f80mop-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon high css-qof5ct-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
@@ -452,7 +452,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall unknown-confidence css-z6pi6j-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall unknown-confidence css-6qq5hg-MuiTableCell-root"
               data-testid="confidence-icon"
             >
               <button

--- a/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
             class="MuiTableRow-root MuiTableRow-head css-1eza0l0-MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1l87mn7-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeSmall css-1gaeir8-MuiTableCell-root"
               scope="col"
             >
               Platform
@@ -101,7 +101,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
               Status
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1l87mn7-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeSmall css-1gaeir8-MuiTableCell-root"
               scope="col"
             >
               Confidence
@@ -128,7 +128,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
               </button>
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeSmall css-pmw8xp-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1l87mn7-MuiTableCell-root"
               scope="col"
             >
               Total Runs
@@ -144,7 +144,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
           >
             <td
               aria-label="macosx1015-64-shippable-qr"
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode osx css-8h992v-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode osx css-1ild2ts-MuiTableCell-root"
               data-mui-internal-clone-element="true"
             />
             <td
@@ -213,11 +213,12 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon low css-8h992v-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon low css-1ild2ts-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-u18ybd-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-ar89v3-MuiTableCell-root"
+              id="total-runs"
             >
               1
               /
@@ -230,7 +231,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
           >
             <td
               aria-label="linux1804-64-shippable-qr"
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode linux css-8h992v-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode linux css-1ild2ts-MuiTableCell-root"
               data-mui-internal-clone-element="true"
             />
             <td
@@ -299,11 +300,12 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon med css-8h992v-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon med css-1ild2ts-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-u18ybd-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-ar89v3-MuiTableCell-root"
+              id="total-runs"
             >
               1
               /
@@ -316,7 +318,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
           >
             <td
               aria-label="windows10-64-shippable-qr"
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode windows css-8h992v-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode windows css-1ild2ts-MuiTableCell-root"
               data-mui-internal-clone-element="true"
             />
             <td
@@ -374,11 +376,12 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon high css-8h992v-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon high css-1ild2ts-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-u18ybd-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-ar89v3-MuiTableCell-root"
+              id="total-runs"
             >
               1
               /
@@ -391,7 +394,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
           >
             <td
               aria-label="windows10-64-shippable-qr"
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode windows css-8h992v-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode windows css-1ild2ts-MuiTableCell-root"
               data-mui-internal-clone-element="true"
             />
             <td
@@ -476,7 +479,8 @@ exports[`CompareResults View Should match snapshot 1`] = `
               </button>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-u18ybd-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-ar89v3-MuiTableCell-root"
+              id="total-runs"
             >
               1
               /

--- a/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
               </button>
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1l87mn7-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeSmall css-pmw8xp-MuiTableCell-root"
               scope="col"
             >
               Graph
@@ -77,25 +77,25 @@ exports[`CompareResults View Should match snapshot 1`] = `
               </button>
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1l87mn7-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeSmall css-pmw8xp-MuiTableCell-root"
               scope="col"
             >
               Base
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1l87mn7-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeSmall css-pmw8xp-MuiTableCell-root"
               scope="col"
             >
               New
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1l87mn7-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeSmall css-pmw8xp-MuiTableCell-root"
               scope="col"
             >
               Delta
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1l87mn7-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeSmall css-pmw8xp-MuiTableCell-root"
               scope="col"
             >
               Status
@@ -128,7 +128,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
               </button>
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1l87mn7-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeSmall css-pmw8xp-MuiTableCell-root"
               scope="col"
             >
               Total Runs
@@ -144,7 +144,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
           >
             <td
               aria-label="macosx1015-64-shippable-qr"
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode osx css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode osx css-8h992v-MuiTableCell-root"
               data-mui-internal-clone-element="true"
             />
             <td
@@ -213,11 +213,11 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon low css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon low css-8h992v-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-u18ybd-MuiTableCell-root"
             >
               1
               /
@@ -230,7 +230,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
           >
             <td
               aria-label="linux1804-64-shippable-qr"
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode linux css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode linux css-8h992v-MuiTableCell-root"
               data-mui-internal-clone-element="true"
             />
             <td
@@ -299,11 +299,11 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon med css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon med css-8h992v-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-u18ybd-MuiTableCell-root"
             >
               1
               /
@@ -316,7 +316,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
           >
             <td
               aria-label="windows10-64-shippable-qr"
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode windows css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode windows css-8h992v-MuiTableCell-root"
               data-mui-internal-clone-element="true"
             />
             <td
@@ -374,11 +374,11 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon high css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon high css-8h992v-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-u18ybd-MuiTableCell-root"
             >
               1
               /
@@ -391,7 +391,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
           >
             <td
               aria-label="windows10-64-shippable-qr"
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode windows css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode windows css-8h992v-MuiTableCell-root"
               data-mui-internal-clone-element="true"
             />
             <td
@@ -476,7 +476,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
               </button>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-u18ybd-MuiTableCell-root"
             >
               1
               /

--- a/src/__tests__/accessiblity/accessibility.test.tsx
+++ b/src/__tests__/accessiblity/accessibility.test.tsx
@@ -73,13 +73,13 @@ describe('Accessibility', () => {
 
   // TO DO: resolve 'Axe is already running' issue and re-enable test
   // https://github.com/mozilla/perfcompare/issues/222
-  // it('CompareResultsView should have no violations in dark mode', async () => {
-  //   const { testData } = getTestData();
-  //   const selectedRevisions = testData.slice(0, 4);
-  //   store.dispatch(setSelectedRevisions(selectedRevisions));
+  it('CompareResultsView should have no violations in dark mode', async () => {
+    const { testData } = getTestData();
+    const selectedRevisions = testData.slice(0, 4);
+    store.dispatch(setSelectedRevisions(selectedRevisions));
 
-  //   const { container } = renderWithRouter(<CompareResultsView mode="dark" />);
-  //   const results = await axe(container);
-  //   expect(results).toHaveNoViolations();
-  // });
+    const { container } = renderWithRouter(<CompareResultsView mode="dark" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
 });

--- a/src/__tests__/accessiblity/accessibility.test.tsx
+++ b/src/__tests__/accessiblity/accessibility.test.tsx
@@ -73,13 +73,13 @@ describe('Accessibility', () => {
 
   // TO DO: resolve 'Axe is already running' issue and re-enable test
   // https://github.com/mozilla/perfcompare/issues/222
-  it('CompareResultsView should have no violations in dark mode', async () => {
-    const { testData } = getTestData();
-    const selectedRevisions = testData.slice(0, 4);
-    store.dispatch(setSelectedRevisions(selectedRevisions));
+  // it('CompareResultsView should have no violations in dark mode', async () => {
+  //   const { testData } = getTestData();
+  //   const selectedRevisions = testData.slice(0, 4);
+  //   store.dispatch(setSelectedRevisions(selectedRevisions));
 
-    const { container } = renderWithRouter(<CompareResultsView mode="dark" />);
-    const results = await axe(container);
-    expect(results).toHaveNoViolations();
-  });
+  //   const { container } = renderWithRouter(<CompareResultsView mode="dark" />);
+  //   const results = await axe(container);
+  //   expect(results).toHaveNoViolations();
+  // });
 });

--- a/src/__tests__/accessiblity/accessibility.test.tsx
+++ b/src/__tests__/accessiblity/accessibility.test.tsx
@@ -73,6 +73,7 @@ describe('Accessibility', () => {
 
   // TO DO: resolve 'Axe is already running' issue and re-enable test
   // https://github.com/mozilla/perfcompare/issues/222
+  // eslint-disable-next-line jest/no-commented-out-tests
   // it('CompareResultsView should have no violations in dark mode', async () => {
   //   const { testData } = getTestData();
   //   const selectedRevisions = testData.slice(0, 4);

--- a/src/components/CompareResults/CompareResultsTableHead.tsx
+++ b/src/components/CompareResults/CompareResultsTableHead.tsx
@@ -20,7 +20,7 @@ const tableHead: CompareResultsTableHeader[] = [
     id: 'platform',
     label: 'Platform',
     key: 'platform',
-    align: 'left',
+    align: 'center',
   },
   {
     id: 'graph',
@@ -61,7 +61,7 @@ const tableHead: CompareResultsTableHeader[] = [
     id: 'confidence',
     label: 'Confidence',
     key: 'confidence',
-    align: 'left',
+    align: 'center',
   },
   {
     id: 'total-runs',

--- a/src/components/CompareResults/CompareResultsTableHead.tsx
+++ b/src/components/CompareResults/CompareResultsTableHead.tsx
@@ -20,7 +20,7 @@ const tableHead: CompareResultsTableHeader[] = [
     id: 'platform',
     label: 'Platform',
     key: 'platform',
-    align: 'center',
+    align: 'right',
   },
   {
     id: 'graph',
@@ -61,13 +61,13 @@ const tableHead: CompareResultsTableHeader[] = [
     id: 'confidence',
     label: 'Confidence',
     key: 'confidence',
-    align: 'center',
+    align: 'right',
   },
   {
     id: 'total-runs',
     label: 'Total Runs',
     key: 'run',
-    align: 'left',
+    align: 'center',
   },
 ];
 

--- a/src/components/CompareResults/CompareResultsTableHead.tsx
+++ b/src/components/CompareResults/CompareResultsTableHead.tsx
@@ -20,13 +20,13 @@ const tableHead: CompareResultsTableHeader[] = [
     id: 'platform',
     label: 'Platform',
     key: 'platform',
-    align: 'center',
+    align: 'left',
   },
   {
     id: 'graph',
     label: 'Graph',
     key: 'graph',
-    align: 'center',
+    align: 'left',
   },
   {
     id: 'test-name',
@@ -38,36 +38,36 @@ const tableHead: CompareResultsTableHeader[] = [
     id: 'base-value',
     label: 'Base',
     key: 'base',
-    align: 'center',
+    align: 'left',
   },
   {
     id: 'new-value',
     label: 'New',
     key: 'new',
-    align: 'center',
+    align: 'left',
   },
   {
     id: 'delta-percent',
     label: 'Delta',
     key: 'delta',
-    align: 'center',
+    align: 'left',
   },
   { id: 'status', 
     label: 'Status',
     key: 'status',
-    align: 'center',
+    align: 'left',
   },
   {
     id: 'confidence',
     label: 'Confidence',
     key: 'confidence',
-    align: 'center',
+    align: 'left',
   },
   {
     id: 'total-runs',
     label: 'Total Runs',
     key: 'run',
-    align: 'center',
+    align: 'left',
   },
 ];
 
@@ -132,7 +132,7 @@ const CompareResultsTableHead = () => {
             }
 
             return (
-              <TableCell key={index} align={align}>
+              <TableCell key={index} align={align} >
                 {label}
                 {filterKeys.includes(headerId) && (
                   <React.Fragment>

--- a/src/components/CompareResults/CompareResultsTableRow.tsx
+++ b/src/components/CompareResults/CompareResultsTableRow.tsx
@@ -13,13 +13,13 @@ import {
   setPlatformClassName,
   setConfidenceClassName,
 } from '../../utils/helpers';
-
 function CompareResultsTableRow(props: ResultsTableRowProps) {
   const { result, index, mode } = props;
   return (
     <TableRow key={index} hover data-testid={'table-row'}>
       <Tooltip title={result.platform}>
         <TableCell
+          sx={{ display: 'flex', height: '60px', width: '200px' }}
           className={`background-icon ${mode}-mode ${setPlatformClassName(
             result.platform,
           )}`}
@@ -50,6 +50,7 @@ function CompareResultsTableRow(props: ResultsTableRowProps) {
       </TableCell>
       {result.confidence_text ? (
         <TableCell
+          sx={{ display: 'flex', height: '60px', width: '200px' }}
           data-testid="confidence-icon"
           className={`background-icon ${setConfidenceClassName(
             result.confidence_text,
@@ -68,7 +69,9 @@ function CompareResultsTableRow(props: ResultsTableRowProps) {
         </TableCell>
       )}
 
-      <TableCell>
+      <TableCell
+        sx={{ width: '150px' }}
+      >
         {result.base_runs.length}/{result.new_runs.length}
       </TableCell>
     </TableRow>

--- a/src/components/CompareResults/CompareResultsTableRow.tsx
+++ b/src/components/CompareResults/CompareResultsTableRow.tsx
@@ -19,7 +19,7 @@ function CompareResultsTableRow(props: ResultsTableRowProps) {
     <TableRow key={index} hover data-testid={'table-row'}>
       <Tooltip title={result.platform}>
         <TableCell
-          sx={{ display: 'flex', height: '60px', width: '200px' }}
+          sx={{ display: 'flex', height: '60px', width: '160px' }}
           className={`background-icon ${mode}-mode ${setPlatformClassName(
             result.platform,
           )}`}
@@ -50,7 +50,7 @@ function CompareResultsTableRow(props: ResultsTableRowProps) {
       </TableCell>
       {result.confidence_text ? (
         <TableCell
-          sx={{ display: 'flex', height: '60px', width: '200px' }}
+          sx={{ display: 'flex', height: '60px', width: '160px' }}
           data-testid="confidence-icon"
           className={`background-icon ${setConfidenceClassName(
             result.confidence_text,
@@ -71,6 +71,8 @@ function CompareResultsTableRow(props: ResultsTableRowProps) {
 
       <TableCell
         sx={{ width: '150px' }}
+        id="total-runs"
+        align="center"
       >
         {result.base_runs.length}/{result.new_runs.length}
       </TableCell>

--- a/src/components/CompareResults/CompareResultsTableRow.tsx
+++ b/src/components/CompareResults/CompareResultsTableRow.tsx
@@ -50,7 +50,7 @@ function CompareResultsTableRow(props: ResultsTableRowProps) {
       </TableCell>
       {result.confidence_text ? (
         <TableCell
-          sx={{ display: 'flex', height: '60px', width: '160px' }}
+          sx={{ display: 'flex', height: '60px', width: '180px' }}
           data-testid="confidence-icon"
           className={`background-icon ${setConfidenceClassName(
             result.confidence_text,


### PR DESCRIPTION
This Pull Request (PR) addresses this issue 👉 https://github.com/mozilla/perfcompare/issues/327

## Issue Summary
The alignment of the table data is not consistent with the alignment of the table head in the 👉 CompareResultsTable.tsx file. 
The table data is properly aligned, but the table head is unaligned, causing a lack of consistency and readability in the results view.

### Steps to Reproduce the Issue:
1. Switch to the [staging branch], if you have not already done so
2. Go to the page where the [CompareResultsTable component] is displayed
2. Observe the alignment of the table head
3. Compare the alignment of the table data with the alignment of the table head
4. Note the lack of consistency in alignment

## Expected Result
The alignment of the table head should be consistent with the alignment of the table data, making the results view more readable and easier to understand.

## Changes

This Pull Request:
- Changes the alignment of some [TableHead](https://mui.com/material-ui/api/table-head/) from `align: 'center'` to `align: 'left'` in [CompareResultsTableHeader.tsx](https://github.com/mozilla/perfcompare/blob/staging/src/components/CompareResults/CompareResultsTableHead.tsx) file.
- Adds the following styling: 

   `sx={{ display: 'flex', height: '60px', width: '160px' }}` 

to the [TableCell](https://mui.com/material-ui/api/table-cell/) with `id: 'platform'` and `id: 'confidence'` in the [CompareResultsTableRow.tsx](https://github.com/mozilla/perfcompare/blob/staging/src/components/CompareResults/CompareResultsTableRow.tsx) file.

@Carla-Moz @kimberlythegeek