### PR TITLE
resolve all warnings that occur when running tests #383

### DIFF
--- a/src/__tests__/CompareResults/CompareResultsTable.test.tsx
+++ b/src/__tests__/CompareResults/CompareResultsTable.test.tsx
@@ -467,6 +467,8 @@ describe('Compare Results Table', () => {
 
   it('should reset to first table page when filtering is changed', async () => {
     // set results data
+    window.scrollTo = jest.fn();
+
     store.dispatch(setCompareResults(paginationTestCompareData));
 
     const activeFilters: ActiveFilters = {

--- a/src/__tests__/SelectedRevisionsTable.test.tsx
+++ b/src/__tests__/SelectedRevisionsTable.test.tsx
@@ -213,9 +213,14 @@ describe('Search View', () => {
     const { testData } = getTestData();
     const selectedRevisions = testData.slice(0, 4);
     store.dispatch(setSelectedRevisions(selectedRevisions));
-    renderWithRouter(<SearchView />);
+
+    await act(async () => {
+      renderWithRouter(<SearchView />);
+    });
+
     const rowEls = screen.getAllByRole('row');
     const bodyRows = rowEls.slice(1);
+
     bodyRows.forEach((row) => {
       expect(row).toHaveAttribute('draggable');
     });

--- a/src/__tests__/accessiblity/accessibility.test.tsx
+++ b/src/__tests__/accessiblity/accessibility.test.tsx
@@ -71,15 +71,13 @@ describe('Accessibility', () => {
     expect(results).toHaveNoViolations();
   });
 
-  // TO DO: resolve 'Axe is already running' issue and re-enable test
-  // https://github.com/mozilla/perfcompare/issues/222
-  // it('CompareResultsView should have no violations in dark mode', async () => {
-  //   const { testData } = getTestData();
-  //   const selectedRevisions = testData.slice(0, 4);
-  //   store.dispatch(setSelectedRevisions(selectedRevisions));
+  it('CompareResultsView should have no violations in dark mode', async () => {
+    const { testData } = getTestData();
+    const selectedRevisions = testData.slice(0, 4);
+    store.dispatch(setSelectedRevisions(selectedRevisions));
 
-  //   const { container } = renderWithRouter(<CompareResultsView mode="dark" />);
-  //   const results = await axe(container);
-  //   expect(results).toHaveNoViolations();
-  // });
+    const { container } = renderWithRouter(<CompareResultsView mode="dark" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
 });


### PR DESCRIPTION
**Related Issue**
#383

 **Additional Context**
- Fixed the `window.scrollTo` not implemented error in the `src/__tests__/CompareResults/CompareResultsTable.test.tsx `
- Fixed the `Component needs to be wrapped in act` error in the `src/__tests__/SelectedRevisionsTable.test.tsx ` file
- Uncommented out the test in `src/__tests__/accessiblity/accessibility.test.tsx` as the associated `axe` warning does not seem to be occuring


** Screenshots **

Original                         | Updated
:------------------------------: | :------------------------------------:
   ![Before-tests](https://user-images.githubusercontent.com/101508815/225416924-47e838ca-858f-4e69-b856-f35b7ee4db4b.gif) |  ![after-tests](https://user-images.githubusercontent.com/101508815/225417060-f72187e3-9943-4caf-ba84-50863d7d81b7.gif)
