### PR TITLE
Scroll-to-top button for results view  [🚀 Feature Request] #370

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Performance Comparison Tool
 
 ![screenshot](screenshot.png)
 
+[Outreachy contributor information](https://docs.google.com/document/d/1NLKAR5B2Rc80lRUYWzU2ISrQCQhR4VsW5Qkz1hxE5n8/edit?usp=sharing)
+
 ## Deployments
 
 PerfCompare is hosted on heroku, and is updated every time commits are pushed to the following branches:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ PerfCompare is hosted on heroku, and is updated every time commits are pushed to
 ## Setup
 
 ### Requirements
-
+- [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [nodejs](https://nodejs.org/en/download/)
 
 ### Installation

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # PerfCompare
 
+**[Outreachy contributor information](https://docs.google.com/document/d/1NLKAR5B2Rc80lRUYWzU2ISrQCQhR4VsW5Qkz1hxE5n8/edit?usp=sharing)**
+_____
+
 [![CircleCI](https://circleci.com/gh/mozilla/perfcompare/tree/master.svg?style=shield)](https://circleci.com/gh/mozilla/perfcompare/tree/master)
 [![codecov](https://codecov.io/gh/mozilla/perfcompare/branch/master/graph/badge.svg?token=XHP440JFDQ)](https://codecov.io/gh/mozilla/perfcompare)
 ![GitHub issues](https://img.shields.io/github/issues/mozilla/perfcompare)
@@ -8,8 +11,6 @@
 Performance Comparison Tool
 
 ![screenshot](screenshot.png)
-
-[Outreachy contributor information](https://docs.google.com/document/d/1NLKAR5B2Rc80lRUYWzU2ISrQCQhR4VsW5Qkz1hxE5n8/edit?usp=sharing)
 
 ## Deployments
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **[Outreachy contributor information](https://docs.google.com/document/d/1NLKAR5B2Rc80lRUYWzU2ISrQCQhR4VsW5Qkz1hxE5n8/edit?usp=sharing)**
 _____
 
-[![CircleCI](https://circleci.com/gh/mozilla/perfcompare/tree/master.svg?style=shield)](https://circleci.com/gh/mozilla/perfcompare/tree/master)
+[![CircleCI](https://circleci.com/gh/mozilla/perfcompare/tree/master.svg?style=shield)](https://circleci.com/gh/mozilla/perfcompare/tree/beta)
 [![codecov](https://codecov.io/gh/mozilla/perfcompare/branch/master/graph/badge.svg?token=XHP440JFDQ)](https://codecov.io/gh/mozilla/perfcompare)
 ![GitHub issues](https://img.shields.io/github/issues/mozilla/perfcompare)
 ![GitHub pull requests](https://img.shields.io/github/issues-pr/mozilla/perfcompare)

--- a/src/__tests__/CompareResults/CompareResultsView.test.tsx
+++ b/src/__tests__/CompareResults/CompareResultsView.test.tsx
@@ -1,8 +1,10 @@
+import { render, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { act } from 'react-dom/test-utils';
 
 import CompareResultsTable from '../../components/CompareResults/CompareResultsTable';
 import CompareResultsView from '../../components/CompareResults/CompareResultsView';
+import GoToTop from '../../components/Shared/GoToTop';
 import SelectedRevisionsTable from '../../components/Shared/SelectedRevisionsTable';
 import { setCompareResults } from '../../reducers/CompareResultsSlice';
 import { updateSearchResults } from '../../reducers/SearchSlice';
@@ -20,6 +22,20 @@ describe('CompareResults View', () => {
     renderWithRouter(<CompareResultsTable mode="light" />);
 
     expect(document.body).toMatchSnapshot();
+  });
+
+  it('Should scroll to the top when the scroll-to-top button is clicked', () => {
+    const scrollToSpy = jest.spyOn(window, 'scrollTo').mockImplementation(() => {});
+
+    const { getByTestId } = render(<GoToTop visible = {true} />);
+
+    fireEvent.click(getByTestId('scroll-to-top'));
+
+    // Verify if window.scrollTo was called with the right arguments.
+    expect(scrollToSpy).toHaveBeenCalledWith({ top: 0, left: 0, behavior: 'smooth' });
+       
+    // Clean up the mock
+    scrollToSpy.mockRestore();
   });
 
   it('should display SelectedRevisionsTable if there are selected revisions', async () => {
@@ -146,3 +162,5 @@ describe('CompareResultsTable', () => {
     expect(icons[3]).toHaveClass('unknown-confidence');
   });
 });
+
+

--- a/src/__tests__/CompareResults/CompareResultsView.test.tsx
+++ b/src/__tests__/CompareResults/CompareResultsView.test.tsx
@@ -25,17 +25,17 @@ describe('CompareResults View', () => {
   });
 
   it('Should scroll to the top when the scroll-to-top button is clicked', () => {
-    const scrollToSpy = jest.spyOn(window, 'scrollTo').mockImplementation(() => {});
+    const scrollToTopSpy = jest.spyOn(window, 'scrollTo').mockImplementation(() => {});
 
     const { getByTestId } = render(<GoToTop visible = {true} />);
 
     fireEvent.click(getByTestId('scroll-to-top'));
 
     // Verify if window.scrollTo was called with the right arguments.
-    expect(scrollToSpy).toHaveBeenCalledWith({ top: 0, left: 0, behavior: 'smooth' });
+    expect(scrollToTopSpy).toHaveBeenCalledWith({ top: 0, left: 0, behavior: 'smooth' });
        
     // Clean up the mock
-    scrollToSpy.mockRestore();
+    scrollToTopSpy.mockRestore();
   });
 
   it('should display SelectedRevisionsTable if there are selected revisions', async () => {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -10,6 +10,7 @@ import useProtocolTheme from '../theme/protocolTheme';
 import CompareResultsView from './CompareResults/CompareResultsView';
 import SearchView from './Search/SearchView';
 import FeedbackAlert from './Shared/FeedbackAlert';
+import GoToTop from './Shared/GoToTop';
 import SnackbarCloseButton from './Shared/SnackbarCloseButton';
 import ToggleDarkMode from './Shared/ToggleDarkModeButton';
 
@@ -17,6 +18,7 @@ function App() {
   const { mode, toggleColorMode, protocolTheme } = useProtocolTheme();
   return (
     <ThemeProvider theme={protocolTheme}>
+      
       <SnackbarProvider
         maxSnack={3}
         autoHideDuration={6000}
@@ -50,6 +52,7 @@ function App() {
           </Routes>
         </Router>
       </SnackbarProvider>
+      <GoToTop/>
     </ThemeProvider>
   );
 }

--- a/src/components/Shared/GoToTop.tsx
+++ b/src/components/Shared/GoToTop.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from 'react';
+
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import Button from '@mui/material/Button';
+import { styled } from '@mui/material/styles';
+import Tooltip from '@mui/material/Tooltip';
+
+
+const ButtonToTop = styled(Button)({
+    fontSize: '3rem',
+    scale: '60%',
+    height: '4rem',
+    width: '4rem',
+    color: '#fff',
+    backgroundColor: '#0065FF',
+    boxShadow: '5px 10px',
+    borderRadius: '50%',
+    position: 'fixed',
+    bottom: '0%',
+    right: '2%',
+    zIndex: '999',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    cursor: 'pointer',
+
+    '&:hover': {
+      backgroundColor: '#1F3DB0',
+      boxShadow: '2px 2px 5px rgba(0, 0, 0, 0.3)',  
+    },
+
+    '&:active': {
+      backgroundColor: '#2D0F65',
+      boxShadow: '2px 2px 5px rgba(0, 0, 0, 0.3)', 
+    },
+
+    '& .topBtn--icon': {
+      animation: 'gototop 1.2s linear infinite alternate-reverse',
+    },
+    '@keyframes gototop': {
+      '0%': {
+        transform: 'translateY(-0.5rem)',
+      },
+      '100%': {
+        transform: 'translateY(1rem)',
+
+      },
+    },
+    '@media (max-width: 500px)': {
+        right: '0',
+        left: '40%',
+    },
+  },
+
+);
+
+const StyledDiv = styled('div')({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  position: 'relative',
+});
+
+function GoToTop() {
+
+  const [isVisible, setIsVisible] = useState(false);
+
+  
+
+      const goToBtn = () => {
+          window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
+      };
+
+      const listenToScroll = () => {
+        const heightToHidden = 20;
+        const winScroll =
+          document.body.scrollTop || document.documentElement.scrollTop;
+    
+        if (winScroll > heightToHidden) {
+          setIsVisible(true);
+        } else {
+          setIsVisible(false);
+        }
+      };
+
+      useEffect(() => {
+        window.addEventListener('scroll', listenToScroll);
+        return () => window.removeEventListener('scroll', listenToScroll);
+      }, []);
+    return (
+
+<StyledDiv>
+        {isVisible && (
+          <Tooltip title="Scroll to top" placement="top">
+      <ButtonToTop className='topBtn' onClick={goToBtn}>
+        <ArrowUpwardIcon className="topBtn--icon"/>
+        </ButtonToTop>
+        </Tooltip>
+
+         )}
+      </StyledDiv>
+
+    );
+  }
+
+
+export default GoToTop;
+
+
+

--- a/src/components/Shared/GoToTop.tsx
+++ b/src/components/Shared/GoToTop.tsx
@@ -47,8 +47,8 @@ const ButtonToTop = styled(Button)({
       },
     },
     '@media (max-width: 500px)': {
-        right: '0',
-        left: '40%',
+        left: '50%',
+        transform: 'translateX(-50%)',
     },
   },
 
@@ -95,7 +95,7 @@ function GoToTop() {
 
 <StyledDiv>
         {isVisible && !isClicked && (
-          <Tooltip title="Scroll to top" placement="top">
+          <Tooltip title="Scroll To Top" placement="top">
       <ButtonToTop className='topBtn' onClick={btnHandler}>
         <ArrowUpwardIcon className="topBtn--icon"/>
         </ButtonToTop>

--- a/src/components/Shared/GoToTop.tsx
+++ b/src/components/Shared/GoToTop.tsx
@@ -61,10 +61,14 @@ const StyledDiv = styled('div')({
   position: 'relative',
 });
 
-function GoToTop() {
+type MyComponentProps = {
+  visible: boolean;
+};
 
-  const [isVisible, setIsVisible] = useState(false);
-  const [isClicked, setIsClicked] = useState(false);
+function GoToTop(props: MyComponentProps = { visible: false }) {
+
+  const [isVisible, setIsVisible] = useState( props.visible || false);
+  const [isClicked, setIsClicked] = useState( false);
 
   
 
@@ -96,7 +100,10 @@ function GoToTop() {
 <StyledDiv>
         {isVisible && !isClicked && (
           <Tooltip title="Scroll To Top" placement="top">
-      <ButtonToTop className='topBtn' onClick={btnHandler}>
+      <ButtonToTop
+      data-testid = 'scroll-to-top'
+      aria-label = 'scroll-to-top'
+      className='topBtn' onClick={btnHandler}>
         <ArrowUpwardIcon className="topBtn--icon"/>
         </ButtonToTop>
         </Tooltip>
@@ -106,6 +113,10 @@ function GoToTop() {
 
     );
   }
+
+  GoToTop.defaultProps = {
+    visible: false,
+  };
 
 
 export default GoToTop;

--- a/src/components/Shared/GoToTop.tsx
+++ b/src/components/Shared/GoToTop.tsx
@@ -64,10 +64,13 @@ const StyledDiv = styled('div')({
 function GoToTop() {
 
   const [isVisible, setIsVisible] = useState(false);
+  const [isClicked, setIsClicked] = useState(false);
 
   
 
-      const goToBtn = () => {
+      const btnHandler = () => {
+
+        setIsClicked(true);
           window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
       };
 
@@ -80,6 +83,7 @@ function GoToTop() {
           setIsVisible(true);
         } else {
           setIsVisible(false);
+          setIsClicked(false);
         }
       };
 
@@ -90,9 +94,9 @@ function GoToTop() {
     return (
 
 <StyledDiv>
-        {isVisible && (
+        {isVisible && !isClicked && (
           <Tooltip title="Scroll to top" placement="top">
-      <ButtonToTop className='topBtn' onClick={goToBtn}>
+      <ButtonToTop className='topBtn' onClick={btnHandler}>
         <ArrowUpwardIcon className="topBtn--icon"/>
         </ButtonToTop>
         </Tooltip>


### PR DESCRIPTION
## Description
In this pull Request a Feature Request has been implemented. A button that enables the users to scroll to the top of the page. 

Following files were Added/Changed
- `GoToTop.tsx` component in the`src/components/Shared` 
- Usage of `GoToTop.tsx' component in the `App.tsx`

## Related Issue
#370 [🚀 Feature Request] Implement an unobtrusive 'scroll to top' button for results view 


## Motivation and Context
* A user scrolling down the results view table becomes frustrated when they want to go back to the top for any number of reasons (they might want to filter results etc) for which they have to scroll all the way back to the top. It can become very cumbersome when there are 100s of results to scroll. For example: 

![scrollBefore](https://user-images.githubusercontent.com/60618877/224871868-ca5550e0-46a5-4bc9-a68a-3ce9b97fdcc1.gif)

### Colors Used: (choice for colors is attributed to @tobidosumu 🙌  )

`#0065FF`  Royal Blue for normal state

`#1F3DB0` Navy blue or dark blue for hover state

`#2D0F65` Dark purple for active state

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots :
Desktop             |  Mobile < (500px)
:-------------------------:|:-------------------------:
 ![scrollDesktop](https://user-images.githubusercontent.com/60618877/224870758-fd8e6105-20ca-4df8-9e2b-726b3959df1c.gif)  |  ![scrollMobile](https://user-images.githubusercontent.com/60618877/224870479-5b60f2c5-9a36-489d-8c58-c483fa718ead.gif)
