### PR TITLE
Implemented: Scroll-to-top Button for CompareResultsView #370

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
             class="MuiTableRow-root MuiTableRow-head css-1eza0l0-MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1l87mn7-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeSmall css-1gaeir8-MuiTableCell-root"
               scope="col"
             >
               Platform
@@ -101,7 +101,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
               Status
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1l87mn7-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeSmall css-1gaeir8-MuiTableCell-root"
               scope="col"
             >
               Confidence
@@ -128,7 +128,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
               </button>
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeSmall css-pmw8xp-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1l87mn7-MuiTableCell-root"
               scope="col"
             >
               Total Runs
@@ -144,7 +144,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
           >
             <td
               aria-label="macosx1015-64-shippable-qr"
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode osx css-8h992v-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode osx css-1ild2ts-MuiTableCell-root"
               data-mui-internal-clone-element="true"
             />
             <td
@@ -213,11 +213,12 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon low css-8h992v-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon low css-1ild2ts-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-u18ybd-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-ar89v3-MuiTableCell-root"
+              id="total-runs"
             >
               1
               /
@@ -230,7 +231,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
           >
             <td
               aria-label="linux1804-64-shippable-qr"
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode linux css-8h992v-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode linux css-1ild2ts-MuiTableCell-root"
               data-mui-internal-clone-element="true"
             />
             <td
@@ -299,11 +300,12 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon med css-8h992v-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon med css-1ild2ts-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-u18ybd-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-ar89v3-MuiTableCell-root"
+              id="total-runs"
             >
               1
               /
@@ -316,7 +318,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
           >
             <td
               aria-label="windows10-64-shippable-qr"
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode windows css-8h992v-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode windows css-1ild2ts-MuiTableCell-root"
               data-mui-internal-clone-element="true"
             />
             <td
@@ -374,11 +376,12 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon high css-8h992v-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon high css-1ild2ts-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-u18ybd-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-ar89v3-MuiTableCell-root"
+              id="total-runs"
             >
               1
               /
@@ -391,7 +394,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
           >
             <td
               aria-label="windows10-64-shippable-qr"
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode windows css-8h992v-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode windows css-1ild2ts-MuiTableCell-root"
               data-mui-internal-clone-element="true"
             />
             <td
@@ -476,7 +479,8 @@ exports[`CompareResults View Should match snapshot 1`] = `
               </button>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-u18ybd-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-ar89v3-MuiTableCell-root"
+              id="total-runs"
             >
               1
               /

--- a/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
               </button>
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1l87mn7-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeSmall css-pmw8xp-MuiTableCell-root"
               scope="col"
             >
               Graph
@@ -77,25 +77,25 @@ exports[`CompareResults View Should match snapshot 1`] = `
               </button>
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1l87mn7-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeSmall css-pmw8xp-MuiTableCell-root"
               scope="col"
             >
               Base
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1l87mn7-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeSmall css-pmw8xp-MuiTableCell-root"
               scope="col"
             >
               New
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1l87mn7-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeSmall css-pmw8xp-MuiTableCell-root"
               scope="col"
             >
               Delta
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1l87mn7-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeSmall css-pmw8xp-MuiTableCell-root"
               scope="col"
             >
               Status
@@ -128,7 +128,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
               </button>
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1l87mn7-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeSmall css-pmw8xp-MuiTableCell-root"
               scope="col"
             >
               Total Runs
@@ -144,7 +144,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
           >
             <td
               aria-label="macosx1015-64-shippable-qr"
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode osx css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode osx css-8h992v-MuiTableCell-root"
               data-mui-internal-clone-element="true"
             />
             <td
@@ -213,11 +213,11 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon low css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon low css-8h992v-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-u18ybd-MuiTableCell-root"
             >
               1
               /
@@ -230,7 +230,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
           >
             <td
               aria-label="linux1804-64-shippable-qr"
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode linux css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode linux css-8h992v-MuiTableCell-root"
               data-mui-internal-clone-element="true"
             />
             <td
