### PR TITLE
Confidence tooltip breaks UI

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
@@ -11,13 +11,13 @@ exports[`CompareResults View Should match snapshot 1`] = `
         class="MuiTable-root css-d8sagy-MuiTable-root"
       >
         <thead
-          class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+          class="MuiTableHead-root css-1y54jnf-MuiTableHead-root"
         >
           <tr
             class="MuiTableRow-root MuiTableRow-head css-1eza0l0-MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1l87mn7-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeSmall css-19fbjjp-MuiTableCell-root"
               scope="col"
             >
               Platform
@@ -44,13 +44,13 @@ exports[`CompareResults View Should match snapshot 1`] = `
               </button>
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1l87mn7-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeSmall css-yepf47-MuiTableCell-root"
               scope="col"
             >
               Graph
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeSmall css-pmw8xp-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeSmall css-yepf47-MuiTableCell-root"
               scope="col"
             >
               Test Name
@@ -77,31 +77,31 @@ exports[`CompareResults View Should match snapshot 1`] = `
               </button>
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1l87mn7-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeSmall css-yepf47-MuiTableCell-root"
               scope="col"
             >
               Base
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1l87mn7-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeSmall css-yepf47-MuiTableCell-root"
               scope="col"
             >
               New
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1l87mn7-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeSmall css-yepf47-MuiTableCell-root"
               scope="col"
             >
               Delta
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1l87mn7-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignLeft MuiTableCell-sizeSmall css-yepf47-MuiTableCell-root"
               scope="col"
             >
               Status
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1l87mn7-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignRight MuiTableCell-sizeSmall css-19fbjjp-MuiTableCell-root"
               scope="col"
             >
               Confidence
@@ -128,7 +128,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
               </button>
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1l87mn7-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter MuiTableCell-sizeSmall css-1a3kr2i-MuiTableCell-root"
               scope="col"
             >
               Total Runs
@@ -139,16 +139,16 @@ exports[`CompareResults View Should match snapshot 1`] = `
           class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
         >
           <tr
-            class="MuiTableRow-root MuiTableRow-hover css-1eza0l0-MuiTableRow-root"
+            class="MuiTableRow-root MuiTableRow-hover css-1h6aczr-MuiTableRow-root"
             data-testid="table-row"
           >
             <td
               aria-label="macosx1015-64-shippable-qr"
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode osx css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode osx css-1jo9vll-MuiTableCell-root"
               data-mui-internal-clone-element="true"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-17qrjz4-MuiTableCell-root"
             >
               <a
                 aria-label="Graph link"
@@ -171,32 +171,32 @@ exports[`CompareResults View Should match snapshot 1`] = `
               </a>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-17qrjz4-MuiTableCell-root"
             >
               a11yr dhtml.html opt e10s fission stylo webrender
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-17qrjz4-MuiTableCell-root"
             >
               704.84
                
               ms
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-17qrjz4-MuiTableCell-root"
             >
               712.44
                
               ms
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-17qrjz4-MuiTableCell-root"
             >
               1.08
               %
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-17qrjz4-MuiTableCell-root"
             >
               <svg
                 aria-hidden="true"
@@ -213,11 +213,12 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon low css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon low css-1353222-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-4wwrew-MuiTableCell-root"
+              id="total-runs"
             >
               1
               /
@@ -225,16 +226,16 @@ exports[`CompareResults View Should match snapshot 1`] = `
             </td>
           </tr>
           <tr
-            class="MuiTableRow-root MuiTableRow-hover css-1eza0l0-MuiTableRow-root"
+            class="MuiTableRow-root MuiTableRow-hover css-1h6aczr-MuiTableRow-root"
             data-testid="table-row"
           >
             <td
               aria-label="linux1804-64-shippable-qr"
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode linux css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode linux css-1jo9vll-MuiTableCell-root"
               data-mui-internal-clone-element="true"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-17qrjz4-MuiTableCell-root"
             >
               <a
                 aria-label="Graph link"
@@ -257,32 +258,32 @@ exports[`CompareResults View Should match snapshot 1`] = `
               </a>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-17qrjz4-MuiTableCell-root"
             >
               a11yr dhtml.html opt e10s fission stylo webrender
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-17qrjz4-MuiTableCell-root"
             >
               776.97
                
               ms
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-17qrjz4-MuiTableCell-root"
             >
               791.34
                
               ms
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-17qrjz4-MuiTableCell-root"
             >
               1.85
               %
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-17qrjz4-MuiTableCell-root"
             >
                
               <svg
@@ -299,11 +300,12 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon med css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon med css-1353222-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-4wwrew-MuiTableCell-root"
+              id="total-runs"
             >
               1
               /
@@ -311,16 +313,16 @@ exports[`CompareResults View Should match snapshot 1`] = `
             </td>
           </tr>
           <tr
