### PR TITLE
Implement: Make Alert Banner Closable

### DIFF
--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -6,7 +6,7 @@ import { render } from './utils/setupTests';
 import { screen } from './utils/test-utils';
 
 describe('App', () => {
-  test('Should render search view on default route', async () => {
+  test('should render search view on default route', async () => {
     render(<App />);
     await act(async () => void jest.runOnlyPendingTimers());
 
@@ -15,7 +15,7 @@ describe('App', () => {
     ).toBeInTheDocument();
   });
 
-  test('Should switch between dark mode and light mode on toggle', async () => {
+  test('should switch between dark mode and light mode on toggle', async () => {
     // set delay to null to prevent test time-out due to useFakeTimers
     const user = userEvent.setup({ delay: null });
 
@@ -32,7 +32,7 @@ describe('App', () => {
     expect(screen.queryByTestId('Brightness4Icon')).toBeInTheDocument();
   });
 
-    test('Clicking on the info icon an alert should be displayed', async () => {
+  test('clicking on the info icon should display an alert', async () => {
     // set delay to null to prevent test time-out due to useFakeTimers
     const user = userEvent.setup({ delay: null });
 
@@ -43,7 +43,13 @@ describe('App', () => {
     });
 
     expect(() => screen.getByTestId('feedback-alert')).toThrow('Unable to find an element');
+
     await user.click(infoButton);
-    expect(screen.getByTestId('feedback-alert')).toBeInTheDocument();
+
+    expect(screen.getByText('This is an unstable pre-release version. Some features may not yet be supported. Please file any bugs on the Github Repo.')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'close' }));
+
+    expect(() => screen.getByTestId('feedback-alert')).toThrow('Unable to find an element');
   });
 });

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -6,7 +6,7 @@ import { render } from './utils/setupTests';
 import { screen } from './utils/test-utils';
 
 describe('App', () => {
-  test('should render search view on default route', async () => {
+  test('Should render search view on default route', async () => {
     render(<App />);
     await act(async () => void jest.runOnlyPendingTimers());
 
@@ -15,7 +15,7 @@ describe('App', () => {
     ).toBeInTheDocument();
   });
 
-  test('should switch between dark mode and light mode on toggle', async () => {
+  test('Should switch between dark mode and light mode on toggle', async () => {
     // set delay to null to prevent test time-out due to useFakeTimers
     const user = userEvent.setup({ delay: null });
 
@@ -32,7 +32,7 @@ describe('App', () => {
     expect(screen.queryByTestId('Brightness4Icon')).toBeInTheDocument();
   });
 
-  test('clicking on the info icon should display an alert', async () => {
+    test('Clicking on the info icon an alert should be displayed', async () => {
     // set delay to null to prevent test time-out due to useFakeTimers
     const user = userEvent.setup({ delay: null });
 
@@ -43,13 +43,7 @@ describe('App', () => {
     });
 
     expect(() => screen.getByTestId('feedback-alert')).toThrow('Unable to find an element');
-
     await user.click(infoButton);
-
-    expect(screen.getByText('This is an unstable pre-release version. Some features may not yet be supported. Please file any bugs on the Github Repo.')).toBeInTheDocument();
-
-    await user.click(screen.getByRole('button', { name: 'close' }));
-
-    expect(() => screen.getByTestId('feedback-alert')).toThrow('Unable to find an element');
+    expect(screen.getByTestId('feedback-alert')).toBeInTheDocument();
   });
 });

--- a/src/__tests__/accessiblity/accessibility.test.tsx
+++ b/src/__tests__/accessiblity/accessibility.test.tsx
@@ -73,6 +73,7 @@ describe('Accessibility', () => {
 
   // TO DO: resolve 'Axe is already running' issue and re-enable test
   // https://github.com/mozilla/perfcompare/issues/222
+  // eslint-disable-next-line jest/no-commented-out-tests
   // it('CompareResultsView should have no violations in dark mode', async () => {
   //   const { testData } = getTestData();
   //   const selectedRevisions = testData.slice(0, 4);

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -40,7 +40,21 @@ function App() {
                 aria-label="close"
                 color="inherit"
                 size="small"
-                sx={{ color: 'grey', border: '1px solid grey', borderRadius: '50px' }}
+                sx={{ 
+                  color: 'grey', 
+                  border: '2px solid grey', 
+                  borderRadius: '50px',
+                  '&:hover': {
+                    color: '#FFA116', 
+                    backgroundColor: '#ffffff',
+                    border: '2px solid #FFA116', 
+                  },
+                  '&:active': {
+                    color: '#000000', 
+                    backgroundColor: '#ffffff',
+                    border: '2px solid #000000', 
+                  },
+                }}
                 onClick={() => {
                   setAlertOpen(false);
                 }}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -33,12 +33,14 @@ function App() {
         <CssBaseline />
         {alertOpen && (
           <Alert
+          sx={{ paddingRight: '40px' }}
             severity="warning"
             action={
               <IconButton
                 aria-label="close"
                 color="inherit"
                 size="small"
+                sx={{ color: 'grey', border: '1px solid grey', borderRadius: '50px' }}
                 onClick={() => {
                   setAlertOpen(false);
                 }}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -33,37 +33,39 @@ function App() {
         <CssBaseline />
         {alertOpen && (
           <Alert
-          sx={{ paddingRight: '38px' }}
+            sx={{ paddingRight: '38px' }}
             severity="warning"
             action={
               <IconButton
                 aria-label="close"
                 color="inherit"
                 size="small"
-                sx={{ 
-                  color: 'grey', 
-                  border: '2px solid grey', 
+                sx={{
+                  color: 'grey',
+                  border: '2px solid grey',
                   borderRadius: '50px',
                   '&:hover': {
-                    color: '#FFA116', 
+                    color: '#FFA116',
                     backgroundColor: '#ffffff',
-                    border: '2px solid #FFA116', 
+                    border: '2px solid #FFA116',
                   },
                   '&:active': {
-                    color: '#000000', 
+                    color: '#000000',
                     backgroundColor: '#ffffff',
-                    border: '2px solid #000000', 
+                    border: '2px solid #000000',
                   },
                 }}
                 onClick={() => {
                   setAlertOpen(false);
                 }}
+                title="Close"
               >
                 <CloseIcon fontSize="inherit" />
               </IconButton>
             }
           >
-            This is an unstable <strong>pre-release</strong> version. Some features may not yet be supported. Please file any bugs on the{' '}
+            This is an unstable <strong>pre-release</strong> version. Some
+            features may not yet be supported. Please file any bugs on the{' '}
             <Link href="https://github.com/mozilla/perfcompare/issues">
               Github Repo
             </Link>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,6 +1,10 @@
+import { useState } from 'react';
+
+import CloseIcon from '@mui/icons-material/Close';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import CssBaseline from '@mui/material/CssBaseline';
+import IconButton from '@mui/material/IconButton';
 import Link from '@mui/material/Link';
 import { ThemeProvider } from '@mui/material/styles';
 import { SnackbarProvider } from 'notistack';
@@ -15,6 +19,8 @@ import ToggleDarkMode from './Shared/ToggleDarkModeButton';
 
 function App() {
   const { mode, toggleColorMode, protocolTheme } = useProtocolTheme();
+  const [alertOpen, setAlertOpen] = useState(true);
+
   return (
     <ThemeProvider theme={protocolTheme}>
       <SnackbarProvider
@@ -25,14 +31,29 @@ function App() {
         )}
       >
         <CssBaseline />
-        <Alert severity="warning" sx={{ textAlign: 'center' }}>
-          This is an unstable <strong>pre-release</strong> version. Some
-          features may not yet be supported. Please file any bugs on the{' '}
-          <Link href="https://github.com/mozilla/perfcompare/issues">
-            Github Repo
-          </Link>
-          .
-        </Alert>
+        {alertOpen && (
+          <Alert
+            severity="warning"
+            action={
+              <IconButton
+                aria-label="close"
+                color="inherit"
+                size="small"
+                onClick={() => {
+                  setAlertOpen(false);
+                }}
+              >
+                <CloseIcon fontSize="inherit" />
+              </IconButton>
+            }
+          >
+            This is an unstable <strong>pre-release</strong> version. Some features may not yet be supported. Please file any bugs on the{' '}
+            <Link href="https://github.com/mozilla/perfcompare/issues">
+              Github Repo
+            </Link>
+            .
+          </Alert>
+        )}
         <Box display="flex" justifyContent="flex-end" alignItems="flex-end">
           <FeedbackAlert />
           <ToggleDarkMode

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -33,7 +33,7 @@ function App() {
         <CssBaseline />
         {alertOpen && (
           <Alert
-          sx={{ paddingRight: '40px' }}
+          sx={{ paddingRight: '38px' }}
             severity="warning"
             action={
               <IconButton


### PR DESCRIPTION
**This PR addresses this issue #403.**

## Description
This PR adds the functionality to make the Alert banner closable by adding a close button that allows users to dismiss the banner after they have read its content. The close button is located on the top right corner of the banner, and when clicked, it dismisses the Alert banner.

## Changes Made
- Imported `CloseIcon` from `@mui/icons-material/Close`
- Added `action` prop to `Alert` component, which contains an `IconButton` that displays the `CloseIcon` and is clickable.
- Added an `onClick` event to the `IconButton` to close the `Alert` banner when clicked.
- Removed the `sx` prop from the `Alert` component.

## Testing
- Tested the functionality of the close button by clicking it and observing that the Alert banner disappears.
- Manually tested the app to ensure there were no unexpected side effects.

## Screenshots
Before:  
![Expected Behavior](https://user-images.githubusercontent.com/60399800/226140378-2a86b943-7b54-4a1c-a905-570d11860b8b.png)

After:  
![functional close button](https://user-images.githubusercontent.com/60399800/226140251-922d24b2-49b8-4a6c-af26-62827f4c8839.gif)

## Checklist
- [x] Added close button to the Alert banner.
- [x] Tested the close button to ensure its functionality.
- [x] Updated the documentation with the new feature and screenshots.
- [x] Manually tested the app to ensure no side effects.

@Carla-Moz @kimberlythegeek 