### PR TITLE
Fix contrast problem of Github repo link [Accessibility ⭐ ] #399

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -28,7 +28,7 @@ function App() {
         <Alert severity="warning" sx={{ textAlign: 'center' }}>
           This is an unstable <strong>pre-release</strong> version. Some
           features may not yet be supported. Please file any bugs on the{' '}
-          <Link href="https://github.com/mozilla/perfcompare/issues">
+          <Link color="secondary" href="https://github.com/mozilla/perfcompare/issues">
             Github Repo
           </Link>
           .


### PR DESCRIPTION
# Summary
This pull requests improves  accessibility of **Github Repo's** link by improving the contrast between the link and it's background .

### Related Issue ❗ 
### #399 

I used the MUI `Link`s prop `color` to change it's default color to `secondary` of the MUI theme. 

``  <Link color="secondary" href="https://github.com/mozilla/perfcompare/issues">
            Github Repo
          </Link>
          ``

### WAVE evalutaion: 

Before             |  This Pull Request
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/60618877/226107020-37f48731-83c2-4f63-be94-9465d3e6598e.png)  |  !![image](https://user-images.githubusercontent.com/60618877/226107079-7fb73fee-3b3d-4ae8-ad64-396e2d6cc4c8.png)

### Tools used
[WAVE accessibility auditing tool](https://wave.webaim.org/) 