### PR TITLE
Add missing labels for Compare results, Selected Revisions Table [Accessibility ⭐ ]

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/CompareResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/CompareResultsTable.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Compare Results Table Should match snapshot 1`] = `
       class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiTableContainer-root css-w09ozj-MuiPaper-root-MuiTableContainer-root"
     >
       <table
-        aria-label="a dense table comparing performance results"
+        aria-label="performance results comparison"
         class="MuiTable-root css-d8sagy-MuiTable-root"
       />
     </div>

--- a/src/__tests__/CompareResults/__snapshots__/CompareResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/CompareResultsTable.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Compare Results Table Should match snapshot 1`] = `
       class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiTableContainer-root css-w09ozj-MuiPaper-root-MuiTableContainer-root"
     >
       <table
-        aria-label="a dense table"
+        aria-label="a dense table comparing performance results"
         class="MuiTable-root css-d8sagy-MuiTable-root"
       />
     </div>

--- a/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
       class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiTableContainer-root css-w09ozj-MuiPaper-root-MuiTableContainer-root"
     >
       <table
-        aria-label="a dense table"
+        aria-label="a dense table comparing performance results"
         class="MuiTable-root css-d8sagy-MuiTable-root"
       >
         <thead

--- a/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
       class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiTableContainer-root css-w09ozj-MuiPaper-root-MuiTableContainer-root"
     >
       <table
-        aria-label="a dense table comparing performance results"
+        aria-label="performance results comparison"
         class="MuiTable-root css-d8sagy-MuiTable-root"
       >
         <thead

--- a/src/__tests__/__snapshots__/SelectedRevisionsTable.test.tsx.snap
+++ b/src/__tests__/__snapshots__/SelectedRevisionsTable.test.tsx.snap
@@ -22,6 +22,7 @@ exports[`Search View should match snapshot 1`] = `
           class="MuiTableContainer-root layout css-10mitjm-MuiTableContainer-root"
         >
           <table
+            aria-label="table showing selected revisions"
             class="MuiTable-root search-selected-table css-qfwgoj-MuiTable-root"
           >
             <thead

--- a/src/__tests__/__snapshots__/SelectedRevisionsTable.test.tsx.snap
+++ b/src/__tests__/__snapshots__/SelectedRevisionsTable.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`Search View should match snapshot 1`] = `
           class="MuiTableContainer-root layout css-10mitjm-MuiTableContainer-root"
         >
           <table
-            aria-label="table showing selected revisions"
+            aria-label="selected revisions"
             class="MuiTable-root search-selected-table css-qfwgoj-MuiTable-root"
           >
             <thead

--- a/src/components/CompareResults/CompareResultsTable.tsx
+++ b/src/components/CompareResults/CompareResultsTable.tsx
@@ -27,7 +27,7 @@ function CompareResultsTable(props: CompareResultsProps) {
             <Table
               sx={{ minWidth: 650 }}
               size="small"
-              aria-label="a dense table comparing performance results"
+              aria-label="performance results comparison"
             >
               <PaginatedCompareResults mode={mode} />
             </Table>

--- a/src/components/CompareResults/CompareResultsTable.tsx
+++ b/src/components/CompareResults/CompareResultsTable.tsx
@@ -27,7 +27,7 @@ function CompareResultsTable(props: CompareResultsProps) {
             <Table
               sx={{ minWidth: 650 }}
               size="small"
-              aria-label="a dense table"
+              aria-label="a dense table comparing performance results"
             >
               <PaginatedCompareResults mode={mode} />
             </Table>

--- a/src/components/Shared/SelectedRevisionsTable.tsx
+++ b/src/components/Shared/SelectedRevisionsTable.tsx
@@ -37,7 +37,7 @@ export function SelectedRevisionsTable(props: SelectedRevisionsProps) {
   };
   return (
     <TableContainer className="layout">
-      <Table className={`${view}-selected-table`} size={size} aria-label="table showing selected revisions" >
+      <Table className={`${view}-selected-table`} size={size} aria-label="selected revisions" >
         <TableHead>
           <TableRow>
             <TableCell component="th" scope="row" />

--- a/src/components/Shared/SelectedRevisionsTable.tsx
+++ b/src/components/Shared/SelectedRevisionsTable.tsx
@@ -37,7 +37,7 @@ export function SelectedRevisionsTable(props: SelectedRevisionsProps) {
   };
   return (
     <TableContainer className="layout">
-      <Table className={`${view}-selected-table`} size={size}>
+      <Table className={`${view}-selected-table`} size={size} aria-label="table showing selected revisions" >
         <TableHead>
           <TableRow>
             <TableCell component="th" scope="row" />


### PR DESCRIPTION
# Pull Request Summary

This pull requests improves the accessibility of tables in `SelectedRevisionsTable.tsx` and `CompareResultsTable.tsx` component. Due to the missing labels, the screen reader does not announce the content of the table before hand that would allow a person to decide if they want to consume the data contained within the table.

## Changes Made

- Added `aria-label="table showing selected revisions"` to <Table/> MUI component in `SelectedRevisionsTable.tsx`
- changed `aria-label` attribute in `CompareResultsTable.tsx` from `aria-label="a dense table` to `aria-label="a dense table comparing performance results"` to ensure compliance with the accessibility standards.  

### Evaluation Tools 
[NVDA](https://www.nvaccess.org/download/)

NVDA Speech Reader (BEFORE)             |  NVDA Speech Reader (AFTER)
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/60618877/226186033-32f00392-b4ff-43b9-95db-46662449721f.png) | ![image](https://user-images.githubusercontent.com/60618877/226185627-09ee12b2-e1b0-4e40-8bd1-c20b83eb477f.png)
