### PR TITLE
Fixed: Display Revision list onSelect from the dropDown #372

### DIFF
--- a/src/components/Search/SearchDropdown.tsx
+++ b/src/components/Search/SearchDropdown.tsx
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
+import type { Dispatch, SetStateAction } from 'react';
+
 import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
@@ -13,7 +15,7 @@ import { Fonts  } from '../../styles/Fonts';
 import { InputStyles } from '../../styles/Input';
 
 function SearchDropdown(props: SearchDropdownProps) {
-  const { repository, view } = props;
+  const { displayList,  repository, view } = props;
   const { handleChangeDropdown } = useHandleChangeDropdown();
   const size = view == 'compare-results' ? 'small' : undefined;
 
@@ -37,7 +39,7 @@ function SearchDropdown(props: SearchDropdownProps) {
             id={repoMap[key]}
             value={repoMap[key]}
             key={repoMap[key]}
-            onClick={(e) => void handleChangeDropdown(e)}
+            onClick={(e) => void handleChangeDropdown(e, displayList)}
           >
             {repoMap[key]}
           </MenuItem>
@@ -48,6 +50,7 @@ function SearchDropdown(props: SearchDropdownProps) {
 }
 
 interface SearchDropdownProps {
+  displayList: Dispatch<SetStateAction<boolean>>;
   repository: string;
   view: 'compare-results' | 'search';
 }

--- a/src/components/Search/SearchInput.tsx
+++ b/src/components/Search/SearchInput.tsx
@@ -17,6 +17,9 @@ function SearchInput(props: SearchInputProps) {
   const { setFocused, inputError, inputHelperText, view } = props;
   const { handleChangeSearch } = useHandleChangeSearch();
   const size = view == 'compare-results' ? 'small' : undefined;
+
+  // const setFocuseDispatch = () => setFocused(true);
+
   return (
     <FormControl variant="outlined" fullWidth>
       <TextField
@@ -27,7 +30,7 @@ function SearchInput(props: SearchInputProps) {
         id="search-revision-input"
         onFocus={() => setFocused(true)}
         sx={{ width: '100%' }}
-        onChange={(e) => handleChangeSearch(e)}
+         onChange={(e) => handleChangeSearch(e)}
         size={size}
         className={`${InputStyles.default} ${Fonts.BodyDefault}`}
         InputProps={{

--- a/src/components/Shared/RevisionSearch.tsx
+++ b/src/components/Shared/RevisionSearch.tsx
@@ -46,6 +46,7 @@ const styles = {
 
 function RevisionSearch(props: RevisionSearchProps) {
   const [focused, setFocused] = useState(false);
+  const [displayList, setDisplayList] = useState(false);
   const { prevRevision, searchResults, setPopoverIsOpen, view } = props;
 
   const dispatch = useAppDispatch();
@@ -67,9 +68,11 @@ function RevisionSearch(props: RevisionSearchProps) {
       )
     ) {
       setFocused(true);
+       setDisplayList(true);
       return;
     } else {
       setFocused(false);
+      setDisplayList(false);
       dispatch(clearCheckedRevisions());
     }
   };
@@ -77,6 +80,7 @@ function RevisionSearch(props: RevisionSearchProps) {
   const handleEscKeypress = (e: KeyboardEvent) => {
     if (e.key === 'Escape') {
       setFocused(false);
+      setDisplayList(false);
       dispatch(clearCheckedRevisions());
     }
   };
@@ -108,8 +112,25 @@ function RevisionSearch(props: RevisionSearchProps) {
         id='revision-search-dropdown'
         className='revision_search-dropdown'
       >
-        <SearchDropdown view={view} />
+        <SearchDropdown view={view} displayList={setDisplayList} />
       </Grid>
+
+      {displayList ? ( <Grid
+        item
+        xs={9}
+        className={`revision_search-input ${
+          matches ? 'revision_search-input--mobile' : ''
+        }`}
+      >
+        <SearchInput setFocused={setFocused} view={view} />
+        {searchResults.length > 0 && (
+          <SearchResultsList searchResults={searchResults} view={view} />
+        )}
+        {view == 'search' && searchResults.length > 0 && focused && (
+          <AddRevisionButton setFocused={setFocused} />
+        )}
+      </Grid>) : null}
+
       <Grid
         item
         xs={9}
@@ -118,7 +139,7 @@ function RevisionSearch(props: RevisionSearchProps) {
         }`}
       >
         <SearchInput setFocused={setFocused} view={view} />
-        {searchResults.length > 0 && focused && (
+        {searchResults.length > 0 && focused &&  (
           <SearchResultsList searchResults={searchResults} view={view} />
         )}
         {view == 'search' && searchResults.length > 0 && focused && (

--- a/src/hooks/useHandleChangeDropdown.ts
+++ b/src/hooks/useHandleChangeDropdown.ts
@@ -1,3 +1,5 @@
+import type { Dispatch, SetStateAction } from 'react';
+
 import { updateRepository } from '../reducers/SearchSlice';
 import { fetchRecentRevisions } from '../thunks/searchThunk';
 import type { Repository } from '../types/state';
@@ -6,15 +8,16 @@ import { useAppDispatch } from './app';
 function useHandleChangeDropdown() {
   const dispatch = useAppDispatch();
 
-  const handleChangeDropdown = async (e: React.MouseEvent<HTMLLIElement>) => {
+  const handleChangeDropdown = async (e: React.MouseEvent<HTMLLIElement>, displayList: Dispatch<SetStateAction<boolean>>) => {
     const repository = e.currentTarget.id;
 
     dispatch(updateRepository(repository as Repository['name']));
 
     // Fetch 10 most recent revisions when repository changes
     await dispatch(fetchRecentRevisions(repository as Repository['name']));
+    displayList(true);
   };
   return { handleChangeDropdown };
-}
+} 
 
 export default useHandleChangeDropdown;


### PR DESCRIPTION
This pull request  references issue #372  
 From the previous implementation the user has to focus on the text area before the list of revisions is rendered, which causes poor user interaction  since they have to perform two operations to to get a single result 

Solution: 
Using a displayList state to check if the revision is selected or not the setDisplayList is passed as a prop to the unHandleChangeDropdown and when the searchDropDown is called the displayList is set to true  and they triggers the display of the list hence the user need to select the appropriate revision from the drop down and the list is instantly rendered, and also the user can search specified revision