### PR TITLE
Fix close filter popper test

### DIFF
--- a/src/__tests__/CompareResults/CompareResultsTable.test.tsx
+++ b/src/__tests__/CompareResults/CompareResultsTable.test.tsx
@@ -462,8 +462,12 @@ describe('Compare Results Table', () => {
     await user.click(applyButtons[1]);
 
     popper = await waitFor(() => screen.getByRole('tooltip'));
-    
-    expect(popper).toHaveAttribute('style', '');
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(popper).not.toBeInTheDocument();
   });
 
   it('Should close filter popper by clicking outside of it', async () => {


### PR DESCRIPTION
This fix is needed to address the failing test when the popper is being closed.