### PR TITLE
new feat: render list on selecting from dropdown

### DIFF
--- a/src/__tests__/accessiblity/accessibility.test.tsx
+++ b/src/__tests__/accessiblity/accessibility.test.tsx
@@ -70,16 +70,4 @@ describe('Accessibility', () => {
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
-
-  // TO DO: resolve 'Axe is already running' issue and re-enable test
-  // https://github.com/mozilla/perfcompare/issues/222
-  // it('CompareResultsView should have no violations in dark mode', async () => {
-  //   const { testData } = getTestData();
-  //   const selectedRevisions = testData.slice(0, 4);
-  //   store.dispatch(setSelectedRevisions(selectedRevisions));
-
-  //   const { container } = renderWithRouter(<CompareResultsView mode="dark" />);
-  //   const results = await axe(container);
-  //   expect(results).toHaveNoViolations();
-  // });
 });

--- a/src/components/Search/SearchDropdown.tsx
+++ b/src/components/Search/SearchDropdown.tsx
@@ -1,20 +1,24 @@
+import React from 'react';
 import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
+
 import Select from '@mui/material/Select';
+
 import { connect } from 'react-redux';
+import type { Dispatch, SetStateAction } from 'react';
 
 import { repoMap } from '../../common/constants';
 import type { RootState } from '../../common/store';
 import useHandleChangeDropdown from '../../hooks/useHandleChangeDropdown';
 
 function SearchDropdown(props: SearchDropdownProps) {
-  const { repository, view } = props;
+  const { repository, view, showList } = props;
   const { handleChangeDropdown } = useHandleChangeDropdown();
   const size = view == 'compare-results' ? 'small' : undefined;
 
   return (
-    <FormControl sx={{ width: '100%' }} size={size}>
+    <FormControl sx={{ width: '100%', marginBottom: '8px' }} size={size}>
       <InputLabel id="select-repository">repository</InputLabel>
       <Select value={repository} labelId="select-repository" label="repository">
         {Object.keys(repoMap).map((key) => (
@@ -22,7 +26,7 @@ function SearchDropdown(props: SearchDropdownProps) {
             id={repoMap[key]}
             value={repoMap[key]}
             key={repoMap[key]}
-            onClick={(e) => void handleChangeDropdown(e)}
+            onClick={(e) => void handleChangeDropdown(e, showList)}
           >
             {repoMap[key]}
           </MenuItem>
@@ -35,6 +39,7 @@ function SearchDropdown(props: SearchDropdownProps) {
 interface SearchDropdownProps {
   repository: string;
   view: 'compare-results' | 'search';
+  showList: Dispatch<SetStateAction<boolean>>;
 }
 
 function mapStateToProps(state: RootState) {

--- a/src/components/Search/SearchDropdown.tsx
+++ b/src/components/Search/SearchDropdown.tsx
@@ -1,12 +1,10 @@
-import React from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+
 import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
-
 import Select from '@mui/material/Select';
-
 import { connect } from 'react-redux';
-import type { Dispatch, SetStateAction } from 'react';
 
 import { repoMap } from '../../common/constants';
 import type { RootState } from '../../common/store';

--- a/src/components/Search/SearchInput.tsx
+++ b/src/components/Search/SearchInput.tsx
@@ -1,8 +1,8 @@
 import type { Dispatch, SetStateAction } from 'react';
 
 import TextField from '@mui/material/TextField';
-import { connect } from 'react-redux';
 
+import { connect } from 'react-redux';
 import type { RootState } from '../../common/store';
 import useHandleChangeSearch from '../../hooks/useHandleChangeSearch';
 
@@ -15,6 +15,7 @@ function SearchInput(props: SearchInputProps) {
       error={inputError}
       helperText={inputHelperText}
       label="Search By Revision ID or Author Email"
+      placeholder="Search By Revision ID or Author Email"
       id="search-revision-input"
       onFocus={() => setFocused(true)}
       variant="outlined"

--- a/src/components/Search/SearchInput.tsx
+++ b/src/components/Search/SearchInput.tsx
@@ -1,8 +1,8 @@
 import type { Dispatch, SetStateAction } from 'react';
 
 import TextField from '@mui/material/TextField';
-
 import { connect } from 'react-redux';
+
 import type { RootState } from '../../common/store';
 import useHandleChangeSearch from '../../hooks/useHandleChangeSearch';
 

--- a/src/components/Shared/RevisionSearch.tsx
+++ b/src/components/Shared/RevisionSearch.tsx
@@ -38,7 +38,7 @@ function RevisionSearch(props: RevisionSearchProps) {
         #cancel-edit-revision-button *`,
       )
     ) {
-      setShowList(true);
+      setShowList(true); //change
       setFocused(true);
 
       return;

--- a/src/components/Shared/RevisionSearch.tsx
+++ b/src/components/Shared/RevisionSearch.tsx
@@ -18,6 +18,7 @@ import SearchResultsList from '../Search/SearchResultsList';
 
 function RevisionSearch(props: RevisionSearchProps) {
   const [focused, setFocused] = useState(false);
+  const [showList, setShowList] = useState(false);
   const { prevRevision, searchResults, setPopoverIsOpen, view } = props;
 
   const dispatch = useAppDispatch();
@@ -37,10 +38,13 @@ function RevisionSearch(props: RevisionSearchProps) {
         #cancel-edit-revision-button *`,
       )
     ) {
+      setShowList(true);
       setFocused(true);
+
       return;
     } else {
       setFocused(false);
+      setShowList(false);
       dispatch(clearCheckedRevisions());
     }
   };
@@ -48,6 +52,7 @@ function RevisionSearch(props: RevisionSearchProps) {
   const handleEscKeypress = (e: KeyboardEvent) => {
     if (e.key === 'Escape') {
       setFocused(false);
+      setShowList(false);
       dispatch(clearCheckedRevisions());
     }
   };
@@ -73,9 +78,15 @@ function RevisionSearch(props: RevisionSearchProps) {
       justifyContent="center"
       id="revision-search-container"
     >
-      <Grid item xs={2} id="revision-search-dropdown">
-        <SearchDropdown view={view} />
+      <Grid
+        item
+        xs={2}
+        id="revision-search-dropdown"
+        className="revision_search-dropdown"
+      >
+        <SearchDropdown view={view} showList={setShowList} />
       </Grid>
+
       <Grid item xs={9}>
         <SearchInput setFocused={setFocused} view={view} />
       </Grid>
@@ -84,7 +95,6 @@ function RevisionSearch(props: RevisionSearchProps) {
         {view == 'search' && <AddRevisionButton setFocused={setFocused} />}
         {view == 'compare-results' && setPopoverIsOpen && prevRevision && (
           <>
-            {/* TODO: add functionality for buttons and improve styling */}
             <Button
               className="edit-revision-button"
               id="replace-revision-button"
@@ -94,6 +104,7 @@ function RevisionSearch(props: RevisionSearchProps) {
             >
               <CheckIcon className="accept" />
             </Button>
+
             <Button
               className="edit-revision-button"
               id="cancel-edit-revision-button"
@@ -107,11 +118,11 @@ function RevisionSearch(props: RevisionSearchProps) {
         )}
       </Grid>
 
-      <Grid item xs={12}>
-        {searchResults.length > 0 && focused && (
+      {showList && (
+        <Grid xs={12} sx={{ width: '100%', marginBottom: '20px' }}>
           <SearchResultsList searchResults={searchResults} view={view} />
-        )}
-      </Grid>
+        </Grid>
+      )}
     </Grid>
   );
 }

--- a/src/components/Shared/RevisionSearch.tsx
+++ b/src/components/Shared/RevisionSearch.tsx
@@ -63,7 +63,7 @@ function RevisionSearch(props: RevisionSearchProps) {
       document.removeEventListener('mousedown', handleFocus);
     };
   }, []);
-
+  console.log(focused);
   useEffect(() => {
     document.addEventListener('keydown', handleEscKeypress);
     return () => {

--- a/src/hooks/useHandleChangeDropdown.ts
+++ b/src/hooks/useHandleChangeDropdown.ts
@@ -1,10 +1,9 @@
 import React from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+
 import { updateRepository } from '../reducers/SearchSlice';
 import { fetchRecentRevisions } from '../thunks/searchThunk';
 import type { Repository } from '../types/state';
-
-import type { Dispatch, SetStateAction } from 'react';
-
 import { useAppDispatch } from './app';
 
 function useHandleChangeDropdown() {

--- a/src/hooks/useHandleChangeDropdown.ts
+++ b/src/hooks/useHandleChangeDropdown.ts
@@ -1,18 +1,26 @@
+import React from 'react';
 import { updateRepository } from '../reducers/SearchSlice';
 import { fetchRecentRevisions } from '../thunks/searchThunk';
 import type { Repository } from '../types/state';
+
+import type { Dispatch, SetStateAction } from 'react';
+
 import { useAppDispatch } from './app';
 
 function useHandleChangeDropdown() {
   const dispatch = useAppDispatch();
 
-  const handleChangeDropdown = async (e: React.MouseEvent<HTMLLIElement>) => {
+  const handleChangeDropdown = async (
+    e: React.MouseEvent<HTMLLIElement>,
+    showList: Dispatch<SetStateAction<boolean>>,
+  ) => {
     const repository = e.currentTarget.id;
 
     dispatch(updateRepository(repository as Repository['name']));
 
     // Fetch 10 most recent revisions when repository changes
     await dispatch(fetchRecentRevisions(repository as Repository['name']));
+    showList(true);
   };
   return { handleChangeDropdown };
 }


### PR DESCRIPTION
Initially, the list item was only rendering after the user has focused on the search input which I think is a bad UX issue. So my solution is to render the list immediately the user chooses the repository name from the drop down rather than waiting until the search input is focused.