### PR TITLE
Add dynamic label to icons in confidence column [Accessibility ⭐ ]

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
@@ -213,6 +213,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
+              aria-label="confidence low"
               class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon low css-6qq5hg-MuiTableCell-root"
               data-testid="confidence-icon"
             />
@@ -299,6 +300,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
+              aria-label="confidence med"
               class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon med css-6qq5hg-MuiTableCell-root"
               data-testid="confidence-icon"
             />
@@ -374,6 +376,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
+              aria-label="confidence high"
               class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall background-icon high css-6qq5hg-MuiTableCell-root"
               data-testid="confidence-icon"
             />
@@ -449,6 +452,7 @@ exports[`CompareResults View Should match snapshot 1`] = `
                
             </td>
             <td
+              aria-label="confidence not available"
               class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall unknown-confidence css-6qq5hg-MuiTableCell-root"
               data-testid="confidence-icon"
             >

--- a/src/components/CompareResults/CompareResultsTableRow.tsx
+++ b/src/components/CompareResults/CompareResultsTableRow.tsx
@@ -51,6 +51,7 @@ function CompareResultsTableRow(props: ResultsTableRowProps) {
       {result.confidence_text ? (
         <TableCell
           data-testid="confidence-icon"
+          aria-label={`confidence ${result.confidence_text}`}
           className={`background-icon ${setConfidenceClassName(
             result.confidence_text,
           )}`}
@@ -58,6 +59,7 @@ function CompareResultsTableRow(props: ResultsTableRowProps) {
       ) : (
         <TableCell
           data-testid="confidence-icon"
+          aria-label="confidence not available"
           className={`${setConfidenceClassName(result.confidence_text)}`}
         >
           <Tooltip title="Confidence not available">


### PR DESCRIPTION
# Pull Request Summary

This pull request improves the accessibility of confidence icons in `CompareResultsTableRow.tsx` component. Due to the missing labels, the screen reader does not translate the meaning of confidence icons to users with limited sight.

## Changes Made

- Added `aria-label={`confidence ${result.confidence_text}`}` to <TableCell/> MUI component in `CompareResultsTableRow.tsx` to ensure compliance with the accessibility standards.  
- Added `aria-label="confidence not available"` in the alternative condition of the ternary operator in `CompareResultsTableRow.tsx`

### Evaluation Tools 
[NVDA](https://www.nvaccess.org/download/)

![image](https://user-images.githubusercontent.com/60618877/227076322-39007e8b-032d-463d-9eeb-06293674e04d.png)

![image](https://user-images.githubusercontent.com/60618877/227075949-56012f13-6450-4bcc-ada9-cb392c46ea1d.png)
