### PR TITLE
Add aria-label to table filters [Accessibility ⭐ ]

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
@@ -22,6 +22,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
             >
               Platform
               <button
+                aria-label="filter by platform"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1qlpk5e-MuiButtonBase-root-MuiIconButton-root"
                 data-testid="platform-options-button"
                 tabindex="0"
@@ -55,6 +56,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
             >
               Test Name
               <button
+                aria-label="filter by test"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1qlpk5e-MuiButtonBase-root-MuiIconButton-root"
                 data-testid="test-options-button"
                 tabindex="0"
@@ -106,6 +108,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
             >
               Confidence
               <button
+                aria-label="filter by confidence"
                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1qlpk5e-MuiButtonBase-root-MuiIconButton-root"
                 data-testid="confidence-options-button"
                 tabindex="0"

--- a/src/components/CompareResults/CompareResultsTableHead.tsx
+++ b/src/components/CompareResults/CompareResultsTableHead.tsx
@@ -139,6 +139,7 @@ const CompareResultsTableHead = () => {
                     <IconButton
                       data-testid={`${headerId}-options-button`}
                       onClick={(e) => handleOpenOptions(e, headerId)}
+                      aria-label={`filter by ${headerId}`}
                     >
                       <MoreVertIcon />
                     </IconButton>


### PR DESCRIPTION
# Pull Request Summary

This pull requests improves the accessibility of filters in `CompareResultsTableHead.tsx` component. Due to the missing labels, the screen reader does not announce the filters before hand that would allow a person to apply the filters of their choice .

## Changes Made

- Added `aria-label={filter by ${headerId}}` to <IconButton/> MUI component in `CompareResultsTableHead.tsx` to ensure compliance with the accessibility standards.  

### Evaluation Tools 
[NVDA](https://www.nvaccess.org/download/)