### PR TITLE
[Fix Accessibility ♿] - Add Missing Tooltip for Add Revision Button

### DIFF
--- a/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
@@ -129,6 +129,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
           <button
             aria-label="add revisions"
             class="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root add-revision-button css-6yg5eq-MuiButtonBase-root-MuiButton-root"
+            data-mui-internal-clone-element="true"
             id="add-revision-button"
             tabindex="0"
             type="button"

--- a/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
@@ -129,6 +129,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
           <button
             aria-label="add revisions"
             class="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root add-revision-button css-6yg5eq-MuiButtonBase-root-MuiButton-root"
+            data-mui-internal-clone-element="true"
             id="add-revision-button"
             tabindex="0"
             type="button"
@@ -287,6 +288,7 @@ exports[`Search View should hide search results when clicking outside of search 
           <button
             aria-label="add revisions"
             class="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root add-revision-button css-6yg5eq-MuiButtonBase-root-MuiButton-root"
+            data-mui-internal-clone-element="true"
             id="add-revision-button"
             tabindex="0"
             type="button"
@@ -445,6 +447,7 @@ exports[`Search View should not hide search results when clicking search results
           <button
             aria-label="add revisions"
             class="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root add-revision-button css-6yg5eq-MuiButtonBase-root-MuiButton-root"
+            data-mui-internal-clone-element="true"
             id="add-revision-button"
             tabindex="0"
             type="button"

--- a/src/__tests__/Snackbar.test.tsx
+++ b/src/__tests__/Snackbar.test.tsx
@@ -10,6 +10,7 @@ import { renderWithRouter, render } from './utils/setupTests';
 import { screen } from './utils/test-utils';
 
 describe('Snackbar', () => {
+  jest.setTimeout(10000);
   it('should dismiss an alert when close button is clicked', async () => {
     const { testData } = getTestData();
     global.fetch = jest.fn(() =>

--- a/src/__tests__/__snapshots__/SelectedRevisionsTable.test.tsx.snap
+++ b/src/__tests__/__snapshots__/SelectedRevisionsTable.test.tsx.snap
@@ -550,6 +550,7 @@ exports[`Search View should match snapshot 1`] = `
           <button
             aria-label="add revisions"
             class="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root add-revision-button css-6yg5eq-MuiButtonBase-root-MuiButton-root"
+            data-mui-internal-clone-element="true"
             id="add-revision-button"
             tabindex="0"
             type="button"

--- a/src/__tests__/accessiblity/accessibility.test.tsx
+++ b/src/__tests__/accessiblity/accessibility.test.tsx
@@ -73,6 +73,7 @@ describe('Accessibility', () => {
 
   // TO DO: resolve 'Axe is already running' issue and re-enable test
   // https://github.com/mozilla/perfcompare/issues/222
+  // eslint-disable-next-line jest/no-commented-out-tests
   // it('CompareResultsView should have no violations in dark mode', async () => {
   //   const { testData } = getTestData();
   //   const selectedRevisions = testData.slice(0, 4);

--- a/src/components/Search/AddRevisionButton.tsx
+++ b/src/components/Search/AddRevisionButton.tsx
@@ -2,6 +2,7 @@ import type { Dispatch, SetStateAction } from 'react';
 
 import AddIcon from '@mui/icons-material/Add';
 import Button from '@mui/material/Button';
+import Tooltip from '@mui/material/Tooltip';
 
 import useSelectRevision from '../../hooks/useSelectRevision';
 
@@ -14,15 +15,17 @@ export default function AddRevisionButton(props: AddRevisionButtonProps) {
   };
 
   return (
-    <Button
-      id="add-revision-button"
-      variant="contained"
-      className="add-revision-button"
-      aria-label="add revisions"
-      onClick={handleAddRevision}
-    >
-      <AddIcon />
-    </Button>
+    <Tooltip title="Add Revisions">
+      <Button
+        id="add-revision-button"
+        variant="contained"
+        className="add-revision-button"
+        aria-label="add revisions"
+        onClick={handleAddRevision}
+      >
+        <AddIcon />
+      </Button>
+    </Tooltip>
   );
 }
 


### PR DESCRIPTION
**This is a PR to issue #423.**

### Description

This PR adds a tooltip to the Add Revision button to improve accessibility for users. The tooltip will be displayed when a user hovers over the button, providing additional context and information about the button's purpose.

### Changes Made

- Added title attribute to the Button component in the `AddRevisionButton.tsx` file

- The title attribute contains the string "Add Revisions", which will be displayed as the tooltip when the user hovers over the button.

### Testing

- Tested the changes locally to ensure that the tooltip appears correctly when hovering over the Add Revision button

- Tested with screen readers and other accessibility tools to ensure that the tooltip is read out and displayed correctly

- Confirmed that all existing tests pass with the addition of the title attribute

### Before

![addBtnTooltip-before](https://user-images.githubusercontent.com/60399800/226222667-c457a713-1eac-4e7b-8f39-8a5a9dba995e.gif)

### After

![addBtnTooltip](https://user-images.githubusercontent.com/60399800/226222692-f765b4bf-bd6e-47eb-98f8-02c6b144839f.gif)

@Carla-Moz @kimberlythegeek 