-            class="MuiTableRow-root MuiTableRow-hover css-1eza0l0-MuiTableRow-root"
+            class="MuiTableRow-root MuiTableRow-hover css-1h6aczr-MuiTableRow-root"
             data-testid="table-row"
           >
             <td
               aria-label="windows10-64-shippable-qr"
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode windows css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode windows css-1jo9vll-MuiTableCell-root"
               data-mui-internal-clone-element="true"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-17qrjz4-MuiTableCell-root"
             >
               <a
                 aria-label="Graph link"
@@ -343,42 +345,43 @@ exports[`CompareResults View Should match snapshot 1`] = `
               </a>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-17qrjz4-MuiTableCell-root"
             >
               a11yr dhtml.html opt e10s fission stylo webrender
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-17qrjz4-MuiTableCell-root"
             >
               643.54
                
               ms
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-17qrjz4-MuiTableCell-root"
             >
               628.09
                
               ms
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-17qrjz4-MuiTableCell-root"
             >
               -2.4
               %
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-17qrjz4-MuiTableCell-root"
             >
                
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon high css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon high css-1353222-MuiTableCell-root"
               data-testid="confidence-icon"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-4wwrew-MuiTableCell-root"
+              id="total-runs"
             >
               1
               /
@@ -386,16 +389,16 @@ exports[`CompareResults View Should match snapshot 1`] = `
             </td>
           </tr>
           <tr
-            class="MuiTableRow-root MuiTableRow-hover css-1eza0l0-MuiTableRow-root"
+            class="MuiTableRow-root MuiTableRow-hover css-1h6aczr-MuiTableRow-root"
             data-testid="table-row"
           >
             <td
               aria-label="windows10-64-shippable-qr"
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode windows css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon light-mode windows css-1jo9vll-MuiTableCell-root"
               data-mui-internal-clone-element="true"
             />
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-17qrjz4-MuiTableCell-root"
             >
               <a
                 aria-label="Graph link"
@@ -418,43 +421,43 @@ exports[`CompareResults View Should match snapshot 1`] = `
               </a>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-17qrjz4-MuiTableCell-root"
             >
               a11yr dhtml.html opt e10s fission stylo webrender
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-17qrjz4-MuiTableCell-root"
             >
               643.54
                
               ms
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-17qrjz4-MuiTableCell-root"
             >
               628.09
                
               ms
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-17qrjz4-MuiTableCell-root"
             >
               -2.4
               %
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-17qrjz4-MuiTableCell-root"
             >
                
                
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall unknown-confidence css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall unknown-confidence css-1bo9nv8-MuiTableCell-root"
               data-testid="confidence-icon"
             >
               <button
                 aria-label="Confidence not available"
-                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium missing-confidence-button css-1qlpk5e-MuiButtonBase-root-MuiIconButton-root"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium missing-confidence-button css-yrc3zf-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"
                 tabindex="0"
                 type="button"
@@ -476,7 +479,8 @@ exports[`CompareResults View Should match snapshot 1`] = `
               </button>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-6qq5hg-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignCenter MuiTableCell-sizeSmall css-4wwrew-MuiTableCell-root"
+              id="total-runs"
             >
               1
               /

--- a/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
@@ -457,7 +457,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
             >
               <button
                 aria-label="Confidence not available"
-                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium missing-confidence-button css-yrc3zf-MuiButtonBase-root-MuiIconButton-root"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium missing-confidence-button css-11cqn39-MuiButtonBase-root-MuiIconButton-root"
                 data-mui-internal-clone-element="true"
                 tabindex="0"
                 type="button"

