### PR TITLE
Fix 226/ clear checked revisions when selected revisons change

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Performance Comparison Tool
 
 ![screenshot](screenshot.png)
 
+[Outreachy contributor information](https://docs.google.com/document/d/1NLKAR5B2Rc80lRUYWzU2ISrQCQhR4VsW5Qkz1hxE5n8/edit?usp=sharing)
+
 ## Deployments
 
 PerfCompare is hosted on heroku, and is updated every time commits are pushed to the following branches:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ PerfCompare is hosted on heroku, and is updated every time commits are pushed to
 ## Setup
 
 ### Requirements
-
+- [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [nodejs](https://nodejs.org/en/download/)
 
 ### Installation

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # PerfCompare
 
+**[Outreachy contributor information](https://docs.google.com/document/d/1NLKAR5B2Rc80lRUYWzU2ISrQCQhR4VsW5Qkz1hxE5n8/edit?usp=sharing)**
+_____
+
 [![CircleCI](https://circleci.com/gh/mozilla/perfcompare/tree/master.svg?style=shield)](https://circleci.com/gh/mozilla/perfcompare/tree/master)
 [![codecov](https://codecov.io/gh/mozilla/perfcompare/branch/master/graph/badge.svg?token=XHP440JFDQ)](https://codecov.io/gh/mozilla/perfcompare)
 ![GitHub issues](https://img.shields.io/github/issues/mozilla/perfcompare)
@@ -8,8 +11,6 @@
 Performance Comparison Tool
 
 ![screenshot](screenshot.png)
-
-[Outreachy contributor information](https://docs.google.com/document/d/1NLKAR5B2Rc80lRUYWzU2ISrQCQhR4VsW5Qkz1hxE5n8/edit?usp=sharing)
 
 ## Deployments
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **[Outreachy contributor information](https://docs.google.com/document/d/1NLKAR5B2Rc80lRUYWzU2ISrQCQhR4VsW5Qkz1hxE5n8/edit?usp=sharing)**
 _____
 
-[![CircleCI](https://circleci.com/gh/mozilla/perfcompare/tree/master.svg?style=shield)](https://circleci.com/gh/mozilla/perfcompare/tree/master)
+[![CircleCI](https://circleci.com/gh/mozilla/perfcompare/tree/master.svg?style=shield)](https://circleci.com/gh/mozilla/perfcompare/tree/beta)
 [![codecov](https://codecov.io/gh/mozilla/perfcompare/branch/master/graph/badge.svg?token=XHP440JFDQ)](https://codecov.io/gh/mozilla/perfcompare)
 ![GitHub issues](https://img.shields.io/github/issues/mozilla/perfcompare)
 ![GitHub pull requests](https://img.shields.io/github/issues-pr/mozilla/perfcompare)

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "typescript": "^4.7.4",
         "webpack": "^5.74.0",
         "webpack-cli": "^4.10.0",
-        "webpack-dev-server": "^4.9.3",
+        "webpack-dev-server": "^4.11.1",
         "webpack-merge": "^5.8.0"
       }
     },
@@ -12904,9 +12904,9 @@
       "dev": true
     },
     "node_modules/selfsigned": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.0.1.tgz",
-      "integrity": "sha512-LmME957M1zOsUhG+67rAjKfiWFox3SBxE/yymatMZsAx+oMrJ0YQ8AToOnyCm7xbeg2ep37IHLxdu0o2MavQOQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.1.1.tgz",
+      "integrity": "sha512-GSL3aowiF7wa/WtSFwnUrludWFoNhftq8bUkH9pkzjpN2XSPOAYEgg6e0sS9s0rZwgJzJiQRPU18A6clnoW5wQ==",
       "dev": true,
       "dependencies": {
         "node-forge": "^1"
@@ -14521,9 +14521,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.9.3.tgz",
-      "integrity": "sha512-3qp/eoboZG5/6QgiZ3llN8TUzkSpYg1Ko9khWX1h40MIEUNS2mDoIa8aXsPfskER+GbTvs/IJZ1QTBBhhuetSw==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.11.1.tgz",
+      "integrity": "sha512-lILVz9tAUy1zGFwieuaQtYiadImb5M3d+H+L1zDYalYoDl0cksAB1UNyuE5MMWJrG6zR1tXkCP2fitl7yoUJiw==",
       "dev": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
@@ -14549,7 +14549,7 @@
         "p-retry": "^4.5.0",
         "rimraf": "^3.0.2",
         "schema-utils": "^4.0.0",
-        "selfsigned": "^2.0.1",
+        "selfsigned": "^2.1.1",
         "serve-index": "^1.9.1",
         "sockjs": "^0.3.24",
         "spdy": "^4.0.2",
@@ -24444,9 +24444,9 @@
       "dev": true
     },
     "selfsigned": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.0.1.tgz",
-      "integrity": "sha512-LmME957M1zOsUhG+67rAjKfiWFox3SBxE/yymatMZsAx+oMrJ0YQ8AToOnyCm7xbeg2ep37IHLxdu0o2MavQOQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.1.1.tgz",
+      "integrity": "sha512-GSL3aowiF7wa/WtSFwnUrludWFoNhftq8bUkH9pkzjpN2XSPOAYEgg6e0sS9s0rZwgJzJiQRPU18A6clnoW5wQ==",
       "dev": true,
       "requires": {
         "node-forge": "^1"
@@ -25638,9 +25638,9 @@
       }
     },
     "webpack-dev-server": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.9.3.tgz",
-      "integrity": "sha512-3qp/eoboZG5/6QgiZ3llN8TUzkSpYg1Ko9khWX1h40MIEUNS2mDoIa8aXsPfskER+GbTvs/IJZ1QTBBhhuetSw==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.11.1.tgz",
+      "integrity": "sha512-lILVz9tAUy1zGFwieuaQtYiadImb5M3d+H+L1zDYalYoDl0cksAB1UNyuE5MMWJrG6zR1tXkCP2fitl7yoUJiw==",
       "dev": true,
       "requires": {
         "@types/bonjour": "^3.5.9",
@@ -25666,7 +25666,7 @@
         "p-retry": "^4.5.0",
         "rimraf": "^3.0.2",
         "schema-utils": "^4.0.0",
-        "selfsigned": "^2.0.1",
+        "selfsigned": "^2.1.1",
         "serve-index": "^1.9.1",
         "sockjs": "^0.3.24",
         "spdy": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "typescript": "^4.7.4",
     "webpack": "^5.74.0",
     "webpack-cli": "^4.10.0",
-    "webpack-dev-server": "^4.9.3",
+    "webpack-dev-server": "^4.11.1",
     "webpack-merge": "^5.8.0"
   }
 }

--- a/src/__tests__/CompareResults/CompareResultsView.test.tsx
+++ b/src/__tests__/CompareResults/CompareResultsView.test.tsx
@@ -7,6 +7,8 @@ import SelectedRevisionsTable from '../../components/Shared/SelectedRevisionsTab
 import { setCompareResults } from '../../reducers/CompareResultsSlice';
 import { updateSearchResults } from '../../reducers/SearchSlice';
 import { setSelectedRevisions } from '../../reducers/SelectedRevisions';
+import { clearCheckedRevisions } from '../../reducers/CheckedRevisions';
+import { setCheckedRevisions } from '../../reducers/CheckedRevisions';
 import getTestData from '../utils/fixtures';
 import { renderWithRouter, store } from '../utils/setupTests';
 import { screen } from '../utils/test-utils';
@@ -145,4 +147,19 @@ describe('CompareResultsTable', () => {
     expect(icons[2]).toHaveClass('high');
     expect(icons[3]).toHaveClass('unknown-confidence');
   });
+  it('should clear checked revisions when selected revisions changes', async () => {
+    const { testData } = getTestData();
+    const selectedRevisions = testData.slice(0, 2);
+    store.dispatch(setSelectedRevisions(selectedRevisions));
+    store.dispatch(setCheckedRevisions(selectedRevisions));
+
+    const newRevisions = testData.slice(2,4);
+    store.dispatch(setSelectedRevisions(newRevisions));
+    store.dispatch(clearCheckedRevisions()); 
+
+    renderWithRouter(<SelectedRevisionsTable view="compare-results" />);
+
+    expect(store.getState().checkedRevisions.revisions).toEqual([]);
+  });
+
 });

--- a/src/__tests__/CompareResults/CompareResultsView.test.tsx
+++ b/src/__tests__/CompareResults/CompareResultsView.test.tsx
@@ -4,11 +4,11 @@ import { act } from 'react-dom/test-utils';
 import CompareResultsTable from '../../components/CompareResults/CompareResultsTable';
 import CompareResultsView from '../../components/CompareResults/CompareResultsView';
 import SelectedRevisionsTable from '../../components/Shared/SelectedRevisionsTable';
+import { clearCheckedRevisions } from '../../reducers/CheckedRevisions';
+import { setCheckedRevisions } from '../../reducers/CheckedRevisions';
 import { setCompareResults } from '../../reducers/CompareResultsSlice';
 import { updateSearchResults } from '../../reducers/SearchSlice';
 import { setSelectedRevisions } from '../../reducers/SelectedRevisions';
-import { clearCheckedRevisions } from '../../reducers/CheckedRevisions';
-import { setCheckedRevisions } from '../../reducers/CheckedRevisions';
 import getTestData from '../utils/fixtures';
 import { renderWithRouter, store } from '../utils/setupTests';
 import { screen } from '../utils/test-utils';
@@ -153,7 +153,7 @@ describe('CompareResultsTable', () => {
     store.dispatch(setSelectedRevisions(selectedRevisions));
     store.dispatch(setCheckedRevisions(selectedRevisions));
 
-    const newRevisions = testData.slice(2,4);
+    const newRevisions = testData.slice(2, 4);
     store.dispatch(setSelectedRevisions(newRevisions));
     store.dispatch(clearCheckedRevisions()); 
 

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -6,6 +6,10 @@ import { Framework, Platform } from '../types/types';
 export const treeherderBaseURL = 'https://treeherder.mozilla.org';
 
 export const maxRevisionsError = 'Maximum 4 revision(s).';
+
+export const differingProjectsWarning = 
+'The Projects being compared are from different repositories';
+
 export const featureNotSupportedError =
   'This feature is not supported yet. Please compare two revisions only.';
 

--- a/src/components/CompareResults/CompareResultsView.tsx
+++ b/src/components/CompareResults/CompareResultsView.tsx
@@ -11,7 +11,6 @@ import { Repository, Revision } from '../../types/state';
 import PerfCompareHeader from '../Shared/PerfCompareHeader';
 import SelectedRevisionsTable from '../Shared/SelectedRevisionsTable';
 import CompareResultsTable from './CompareResultsTable';
-import {clearCheckedRevisions} from '../../reducers/CheckedRevisions'
 
 function CompareResultsView(props: CompareResultsViewProps) {
   const { revisions, mode } = props;

--- a/src/components/CompareResults/CompareResultsView.tsx
+++ b/src/components/CompareResults/CompareResultsView.tsx
@@ -11,6 +11,7 @@ import { Repository, Revision } from '../../types/state';
 import PerfCompareHeader from '../Shared/PerfCompareHeader';
 import SelectedRevisionsTable from '../Shared/SelectedRevisionsTable';
 import CompareResultsTable from './CompareResultsTable';
+import {clearCheckedRevisions} from '../../reducers/CheckedRevisions'
 
 function CompareResultsView(props: CompareResultsViewProps) {
   const { revisions, mode } = props;

--- a/src/components/Search/SearchView.tsx
+++ b/src/components/Search/SearchView.tsx
@@ -6,7 +6,7 @@ import { useSnackbar, VariantType } from 'notistack';
 import { connect } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
-import { repoMap, featureNotSupportedError,differingProjectsWarning } from '../../common/constants';
+import { repoMap, featureNotSupportedError, differingProjectsWarning } from '../../common/constants';
 import type { RootState } from '../../common/store';
 import useFilterCompareResults from '../../hooks/useFilterCompareResults';
 import { Revision } from '../../types/state';
@@ -34,7 +34,7 @@ function SearchView(props: SearchViewProps) {
     const revs = selectedRevisions.map((rev) => rev.revision);
     const repos = selectedRevisions.map((rev) => repoMap[rev.repository_id]);
     
-    if(!repos.every(repo => repo === repos[0])){
+    if (!repos.every(repo => repo === repos[0])) {
       enqueueSnackbar(differingProjectsWarning as string, {
         variant: warningVariant,
     });

--- a/src/components/Search/SearchView.tsx
+++ b/src/components/Search/SearchView.tsx
@@ -6,7 +6,7 @@ import { useSnackbar, VariantType } from 'notistack';
 import { connect } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
-import { repoMap, featureNotSupportedError } from '../../common/constants';
+import { repoMap, featureNotSupportedError,differingProjectsWarning } from '../../common/constants';
 import type { RootState } from '../../common/store';
 import useFilterCompareResults from '../../hooks/useFilterCompareResults';
 import { Revision } from '../../types/state';
@@ -30,8 +30,16 @@ function SearchView(props: SearchViewProps) {
     });
     return;
     }
+
     const revs = selectedRevisions.map((rev) => rev.revision);
     const repos = selectedRevisions.map((rev) => repoMap[rev.repository_id]);
+    
+    if(!repos.every(repo => repo === repos[0])){
+      enqueueSnackbar(differingProjectsWarning as string, {
+        variant: warningVariant,
+    });
+    }
+
     clearFilters();
     navigate({
       pathname: '/compare-results',

--- a/src/hooks/useSelectRevision.ts
+++ b/src/hooks/useSelectRevision.ts
@@ -69,6 +69,7 @@ const useSelectRevision = () => {
       newSelected[newSelected.indexOf(prev)] = newRevision;
     }
     dispatch(setSelectedRevisions(newSelected));
+    dispatch(clearCheckedRevisions());
   };
 
   return { addSelectedRevisions, replaceSelectedRevision };


### PR DESCRIPTION
I dispatched the clearCheckedRevision reducer in useSelectedRevisons hook to clear checked revisions when selected revisions change
#226 