@@ -299,11 +299,11 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon med css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon med css-8h992v-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-u18ybd-MuiTableCell-root"
             >
               1
               /
@@ -316,7 +316,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
           >
             <td
               aria-label="windows10-64-shippable-qr"
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode windows css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode windows css-8h992v-MuiTableCell-root"
               data-mui-internal-clone-element="true"
             />
             <td
@@ -374,11 +374,11 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon high css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon high css-8h992v-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-u18ybd-MuiTableCell-root"
             >
               1
               /
@@ -391,7 +391,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
           >
             <td
               aria-label="windows10-64-shippable-qr"
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode windows css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode windows css-8h992v-MuiTableCell-root"
               data-mui-internal-clone-element="true"
             />
             <td
@@ -476,7 +476,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
               </button>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-u18ybd-MuiTableCell-root"
             >
               1
               /

--- a/src/__tests__/accessiblity/accessibility.test.tsx
+++ b/src/__tests__/accessiblity/accessibility.test.tsx
@@ -73,13 +73,13 @@ describe('Accessibility', () => {
 
   // TO DO: resolve 'Axe is already running' issue and re-enable test
   // https://github.com/mozilla/perfcompare/issues/222
-  // it('CompareResultsView should have no violations in dark mode', async () => {
-  //   const { testData } = getTestData();
-  //   const selectedRevisions = testData.slice(0, 4);
-  //   store.dispatch(setSelectedRevisions(selectedRevisions));
+  it('CompareResultsView should have no violations in dark mode', async () => {
+    const { testData } = getTestData();
+    const selectedRevisions = testData.slice(0, 4);
+    store.dispatch(setSelectedRevisions(selectedRevisions));
 
-  //   const { container } = renderWithRouter(<CompareResultsView mode="dark" />);
-  //   const results = await axe(container);
-  //   expect(results).toHaveNoViolations();
-  // });
+    const { container } = renderWithRouter(<CompareResultsView mode="dark" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
 });

--- a/src/components/CompareResults/CompareResultsTableHead.tsx
+++ b/src/components/CompareResults/CompareResultsTableHead.tsx
@@ -20,7 +20,7 @@ const tableHead: CompareResultsTableHeader[] = [
     id: 'platform',
     label: 'Platform',
     key: 'platform',
-    align: 'left',
+    align: 'center',
   },
   {
     id: 'graph',
@@ -61,7 +61,7 @@ const tableHead: CompareResultsTableHeader[] = [
     id: 'confidence',
     label: 'Confidence',
     key: 'confidence',
-    align: 'left',
+    align: 'center',
   },
   {
     id: 'total-runs',

--- a/src/components/CompareResults/CompareResultsTableHead.tsx
+++ b/src/components/CompareResults/CompareResultsTableHead.tsx
@@ -20,7 +20,7 @@ const tableHead: CompareResultsTableHeader[] = [
     id: 'platform',
     label: 'Platform',
     key: 'platform',
-    align: 'center',
+    align: 'right',
   },
   {
     id: 'graph',
@@ -61,13 +61,13 @@ const tableHead: CompareResultsTableHeader[] = [
     id: 'confidence',
     label: 'Confidence',
     key: 'confidence',
-    align: 'center',
+    align: 'right',
   },
   {
     id: 'total-runs',
     label: 'Total Runs',
     key: 'run',
-    align: 'left',
+    align: 'center',
   },
 ];
 

--- a/src/components/CompareResults/CompareResultsTableHead.tsx
+++ b/src/components/CompareResults/CompareResultsTableHead.tsx
@@ -20,13 +20,13 @@ const tableHead: CompareResultsTableHeader[] = [
     id: 'platform',
     label: 'Platform',
     key: 'platform',
-    align: 'center',
+    align: 'left',
   },
   {
     id: 'graph',
     label: 'Graph',
     key: 'graph',
-    align: 'center',
+    align: 'left',
   },
   {
     id: 'test-name',
@@ -38,36 +38,36 @@ const tableHead: CompareResultsTableHeader[] = [
     id: 'base-value',
     label: 'Base',
     key: 'base',
-    align: 'center',
+    align: 'left',
   },
   {
     id: 'new-value',
     label: 'New',
     key: 'new',
-    align: 'center',
+    align: 'left',
   },
   {
     id: 'delta-percent',
     label: 'Delta',
     key: 'delta',
-    align: 'center',
+    align: 'left',
   },
   { id: 'status', 
     label: 'Status',
     key: 'status',
-    align: 'center',
+    align: 'left',
   },
   {
     id: 'confidence',
     label: 'Confidence',
     key: 'confidence',
-    align: 'center',
+    align: 'left',
   },
   {
     id: 'total-runs',
     label: 'Total Runs',
     key: 'run',
-    align: 'center',
+    align: 'left',
   },
 ];
 
@@ -132,7 +132,7 @@ const CompareResultsTableHead = () => {
             }
 
             return (
-              <TableCell key={index} align={align}>
+              <TableCell key={index} align={align} >
                 {label}
                 {filterKeys.includes(headerId) && (
                   <React.Fragment>

--- a/src/components/CompareResults/CompareResultsTableRow.tsx
+++ b/src/components/CompareResults/CompareResultsTableRow.tsx
@@ -13,13 +13,13 @@ import {
   setPlatformClassName,
   setConfidenceClassName,
 } from '../../utils/helpers';
-
 function CompareResultsTableRow(props: ResultsTableRowProps) {
   const { result, index, mode } = props;
   return (
     <TableRow key={index} hover data-testid={'table-row'}>
       <Tooltip title={result.platform}>
         <TableCell
+          sx={{ display: 'flex', height: '60px', width: '200px' }}
           className={`background-icon ${mode}-mode ${setPlatformClassName(
             result.platform,
           )}`}
@@ -50,6 +50,7 @@ function CompareResultsTableRow(props: ResultsTableRowProps) {
       </TableCell>
       {result.confidence_text ? (
         <TableCell
+          sx={{ display: 'flex', height: '60px', width: '200px' }}
           data-testid="confidence-icon"
           className={`background-icon ${setConfidenceClassName(
             result.confidence_text,
@@ -68,7 +69,9 @@ function CompareResultsTableRow(props: ResultsTableRowProps) {
         </TableCell>
       )}
 
-      <TableCell>
+      <TableCell
+        sx={{ width: '150px' }}
+      >
         {result.base_runs.length}/{result.new_runs.length}
       </TableCell>
     </TableRow>

--- a/src/components/CompareResults/CompareResultsTableRow.tsx
+++ b/src/components/CompareResults/CompareResultsTableRow.tsx
@@ -19,7 +19,7 @@ function CompareResultsTableRow(props: ResultsTableRowProps) {
     <TableRow key={index} hover data-testid={'table-row'}>
       <Tooltip title={result.platform}>
         <TableCell
-          sx={{ display: 'flex', height: '60px', width: '200px' }}
+          sx={{ display: 'flex', height: '60px', width: '160px' }}
           className={`background-icon ${mode}-mode ${setPlatformClassName(
             result.platform,
           )}`}
@@ -50,7 +50,7 @@ function CompareResultsTableRow(props: ResultsTableRowProps) {
       </TableCell>
       {result.confidence_text ? (
         <TableCell
-          sx={{ display: 'flex', height: '60px', width: '200px' }}
+          sx={{ display: 'flex', height: '60px', width: '160px' }}
           data-testid="confidence-icon"
           className={`background-icon ${setConfidenceClassName(
             result.confidence_text,
@@ -71,6 +71,8 @@ function CompareResultsTableRow(props: ResultsTableRowProps) {
 
       <TableCell
         sx={{ width: '150px' }}
+        id="total-runs"
+        align="center"
       >
         {result.base_runs.length}/{result.new_runs.length}
       </TableCell>

--- a/src/components/CompareResults/CompareResultsView.tsx
+++ b/src/components/CompareResults/CompareResultsView.tsx
@@ -11,6 +11,7 @@ import { Repository, Revision } from '../../types/state';
 import PerfCompareHeader from '../Shared/PerfCompareHeader';
 import SelectedRevisionsTable from '../Shared/SelectedRevisionsTable';
 import CompareResultsTable from './CompareResultsTable';
+import ScrollToTopButton from './ScrollToTopButton';
 
 function CompareResultsView(props: CompareResultsViewProps) {
   const { revisions, mode } = props;
@@ -40,6 +41,7 @@ function CompareResultsView(props: CompareResultsViewProps) {
           <CompareResultsTable mode={mode} />
         </Grid>
       </Grid>
+      <ScrollToTopButton></ScrollToTopButton>
     </Container>
   );
 }

--- a/src/components/CompareResults/ScrollToTopButton.tsx
+++ b/src/components/CompareResults/ScrollToTopButton.tsx
@@ -1,0 +1,59 @@
+import { useState, useEffect } from 'react';
+
+import KeyboardArrowUpRoundedIcon from '@mui/icons-material/KeyboardArrowUpRounded';
+import { IconButton, Tooltip } from '@mui/material';
+
+const ScrollToTopButton = () => {
+  const [showButton, setShowButton] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (window.pageYOffset > 300) {
+        setShowButton(true);
+      } else {
+        setShowButton(false);
+      }
+    };
+
+    window.addEventListener('scroll', handleScroll);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+
+  const handleButtonClick = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  return (
+    <Tooltip title="Scroll to top">
+        <IconButton
+            sx={{
+                display: showButton ? 'block' : 'none',
+                position: 'fixed',
+                bottom: '50px',
+                right: '22px',
+                width: '55px',
+                height: '55px',
+                borderRadius: '50%',
+                bgcolor: '#0065FF',
+                color: 'primary.contrastText',
+                boxShadow: 4,
+                '&:hover': {
+                    bgcolor: '#1F3DB0',
+                },
+                '&:active': {
+                    bgcolor: '#2D0F65',
+                },
+            }}
+            onClick={handleButtonClick}
+            aria-label="Scroll to top"
+        >
+            <KeyboardArrowUpRoundedIcon fontSize="large" />
+        </IconButton>
+    </Tooltip>
+  );
+};
+
+export default ScrollToTopButton;


### PR DESCRIPTION
### Description

This PR adds a 'scroll to top' button to the results view, which allows users to easily navigate back to the top of the page after scrolling down to view search results.

The button is only visible when the user has scrolled down a certain amount, and it is designed to be unobtrusive and fit in with the overall look and feel of the page.

**Note:**
Contrary to [my initial design](https://user-images.githubusercontent.com/60399800/224705521-7c3d3166-a72e-443c-bca5-d65ae872e7b5.png) and choice of colors for the tooltip, I have left it at its default state to ensure a consistent look and positioning with the other tooltips on the `CompareResultsView` page.

The button is circular and features an up caret icon. When hovered over, a tooltip appears with the text 'Scroll to top' to indicate its purpose.

To implement this feature, the following changes were made:

- Added a new component called `ScrollToTopButton` which renders the button and handles scrolling functionality.
- Added the `ScrollToTopButton` component to the `ResultsView` component.
- Styled the button using Material-UI's `IconButton` and `Tooltip` components.
- Added logic to show/hide the button based on the user's scroll position.

Overall, this feature should make it easier for users to navigate the search results view and provide a better user experience.

### Desktop View

![Scroll-to-top-button-implemented-desktop](https://user-images.githubusercontent.com/60399800/224999014-4008f425-a763-4497-a765-2c46d7fe279e.gif)

### Mobile View

![Scroll-to-top-button-implemented-mobile](https://user-images.githubusercontent.com/60399800/224999226-ebbd012e-aff3-4c6c-a59c-e21ade5ff771.gif)


Please let me know if you have any feedback or suggestions for improvements.

@esanuandra @kimberlythegeek 