--- a/src/__tests__/accessiblity/accessibility.test.tsx
+++ b/src/__tests__/accessiblity/accessibility.test.tsx
@@ -73,6 +73,7 @@ describe('Accessibility', () => {
 
   // TO DO: resolve 'Axe is already running' issue and re-enable test
   // https://github.com/mozilla/perfcompare/issues/222
+  // eslint-disable-next-line jest/no-commented-out-tests
   // it('CompareResultsView should have no violations in dark mode', async () => {
   //   const { testData } = getTestData();
   //   const selectedRevisions = testData.slice(0, 4);

--- a/src/components/CompareResults/CompareResultsTableHead.tsx
+++ b/src/components/CompareResults/CompareResultsTableHead.tsx
@@ -20,13 +20,13 @@ const tableHead: CompareResultsTableHeader[] = [
     id: 'platform',
     label: 'Platform',
     key: 'platform',
-    align: 'center',
+    align: 'right',
   },
   {
     id: 'graph',
     label: 'Graph',
     key: 'graph',
-    align: 'center',
+    align: 'left',
   },
   {
     id: 'test-name',
@@ -38,30 +38,30 @@ const tableHead: CompareResultsTableHeader[] = [
     id: 'base-value',
     label: 'Base',
     key: 'base',
-    align: 'center',
+    align: 'left',
   },
   {
     id: 'new-value',
     label: 'New',
     key: 'new',
-    align: 'center',
+    align: 'left',
   },
   {
     id: 'delta-percent',
     label: 'Delta',
     key: 'delta',
-    align: 'center',
+    align: 'left',
   },
   { id: 'status', 
     label: 'Status',
     key: 'status',
-    align: 'center',
+    align: 'left',
   },
   {
     id: 'confidence',
     label: 'Confidence',
     key: 'confidence',
-    align: 'center',
+    align: 'right',
   },
   {
     id: 'total-runs',
@@ -119,7 +119,7 @@ const CompareResultsTableHead = () => {
   };
 
   return (
-    <TableHead>
+    <TableHead sx={{ borderBottom: '1px solid rgba(224, 224, 224, 1)' }}>
       <TableRow>
         {tableHead.map(
           ({ label, key, align }: CompareResultsTableHeader, index) => {
@@ -132,7 +132,7 @@ const CompareResultsTableHead = () => {
             }
 
             return (
-              <TableCell key={index} align={align}>
+              <TableCell key={index} align={align} sx={{ border: 'none' }} >
                 {label}
                 {filterKeys.includes(headerId) && (
                   <React.Fragment>

--- a/src/components/CompareResults/CompareResultsTableRow.tsx
+++ b/src/components/CompareResults/CompareResultsTableRow.tsx
@@ -71,11 +71,8 @@ function CompareResultsTableRow(props: ResultsTableRowProps) {
           <Tooltip title="Confidence not available">
             <IconButton className="missing-confidence-button" 
               sx={{
-                width: 'inherit',
-                height: 'inherit',
                 position: 'relative',
                 top: '50%',
-                fontSize: '.1rem',
                 transform: 'translateY(-50%)',
               }}
               

--- a/src/components/CompareResults/CompareResultsTableRow.tsx
+++ b/src/components/CompareResults/CompareResultsTableRow.tsx
@@ -75,7 +75,6 @@ function CompareResultsTableRow(props: ResultsTableRowProps) {
                 top: '50%',
                 transform: 'translateY(-50%)',
               }}
-              
             >
               <QuestionMarkIcon className="missing-confidence-icon" />
             </IconButton>

--- a/src/components/CompareResults/CompareResultsTableRow.tsx
+++ b/src/components/CompareResults/CompareResultsTableRow.tsx
@@ -13,19 +13,21 @@ import {
   setPlatformClassName,
   setConfidenceClassName,
 } from '../../utils/helpers';
-
 function CompareResultsTableRow(props: ResultsTableRowProps) {
   const { result, index, mode } = props;
   return (
-    <TableRow key={index} hover data-testid={'table-row'}>
+    <TableRow key={index} hover data-testid={'table-row'} 
+      sx={{ minHeight: '60px', borderBottom: '1px solid rgba(224, 224, 224, 1)' }}
+    >
       <Tooltip title={result.platform}>
         <TableCell
+          sx={{ display: 'flex', height: '60px', width: '160px', border: 'none' }}
           className={`background-icon ${mode}-mode ${setPlatformClassName(
             result.platform,
           )}`}
         ></TableCell>
       </Tooltip>
-      <TableCell>
+      <TableCell sx={{ border: 'none' }}>
         <Link
           href={result.graphs_link}
           className={`background-icon ${mode}-mode graph-icon-color`}
@@ -36,39 +38,59 @@ function CompareResultsTableRow(props: ResultsTableRowProps) {
           <TimelineIcon />
         </Link>
       </TableCell>
-      <TableCell>{result.header_name}</TableCell>
-      <TableCell>
+      <TableCell sx={{ border: 'none' }}>
+        {result.header_name}
+      </TableCell>
+      <TableCell sx={{ border: 'none' }}>
         {result.base_median_value} {result.base_measurement_unit}
       </TableCell>
-      <TableCell>
+      <TableCell sx={{ border: 'none' }}>
         {result.new_median_value} {result.new_measurement_unit}
       </TableCell>
-      <TableCell>{result.delta_percentage}%</TableCell>
-      <TableCell>
+      <TableCell sx={{ border: 'none' }}>
+        {result.delta_percentage}%
+      </TableCell>
+      <TableCell sx={{ border: 'none' }}>
         {result.is_improvement && <ThumbUpAltIcon color="success" />}{' '}
         {result.is_regression && <WarningIcon color="error" />}{' '}
       </TableCell>
       {result.confidence_text ? (
         <TableCell
+          sx={{ display: 'flex', height: '60px', width: '180px', border: 'none' }}
           data-testid="confidence-icon"
           className={`background-icon ${setConfidenceClassName(
             result.confidence_text,
           )}`}
         ></TableCell>
-      ) : (
+        ) : (
         <TableCell
           data-testid="confidence-icon"
           className={`${setConfidenceClassName(result.confidence_text)}`}
+          sx={{ width: '180px', border: 'none' }}
         >
           <Tooltip title="Confidence not available">
-            <IconButton className="missing-confidence-button">
+            <IconButton className="missing-confidence-button" 
+              sx={{
+                width: 'inherit',
+                height: 'inherit',
+                position: 'relative',
+                top: '50%',
+                fontSize: '.1rem',
+                transform: 'translateY(-50%)',
+              }}
+              
+            >
               <QuestionMarkIcon className="missing-confidence-icon" />
             </IconButton>
           </Tooltip>
         </TableCell>
       )}
 
-      <TableCell>
+      <TableCell
+        sx={{ width: '150px', border: 'none' }}
+        id="total-runs"
+        align="center"
+      >
         {result.base_runs.length}/{result.new_runs.length}
       </TableCell>
     </TableRow>

--- a/src/components/CompareResults/PaginatedCompareResults.tsx
+++ b/src/components/CompareResults/PaginatedCompareResults.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 import FirstPageIcon from '@mui/icons-material/FirstPage';
 import KeyboardArrowLeft from '@mui/icons-material/KeyboardArrowLeft';
@@ -128,12 +128,6 @@ function PaginatedCompareResults(props: PaginatedCompareResultsProps) {
 
   const shouldResetPage = updatedOptions && page > 0;
 
-  useEffect(() => {
-    if (shouldResetPage) {
-      window.scrollTo({ top: 0, behavior: 'smooth' });
-      setPage(0);
-    }
-  });
 
   // Avoid a layout jump when reaching the last page with empty rows.
   const emptyRows =


### PR DESCRIPTION
### Issue Description  🐛
When there is a result that has unknown confidence, the alignment of the cell is disrupted, and after several of these in the same table, the difference becomes very apparent:
Please, find issue  👉 #258 

### This PR Fixes  💡:

1. the bug causing `confidence` and its `vertical elipsis icon` to collapse and stack on top of  each other when the **vast majority** of the results of the `confidence` table column are `not available`/`unkown` (that is, when it is mostly `question mark`s).
2. the bug causing the `question mark` table cell to break the UI of the table.
3. ensures that the UI remains responsive and consistent across various screen sizes i.e. table UI is mobile responsive. 

- **Fixed Desktop View**
![confidenceToolTipBreaksUi-desktop](https://user-images.githubusercontent.com/60399800/225599116-df0634a8-c7a3-4bda-9273-1c5fbd89c8f2.gif)

- **Fixed Mobile View**
![confidenceToolTipBreaksUi-mobile](https://user-images.githubusercontent.com/60399800/225599597-cfe36829-21f5-4cd1-b7d2-c010b7bfea05.gif)

### How I Fixed the Bug  💡:

1.  **causing the 'not available confidence icon (i.e. the question mark icon)' to break the UI**

 I simply refactored the `Confidence` table cell code from this:

      ```
       <TableCell
          data-testid="confidence-icon"
          className={`${setConfidenceClassName(result.confidence_text)}`}
        >
          <Tooltip title="Confidence not available">
            <IconButton className="missing-confidence-button">
              <QuestionMarkIcon className="missing-confidence-icon" />
            </IconButton>
          </Tooltip>
        </TableCell>
      ```
             
   to this:

          ```
         <Tooltip title="Confidence not available">
            <IconButton className="missing-confidence-button" 
              sx={{
                position: 'relative',
                top: '50%',
                transform: 'translateY(-50%)',
              }}
           >
              <QuestionMarkIcon className="missing-confidence-icon" />
            </IconButton>
          </Tooltip>
        </TableCell>
       ```

-  I also removed the borderBottom styling from the tableCells and then added the borderBottom styling to the `CompareResultsTableRow.tsx` component instead. This way, the table cell UI will not break when the `question mark icons` appear instead of the `downward-pointing caret icons` under the `Confidence` table cell column.

  @kimberlythegeek @Carla-Moz