### PR TITLE
Add captions for tables [Accessibility ⭐ ]

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/CompareResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/CompareResultsTable.test.tsx.snap
@@ -9,7 +9,11 @@ exports[`Compare Results Table Should match snapshot 1`] = `
       <table
         aria-label="a dense table"
         class="MuiTable-root css-d8sagy-MuiTable-root"
-      />
+      >
+        <caption>
+          Performance Results Comparison Table
+        </caption>
+      </table>
     </div>
   </div>
 </body>

--- a/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/CompareResultsView.test.tsx.snap
@@ -10,6 +10,9 @@ exports[`CompareResults View Should match snapshot 1`] = `
         aria-label="a dense table"
         class="MuiTable-root css-d8sagy-MuiTable-root"
       >
+        <caption>
+          Performance Results Comparison Table
+        </caption>
         <thead
           class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
         >

--- a/src/__tests__/__snapshots__/SelectedRevisionsTable.test.tsx.snap
+++ b/src/__tests__/__snapshots__/SelectedRevisionsTable.test.tsx.snap
@@ -24,6 +24,9 @@ exports[`Search View should match snapshot 1`] = `
           <table
             class="MuiTable-root search-selected-table css-qfwgoj-MuiTable-root"
           >
+            <caption>
+              Selected Revisions Table
+            </caption>
             <thead
               class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
             >

--- a/src/components/CompareResults/CompareResultsTable.tsx
+++ b/src/components/CompareResults/CompareResultsTable.tsx
@@ -29,6 +29,7 @@ function CompareResultsTable(props: CompareResultsProps) {
               size="small"
               aria-label="a dense table"
             >
+              <caption>Performance Results Comparison Table</caption>
               <PaginatedCompareResults mode={mode} />
             </Table>
           </TableContainer>

--- a/src/components/Shared/SelectedRevisionsTable.tsx
+++ b/src/components/Shared/SelectedRevisionsTable.tsx
@@ -37,7 +37,8 @@ export function SelectedRevisionsTable(props: SelectedRevisionsProps) {
   };
   return (
     <TableContainer className="layout">
-      <Table className={`${view}-selected-table`} size={size}>
+      <Table className={`${view}-selected-table`} size={size} >
+      <caption>Selected Revisions Table</caption>
         <TableHead>
           <TableRow>
             <TableCell component="th" scope="row" />


### PR DESCRIPTION
# Pull Request Summary

This pull request improves the accessibility of tables by adding the `<caption>` element in `CompareResultsTable.tsx` and `SelectedRevisionsTable.tsx` components. Due to the missing captions, its hard for screen readers to give hints of the table's content to the users without reading out the complete table which could have a lot of data.

## Changes Made

- Added a meaningful `<Caption>` for compare results table in `CompareResultsTable.tsx` to ensure compliance with the accessibility standards. 
- Added a meaningful `<Caption>` for the selected revisions table in `SelectedRevisionsTable.tsx` to ensure compliance with the accessibility standards. 


### Evaluation Tools 
[NVDA](https://www.nvaccess.org/download/)

![image](https://user-images.githubusercontent.com/60618877/227074251-c1ba574b-00ca-4d7b-af73-89fd0f0711c3.png)

![image](https://user-images.githubusercontent.com/60618877/227074443-de6b6102-e885-4553-a8aa-2f9abb2ba51c.png)

