### PR TITLE
Add missing label for delete revision (X) button [Accessibility ♿]

### DIFF
--- a/src/components/Shared/SelectedRevisionsTableRow.tsx
+++ b/src/components/Shared/SelectedRevisionsTableRow.tsx
@@ -68,7 +68,7 @@ export function SelectedRevisionsTableRow(props: SelectedRevisionsRowProps) {
         {view == 'search' && (
           <IconButton
             id="close-button"
-            aria-label="delete-revision"
+            aria-label="delete revision"
             onClick={() => dispatch(deleteRevision(row.id))}
           >
             <Close />

--- a/src/components/Shared/SelectedRevisionsTableRow.tsx
+++ b/src/components/Shared/SelectedRevisionsTableRow.tsx
@@ -68,6 +68,7 @@ export function SelectedRevisionsTableRow(props: SelectedRevisionsRowProps) {
         {view == 'search' && (
           <IconButton
             id="close-button"
+            aria-label="delete-revision"
             onClick={() => dispatch(deleteRevision(row.id))}
           >
             <Close />


### PR DESCRIPTION
# Pull Request Summary

This pull requests improves the accessibility of delete revision(X) button in SelectedRevisionsTableRow component. The delete revision(X) button was missing `aria-label` as a consequence it only read `button` to the screen reader.

## Changes Made

I added `aria-label = "delete revision"` to <IconButton/> MUI component to ensure compliance with the accessibility standards.  

### Evaluation Tools 
[NVDA](https://www.nvaccess.org/download/)
[Wave Evaluation](https://wave.webaim.org/)

NVDA Speech Reader (BEFORE)             |  NVDA Speech Reader (AFTER)
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/60618877/226163458-c1ecc58d-aa25-431c-854f-0c37e942ff59.png) | ![image](https://user-images.githubusercontent.com/60618877/226163153-70904a94-c6df-471d-ae48-a5a96cfa21bc.png)


Wave Evaluation (BEFORE)             |  Wave Evaluation (AFTER)
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/60618877/226162767-8a84306f-4aa0-4387-9bde-5523b21f7ede.png)  |  ![image](https://user-images.githubusercontent.com/60618877/226162950-0dfde12c-d9c9-4ec6-8541-dd8362b529ee.png)