### PR TITLE
[Fix Accessibility ♿] - Add Missing Tooltip for Close Icon Button in SelectedRevisionsTableRow Component

### DIFF
--- a/src/__tests__/__snapshots__/SelectedRevisionsTable.test.tsx.snap
+++ b/src/__tests__/__snapshots__/SelectedRevisionsTable.test.tsx.snap
@@ -136,7 +136,9 @@ exports[`Search View should match snapshot 1`] = `
                   class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-pmplfi-MuiTableCell-root"
                 >
                   <button
+                    aria-label="Close revision"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1qlpk5e-MuiButtonBase-root-MuiIconButton-root"
+                    data-mui-internal-clone-element="true"
                     id="close-button"
                     tabindex="0"
                     type="button"
@@ -221,7 +223,9 @@ exports[`Search View should match snapshot 1`] = `
                   class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-pmplfi-MuiTableCell-root"
                 >
                   <button
+                    aria-label="Close revision"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1qlpk5e-MuiButtonBase-root-MuiIconButton-root"
+                    data-mui-internal-clone-element="true"
                     id="close-button"
                     tabindex="0"
                     type="button"
@@ -306,7 +310,9 @@ exports[`Search View should match snapshot 1`] = `
                   class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-pmplfi-MuiTableCell-root"
                 >
                   <button
+                    aria-label="Close revision"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1qlpk5e-MuiButtonBase-root-MuiIconButton-root"
+                    data-mui-internal-clone-element="true"
                     id="close-button"
                     tabindex="0"
                     type="button"
@@ -391,7 +397,9 @@ exports[`Search View should match snapshot 1`] = `
                   class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-pmplfi-MuiTableCell-root"
                 >
                   <button
+                    aria-label="Close revision"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1qlpk5e-MuiButtonBase-root-MuiIconButton-root"
+                    data-mui-internal-clone-element="true"
                     id="close-button"
                     tabindex="0"
                     type="button"

--- a/src/__tests__/accessiblity/accessibility.test.tsx
+++ b/src/__tests__/accessiblity/accessibility.test.tsx
@@ -73,6 +73,7 @@ describe('Accessibility', () => {
 
   // TO DO: resolve 'Axe is already running' issue and re-enable test
   // https://github.com/mozilla/perfcompare/issues/222
+  // eslint-disable-next-line jest/no-commented-out-tests
   // it('CompareResultsView should have no violations in dark mode', async () => {
   //   const { testData } = getTestData();
   //   const selectedRevisions = testData.slice(0, 4);

--- a/src/components/Shared/SelectedRevisionsTableRow.tsx
+++ b/src/components/Shared/SelectedRevisionsTableRow.tsx
@@ -4,6 +4,7 @@ import IconButton from '@mui/material/IconButton';
 import Link from '@mui/material/Link';
 import TableCell from '@mui/material/TableCell';
 import TableRow from '@mui/material/TableRow';
+import Tooltip from '@mui/material/Tooltip';
 
 import { repoMap } from '../../common/constants';
 import { useAppDispatch } from '../../hooks/app';
@@ -66,12 +67,14 @@ export function SelectedRevisionsTableRow(props: SelectedRevisionsRowProps) {
       <TableCell>{date}</TableCell>
       <TableCell>
         {view == 'search' && (
-          <IconButton
-            id="close-button"
-            onClick={() => dispatch(deleteRevision(row.id))}
-          >
-            <Close />
-          </IconButton>
+          <Tooltip title="Close revision" placement="bottom">
+            <IconButton
+              id="close-button"
+              onClick={() => dispatch(deleteRevision(row.id))}
+            >
+              <Close />
+            </IconButton>
+          </Tooltip>
         )}
         {view == 'compare-results' && (
           <EditRevisionButton index={index} item={row} />


### PR DESCRIPTION
**This is a PR to issue #427.**

### Description
This PR adds a tooltip to the **close** icon button in the `SelectedRevisionsTableRow` component to improve accessibility for users. The tooltip will be displayed when a user hovers over the button, providing additional context and information about the button's purpose.

### Changes Made
Added title attribute to the Button component in the `SelectedRevisionsTableRow.tsx` file.

The title attribute contains the string "Close revision", which will be displayed as the tooltip when the user hovers over the **close** icon button.

### Testing

- Tested the changes locally to ensure that the tooltip appears correctly when hovering over the `close` icon buttons
- Confirmed that all existing tests pass with the addition of the title attribute

### Before

![SelectedRevisionsCloseBtnAccessibility-before](https://user-images.githubusercontent.com/60399800/226302012-3f696671-6c0e-4a2d-a235-51c7d681673b.gif)

### After

![SelectedRevisionsCloseBtnAccessibility-after](https://user-images.githubusercontent.com/60399800/226302070-ee8e605e-2a9d-4b7c-8a95-599a01aa6076.gif)


@Carla-Moz @kimberlythegeek 