### PR TITLE
PCF-227 Results: Display single table component for revision test result

### DIFF
--- a/src/__tests__/CompareResults/beta/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/beta/__snapshots__/ResultsTable.test.tsx.snap
@@ -192,7 +192,7 @@ exports[`Results Table Should match snapshot 1`] = `
           </tr>
         </thead>
         <tbody
-          class="MuiTableBody-root fhjtom1 css-apqrd9-MuiTableBody-root"
+          class="MuiTableBody-root f15luk9e css-apqrd9-MuiTableBody-root"
         >
           <tr
             class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
@@ -201,7 +201,10 @@ exports[`Results Table Should match snapshot 1`] = `
               class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
               colspan="8"
             >
-              Metric 1 
+              <strong>
+                Metric 1
+              </strong>
+               
               <a
                 class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
                 href="#"
@@ -235,7 +238,7 @@ exports[`Results Table Should match snapshot 1`] = `
             </td>
           </tr>
           <tr
-            class="MuiTableRow-root f3tz1z9 css-1yt2i5z-MuiTableRow-root"
+            class="MuiTableRow-root revisionRow fju3wsp css-1yt2i5z-MuiTableRow-root"
           >
             <td
               class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium platform css-15mfgc5-MuiTableCell-root"
@@ -260,9 +263,13 @@ exports[`Results Table Should match snapshot 1`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium base-value css-15mfgc5-MuiTableCell-root"
             >
-              771.39ms
+              <div
+                class="base-container"
+              >
+                771.39ms
+              </div>
             </td>
             <td
               class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium comparison-sign css-15mfgc5-MuiTableCell-root"
@@ -290,54 +297,104 @@ exports[`Results Table Should match snapshot 1`] = `
               High
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium total-runs css-15mfgc5-MuiTableCell-root"
             >
-              B:23 N:27
+              <span>
+                B:
+              </span>
+              <strong>
+                23
+              </strong>
+               
+              <span>
+                N:
+              </span>
+              <strong>
+                27
+              </strong>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button graph css-15mfgc5-MuiTableCell-root"
             >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                data-testid="TimelineIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <div
+                class="graph-link-button-container"
               >
-                <path
-                  d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
-                />
-              </svg>
+                <button
+                  aria-label="graph link"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                    data-testid="TimelineIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button download css-15mfgc5-MuiTableCell-root"
             >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                data-testid="FileDownloadOutlinedIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <div
+                class="download-button-container"
               >
-                <path
-                  d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
-                />
-              </svg>
+                <button
+                  aria-label="download"
+                  class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                    data-testid="FileDownloadOutlinedIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
+                    />
+                  </svg>
+                </button>
+              </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button total-runs css-15mfgc5-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button retrigger-button css-15mfgc5-MuiTableCell-root"
             >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                data-testid="RefreshOutlinedIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <div
+                class="runs-button-container"
               >
-                <path
-                  d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
-                />
-              </svg>
+                <button
+                  aria-label="retrigger button"
+                  class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                    data-testid="RefreshOutlinedIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                    />
+                  </svg>
+                </button>
+              </div>
             </td>
             <td
               class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button expand-button css-15mfgc5-MuiTableCell-root"
@@ -370,7 +427,7 @@ exports[`Results Table Should match snapshot 1`] = `
             </td>
           </tr>
           <tr
-            class="MuiTableRow-root f3tz1z9 css-1yt2i5z-MuiTableRow-root"
+            class="MuiTableRow-root revisionRow fju3wsp css-1yt2i5z-MuiTableRow-root"
           >
             <td
               class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium platform css-15mfgc5-MuiTableCell-root"
@@ -395,9 +452,13 @@ exports[`Results Table Should match snapshot 1`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium base-value css-15mfgc5-MuiTableCell-root"
             >
-              771.39ms
+              <div
+                class="base-container"
+              >
+                771.39ms
+              </div>
             </td>
             <td
               class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium comparison-sign css-15mfgc5-MuiTableCell-root"
@@ -425,54 +486,104 @@ exports[`Results Table Should match snapshot 1`] = `
               High
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium total-runs css-15mfgc5-MuiTableCell-root"
             >
-              B:23 N:27
+              <span>
+                B:
+              </span>
+              <strong>
+                23
+              </strong>
+               
+              <span>
+                N:
+              </span>
+              <strong>
+                27
+              </strong>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button graph css-15mfgc5-MuiTableCell-root"
             >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                data-testid="TimelineIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <div
+                class="graph-link-button-container"
               >
-                <path
-                  d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
-                />
-              </svg>
+                <button
+                  aria-label="graph link"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                    data-testid="TimelineIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button download css-15mfgc5-MuiTableCell-root"
             >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                data-testid="FileDownloadOutlinedIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <div
+                class="download-button-container"
               >
-                <path
-                  d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
-                />
-              </svg>
+                <button
+                  aria-label="download"
+                  class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                    data-testid="FileDownloadOutlinedIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
+                    />
+                  </svg>
+                </button>
+              </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button total-runs css-15mfgc5-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button retrigger-button css-15mfgc5-MuiTableCell-root"
             >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                data-testid="RefreshOutlinedIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <div
+                class="runs-button-container"
               >
-                <path
-                  d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
-                />
-              </svg>
+                <button
+                  aria-label="retrigger button"
+                  class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                    data-testid="RefreshOutlinedIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                    />
+                  </svg>
+                </button>
+              </div>
             </td>
             <td
               class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button expand-button css-15mfgc5-MuiTableCell-root"
@@ -505,7 +616,7 @@ exports[`Results Table Should match snapshot 1`] = `
             </td>
           </tr>
           <tr
-            class="MuiTableRow-root f3tz1z9 css-1yt2i5z-MuiTableRow-root"
+            class="MuiTableRow-root revisionRow fju3wsp css-1yt2i5z-MuiTableRow-root"
           >
             <td
               class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium platform css-15mfgc5-MuiTableCell-root"
@@ -530,9 +641,13 @@ exports[`Results Table Should match snapshot 1`] = `
               </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium base-value css-15mfgc5-MuiTableCell-root"
             >
-              771.39ms
+              <div
+                class="base-container"
+              >
+                771.39ms
+              </div>
             </td>
             <td
               class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium comparison-sign css-15mfgc5-MuiTableCell-root"
@@ -560,54 +675,104 @@ exports[`Results Table Should match snapshot 1`] = `
               High
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium total-runs css-15mfgc5-MuiTableCell-root"
             >
-              B:23 N:27
+              <span>
+                B:
+              </span>
+              <strong>
+                23
+              </strong>
+               
+              <span>
+                N:
+              </span>
+              <strong>
+                27
+              </strong>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button graph css-15mfgc5-MuiTableCell-root"
             >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                data-testid="TimelineIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <div
+                class="graph-link-button-container"
               >
-                <path
-                  d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
-                />
-              </svg>
+                <button
+                  aria-label="graph link"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                    data-testid="TimelineIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button download css-15mfgc5-MuiTableCell-root"
             >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                data-testid="FileDownloadOutlinedIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <div
+                class="download-button-container"
               >
-                <path
-                  d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
-                />
-              </svg>
+                <button
+                  aria-label="download"
+                  class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                    data-testid="FileDownloadOutlinedIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
+                    />
+                  </svg>
+                </button>
+              </div>
             </td>
             <td
-              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button total-runs css-15mfgc5-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button retrigger-button css-15mfgc5-MuiTableCell-root"
             >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                data-testid="RefreshOutlinedIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <div
+                class="runs-button-container"
               >
-                <path
-                  d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
-                />
-              </svg>
+                <button
+                  aria-label="retrigger button"
+                  class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                    data-testid="RefreshOutlinedIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                    />
+                  </svg>
+                </button>
+              </div>
             </td>
             <td
               class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button expand-button css-15mfgc5-MuiTableCell-root"

--- a/src/__tests__/CompareResults/beta/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/beta/__snapshots__/ResultsTable.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Results Table Should match snapshot 1`] = `
   <div />
   <div>
     <div
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiTableContainer-root f1otqxop css-pfrgnn-MuiPaper-root-MuiTableContainer-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiTableContainer-root f1cqtmh css-1inhs6f-MuiPaper-root-MuiTableContainer-root"
       data-testid="results-table"
     >
       <table
@@ -16,7 +16,7 @@ exports[`Results Table Should match snapshot 1`] = `
           data-testid="table-header"
         >
           <tr
-            class="MuiTableRow-root MuiTableRow-head f1frk9dl css-1yt2i5z-MuiTableRow-root"
+            class="MuiTableRow-root MuiTableRow-head f1ctvkx8 css-1yt2i5z-MuiTableRow-root"
           >
             <th
               class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium platform-header css-hwty3m-MuiTableCell-root"
@@ -192,7 +192,7 @@ exports[`Results Table Should match snapshot 1`] = `
           </tr>
         </thead>
         <tbody
-          class="MuiTableBody-root f15luk9e css-apqrd9-MuiTableBody-root"
+          class="MuiTableBody-root f5w6em2 css-apqrd9-MuiTableBody-root"
         >
           <tr
             class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
@@ -238,7 +238,7 @@ exports[`Results Table Should match snapshot 1`] = `
             </td>
           </tr>
           <tr
-            class="MuiTableRow-root revisionRow fju3wsp css-1yt2i5z-MuiTableRow-root"
+            class="MuiTableRow-root revisionRow f131cxob css-1yt2i5z-MuiTableRow-root"
           >
             <td
               class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium platform css-15mfgc5-MuiTableCell-root"
@@ -427,7 +427,7 @@ exports[`Results Table Should match snapshot 1`] = `
             </td>
           </tr>
           <tr
-            class="MuiTableRow-root revisionRow fju3wsp css-1yt2i5z-MuiTableRow-root"
+            class="MuiTableRow-root revisionRow f131cxob css-1yt2i5z-MuiTableRow-root"
           >
             <td
               class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium platform css-15mfgc5-MuiTableCell-root"
@@ -616,7 +616,7 @@ exports[`Results Table Should match snapshot 1`] = `
             </td>
           </tr>
           <tr
-            class="MuiTableRow-root revisionRow fju3wsp css-1yt2i5z-MuiTableRow-root"
+            class="MuiTableRow-root revisionRow f131cxob css-1yt2i5z-MuiTableRow-root"
           >
             <td
               class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium platform css-15mfgc5-MuiTableCell-root"

--- a/src/__tests__/CompareResults/beta/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/beta/__snapshots__/ResultsTable.test.tsx.snap
@@ -9,7 +9,6 @@ exports[`Results Table Should match snapshot 1`] = `
       data-testid="results-table"
     >
       <table
-        aria-label="collapsible table"
         class="MuiTable-root css-yso468-MuiTable-root"
       >
         <thead
@@ -17,14 +16,14 @@ exports[`Results Table Should match snapshot 1`] = `
           data-testid="table-header"
         >
           <tr
-            class="MuiTableRow-root MuiTableRow-head f81wnp2 css-1yt2i5z-MuiTableRow-root"
+            class="MuiTableRow-root MuiTableRow-head f1frk9dl css-1yt2i5z-MuiTableRow-root"
           >
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium platform-header css-hwty3m-MuiTableCell-root"
               scope="col"
             >
               <div
-                class="f1076rq5"
+                class="fzi2oph"
               >
                 <svg
                   aria-hidden="true"
@@ -54,7 +53,7 @@ exports[`Results Table Should match snapshot 1`] = `
               </div>
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium base-header css-hwty3m-MuiTableCell-root"
               scope="col"
             >
               <div
@@ -66,7 +65,17 @@ exports[`Results Table Should match snapshot 1`] = `
               </div>
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium comparisonSign-header css-hwty3m-MuiTableCell-root"
+              scope="col"
+            >
+              <div
+                class=""
+              >
+                <span />
+              </div>
+            </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium new-header css-hwty3m-MuiTableCell-root"
               scope="col"
             >
               <div
@@ -78,11 +87,11 @@ exports[`Results Table Should match snapshot 1`] = `
               </div>
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium status-header css-hwty3m-MuiTableCell-root"
               scope="col"
             >
               <div
-                class="f1076rq5"
+                class="fzi2oph"
               >
                 <svg
                   aria-hidden="true"
@@ -112,7 +121,7 @@ exports[`Results Table Should match snapshot 1`] = `
               </div>
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium delta-header css-hwty3m-MuiTableCell-root"
               scope="col"
             >
               <div
@@ -124,11 +133,11 @@ exports[`Results Table Should match snapshot 1`] = `
               </div>
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium confidence-header css-hwty3m-MuiTableCell-root"
               scope="col"
             >
               <div
-                class="f1076rq5"
+                class="fzi2oph"
               >
                 <svg
                   aria-hidden="true"
@@ -158,7 +167,7 @@ exports[`Results Table Should match snapshot 1`] = `
               </div>
             </th>
             <th
-              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium runs-header css-hwty3m-MuiTableCell-root"
               scope="col"
             >
               <div
@@ -169,8 +178,468 @@ exports[`Results Table Should match snapshot 1`] = `
                 </span>
               </div>
             </th>
+            <th
+              class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium empty-header css-hwty3m-MuiTableCell-root"
+              colspan="4"
+              scope="col"
+            >
+              <div
+                class=""
+              >
+                <span />
+              </div>
+            </th>
           </tr>
         </thead>
+        <tbody
+          class="MuiTableBody-root fhjtom1 css-apqrd9-MuiTableBody-root"
+        >
+          <tr
+            class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+              colspan="8"
+            >
+              Metric 1 
+              <a
+                class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
+                href="#"
+              >
+                0f9ef9ff3ea
+              </a>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+              colspan="4"
+            >
+              <div
+                class="f1oxa67k"
+              >
+                <span
+                  class="f1rpr1m5"
+                >
+                  e10s
+                </span>
+                <span
+                  class="f1rpr1m5"
+                >
+                  stylo
+                </span>
+                <span
+                  class="f1rpr1m5"
+                >
+                  fission
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="MuiTableRow-root f3tz1z9 css-1yt2i5z-MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium platform css-15mfgc5-MuiTableCell-root"
+            >
+              <div
+                class="platform-container"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                  data-testid="AppleIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"
+                  />
+                </svg>
+                <span>
+                  Apple
+                </span>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+            >
+              771.39ms
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium comparison-sign css-15mfgc5-MuiTableCell-root"
+            >
+              &gt;
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium new-value css-15mfgc5-MuiTableCell-root"
+            >
+              771.39ms
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium status css-15mfgc5-MuiTableCell-root"
+            >
+              Improvement
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium delta css-15mfgc5-MuiTableCell-root"
+            >
+              2.5%
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium confidence css-15mfgc5-MuiTableCell-root"
+            >
+              High
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+            >
+              B:23 N:27
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                data-testid="TimelineIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
+                />
+              </svg>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                data-testid="FileDownloadOutlinedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
+                />
+              </svg>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button total-runs css-15mfgc5-MuiTableCell-root"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                data-testid="RefreshOutlinedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                />
+              </svg>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button expand-button css-15mfgc5-MuiTableCell-root"
+            >
+              <div
+                class="expand-button-container"
+              >
+                <button
+                  aria-label="expand row"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                    data-testid="KeyboardArrowDownIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="MuiTableRow-root f3tz1z9 css-1yt2i5z-MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium platform css-15mfgc5-MuiTableCell-root"
+            >
+              <div
+                class="platform-container"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                  data-testid="AppleIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"
+                  />
+                </svg>
+                <span>
+                  Apple
+                </span>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+            >
+              771.39ms
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium comparison-sign css-15mfgc5-MuiTableCell-root"
+            >
+              &gt;
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium new-value css-15mfgc5-MuiTableCell-root"
+            >
+              771.39ms
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium status css-15mfgc5-MuiTableCell-root"
+            >
+              Improvement
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium delta css-15mfgc5-MuiTableCell-root"
+            >
+              2.5%
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium confidence css-15mfgc5-MuiTableCell-root"
+            >
+              High
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+            >
+              B:23 N:27
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                data-testid="TimelineIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
+                />
+              </svg>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                data-testid="FileDownloadOutlinedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
+                />
+              </svg>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button total-runs css-15mfgc5-MuiTableCell-root"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                data-testid="RefreshOutlinedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                />
+              </svg>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button expand-button css-15mfgc5-MuiTableCell-root"
+            >
+              <div
+                class="expand-button-container"
+              >
+                <button
+                  aria-label="expand row"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                    data-testid="KeyboardArrowDownIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="MuiTableRow-root f3tz1z9 css-1yt2i5z-MuiTableRow-root"
+          >
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium platform css-15mfgc5-MuiTableCell-root"
+            >
+              <div
+                class="platform-container"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                  data-testid="AppleIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"
+                  />
+                </svg>
+                <span>
+                  Apple
+                </span>
+              </div>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+            >
+              771.39ms
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium comparison-sign css-15mfgc5-MuiTableCell-root"
+            >
+              &gt;
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium new-value css-15mfgc5-MuiTableCell-root"
+            >
+              771.39ms
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium status css-15mfgc5-MuiTableCell-root"
+            >
+              Improvement
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium delta css-15mfgc5-MuiTableCell-root"
+            >
+              2.5%
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium confidence css-15mfgc5-MuiTableCell-root"
+            >
+              High
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+            >
+              B:23 N:27
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                data-testid="TimelineIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
+                />
+              </svg>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                data-testid="FileDownloadOutlinedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
+                />
+              </svg>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button total-runs css-15mfgc5-MuiTableCell-root"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                data-testid="RefreshOutlinedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                />
+              </svg>
+            </td>
+            <td
+              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button expand-button css-15mfgc5-MuiTableCell-root"
+            >
+              <div
+                class="expand-button-container"
+              >
+                <button
+                  aria-label="expand row"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                    data-testid="KeyboardArrowDownIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+            </td>
+          </tr>
+        </tbody>
       </table>
     </div>
   </div>

--- a/src/__tests__/CompareResults/beta/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/beta/__snapshots__/ResultsView.test.tsx.snap
@@ -227,7 +227,6 @@ exports[`Results View Should match snapshot 1`] = `
               data-testid="results-table"
             >
               <table
-                aria-label="collapsible table"
                 class="MuiTable-root css-yso468-MuiTable-root"
               >
                 <thead
@@ -235,14 +234,14 @@ exports[`Results View Should match snapshot 1`] = `
                   data-testid="table-header"
                 >
                   <tr
-                    class="MuiTableRow-root MuiTableRow-head f81wnp2 css-1yt2i5z-MuiTableRow-root"
+                    class="MuiTableRow-root MuiTableRow-head f1frk9dl css-1yt2i5z-MuiTableRow-root"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium platform-header css-hwty3m-MuiTableCell-root"
                       scope="col"
                     >
                       <div
-                        class="f1076rq5"
+                        class="fzi2oph"
                       >
                         <svg
                           aria-hidden="true"
@@ -272,7 +271,7 @@ exports[`Results View Should match snapshot 1`] = `
                       </div>
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium base-header css-hwty3m-MuiTableCell-root"
                       scope="col"
                     >
                       <div
@@ -284,7 +283,17 @@ exports[`Results View Should match snapshot 1`] = `
                       </div>
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium comparisonSign-header css-hwty3m-MuiTableCell-root"
+                      scope="col"
+                    >
+                      <div
+                        class=""
+                      >
+                        <span />
+                      </div>
+                    </th>
+                    <th
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium new-header css-hwty3m-MuiTableCell-root"
                       scope="col"
                     >
                       <div
@@ -296,11 +305,11 @@ exports[`Results View Should match snapshot 1`] = `
                       </div>
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium status-header css-hwty3m-MuiTableCell-root"
                       scope="col"
                     >
                       <div
-                        class="f1076rq5"
+                        class="fzi2oph"
                       >
                         <svg
                           aria-hidden="true"
@@ -330,7 +339,7 @@ exports[`Results View Should match snapshot 1`] = `
                       </div>
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium delta-header css-hwty3m-MuiTableCell-root"
                       scope="col"
                     >
                       <div
@@ -342,11 +351,11 @@ exports[`Results View Should match snapshot 1`] = `
                       </div>
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium confidence-header css-hwty3m-MuiTableCell-root"
                       scope="col"
                     >
                       <div
-                        class="f1076rq5"
+                        class="fzi2oph"
                       >
                         <svg
                           aria-hidden="true"
@@ -376,7 +385,7 @@ exports[`Results View Should match snapshot 1`] = `
                       </div>
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium runs-header css-hwty3m-MuiTableCell-root"
                       scope="col"
                     >
                       <div
@@ -387,8 +396,468 @@ exports[`Results View Should match snapshot 1`] = `
                         </span>
                       </div>
                     </th>
+                    <th
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium empty-header css-hwty3m-MuiTableCell-root"
+                      colspan="4"
+                      scope="col"
+                    >
+                      <div
+                        class=""
+                      >
+                        <span />
+                      </div>
+                    </th>
                   </tr>
                 </thead>
+                <tbody
+                  class="MuiTableBody-root fhjtom1 css-apqrd9-MuiTableBody-root"
+                >
+                  <tr
+                    class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
+                  >
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                      colspan="8"
+                    >
+                      Metric 1 
+                      <a
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
+                        href="#"
+                      >
+                        0f9ef9ff3ea
+                      </a>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                      colspan="4"
+                    >
+                      <div
+                        class="f1oxa67k"
+                      >
+                        <span
+                          class="f1rpr1m5"
+                        >
+                          e10s
+                        </span>
+                        <span
+                          class="f1rpr1m5"
+                        >
+                          stylo
+                        </span>
+                        <span
+                          class="f1rpr1m5"
+                        >
+                          fission
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="MuiTableRow-root f3tz1z9 css-1yt2i5z-MuiTableRow-root"
+                  >
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium platform css-15mfgc5-MuiTableCell-root"
+                    >
+                      <div
+                        class="platform-container"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                          data-testid="AppleIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"
+                          />
+                        </svg>
+                        <span>
+                          Apple
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                    >
+                      771.39ms
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium comparison-sign css-15mfgc5-MuiTableCell-root"
+                    >
+                      &gt;
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium new-value css-15mfgc5-MuiTableCell-root"
+                    >
+                      771.39ms
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium status css-15mfgc5-MuiTableCell-root"
+                    >
+                      Improvement
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium delta css-15mfgc5-MuiTableCell-root"
+                    >
+                      2.5%
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium confidence css-15mfgc5-MuiTableCell-root"
+                    >
+                      High
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                    >
+                      B:23 N:27
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                        data-testid="TimelineIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
+                        />
+                      </svg>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                        data-testid="FileDownloadOutlinedIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
+                        />
+                      </svg>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button total-runs css-15mfgc5-MuiTableCell-root"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                        data-testid="RefreshOutlinedIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                        />
+                      </svg>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button expand-button css-15mfgc5-MuiTableCell-root"
+                    >
+                      <div
+                        class="expand-button-container"
+                      >
+                        <button
+                          aria-label="expand row"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                            data-testid="KeyboardArrowDownIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                            />
+                          </svg>
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="MuiTableRow-root f3tz1z9 css-1yt2i5z-MuiTableRow-root"
+                  >
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium platform css-15mfgc5-MuiTableCell-root"
+                    >
+                      <div
+                        class="platform-container"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                          data-testid="AppleIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"
+                          />
+                        </svg>
+                        <span>
+                          Apple
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                    >
+                      771.39ms
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium comparison-sign css-15mfgc5-MuiTableCell-root"
+                    >
+                      &gt;
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium new-value css-15mfgc5-MuiTableCell-root"
+                    >
+                      771.39ms
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium status css-15mfgc5-MuiTableCell-root"
+                    >
+                      Improvement
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium delta css-15mfgc5-MuiTableCell-root"
+                    >
+                      2.5%
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium confidence css-15mfgc5-MuiTableCell-root"
+                    >
+                      High
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                    >
+                      B:23 N:27
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                        data-testid="TimelineIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
+                        />
+                      </svg>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                        data-testid="FileDownloadOutlinedIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
+                        />
+                      </svg>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button total-runs css-15mfgc5-MuiTableCell-root"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                        data-testid="RefreshOutlinedIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                        />
+                      </svg>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button expand-button css-15mfgc5-MuiTableCell-root"
+                    >
+                      <div
+                        class="expand-button-container"
+                      >
+                        <button
+                          aria-label="expand row"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                            data-testid="KeyboardArrowDownIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                            />
+                          </svg>
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="MuiTableRow-root f3tz1z9 css-1yt2i5z-MuiTableRow-root"
+                  >
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium platform css-15mfgc5-MuiTableCell-root"
+                    >
+                      <div
+                        class="platform-container"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                          data-testid="AppleIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"
+                          />
+                        </svg>
+                        <span>
+                          Apple
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                    >
+                      771.39ms
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium comparison-sign css-15mfgc5-MuiTableCell-root"
+                    >
+                      &gt;
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium new-value css-15mfgc5-MuiTableCell-root"
+                    >
+                      771.39ms
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium status css-15mfgc5-MuiTableCell-root"
+                    >
+                      Improvement
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium delta css-15mfgc5-MuiTableCell-root"
+                    >
+                      2.5%
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium confidence css-15mfgc5-MuiTableCell-root"
+                    >
+                      High
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                    >
+                      B:23 N:27
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                        data-testid="TimelineIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
+                        />
+                      </svg>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                        data-testid="FileDownloadOutlinedIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
+                        />
+                      </svg>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button total-runs css-15mfgc5-MuiTableCell-root"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                        data-testid="RefreshOutlinedIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                        />
+                      </svg>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button expand-button css-15mfgc5-MuiTableCell-root"
+                    >
+                      <div
+                        class="expand-button-container"
+                      >
+                        <button
+                          aria-label="expand row"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                            data-testid="KeyboardArrowDownIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                            />
+                          </svg>
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
               </table>
             </div>
           </div>

--- a/src/__tests__/CompareResults/beta/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/beta/__snapshots__/ResultsView.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`Results View Should match snapshot 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-z2teic-MuiGrid-root"
         >
           <div
-            class="MuiContainer-root MuiContainer-maxWidthLg f1ctei50 css-1tyv3cf-MuiContainer-root"
+            class="MuiContainer-root MuiContainer-maxWidthLg f3atc20 css-1tyv3cf-MuiContainer-root"
             data-testid="results-main"
           >
             <header>
@@ -223,7 +223,7 @@ exports[`Results View Should match snapshot 1`] = `
               </div>
             </header>
             <div
-              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiTableContainer-root f1otqxop css-pfrgnn-MuiPaper-root-MuiTableContainer-root"
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiTableContainer-root f1cqtmh css-1inhs6f-MuiPaper-root-MuiTableContainer-root"
               data-testid="results-table"
             >
               <table
@@ -234,7 +234,7 @@ exports[`Results View Should match snapshot 1`] = `
                   data-testid="table-header"
                 >
                   <tr
-                    class="MuiTableRow-root MuiTableRow-head f1frk9dl css-1yt2i5z-MuiTableRow-root"
+                    class="MuiTableRow-root MuiTableRow-head f1ctvkx8 css-1yt2i5z-MuiTableRow-root"
                   >
                     <th
                       class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium platform-header css-hwty3m-MuiTableCell-root"
@@ -410,7 +410,7 @@ exports[`Results View Should match snapshot 1`] = `
                   </tr>
                 </thead>
                 <tbody
-                  class="MuiTableBody-root f15luk9e css-apqrd9-MuiTableBody-root"
+                  class="MuiTableBody-root f5w6em2 css-apqrd9-MuiTableBody-root"
                 >
                   <tr
                     class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
@@ -456,7 +456,7 @@ exports[`Results View Should match snapshot 1`] = `
                     </td>
                   </tr>
                   <tr
-                    class="MuiTableRow-root revisionRow fju3wsp css-1yt2i5z-MuiTableRow-root"
+                    class="MuiTableRow-root revisionRow f131cxob css-1yt2i5z-MuiTableRow-root"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium platform css-15mfgc5-MuiTableCell-root"
@@ -645,7 +645,7 @@ exports[`Results View Should match snapshot 1`] = `
                     </td>
                   </tr>
                   <tr
-                    class="MuiTableRow-root revisionRow fju3wsp css-1yt2i5z-MuiTableRow-root"
+                    class="MuiTableRow-root revisionRow f131cxob css-1yt2i5z-MuiTableRow-root"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium platform css-15mfgc5-MuiTableCell-root"
@@ -834,7 +834,7 @@ exports[`Results View Should match snapshot 1`] = `
                     </td>
                   </tr>
                   <tr
-                    class="MuiTableRow-root revisionRow fju3wsp css-1yt2i5z-MuiTableRow-root"
+                    class="MuiTableRow-root revisionRow f131cxob css-1yt2i5z-MuiTableRow-root"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium platform css-15mfgc5-MuiTableCell-root"

--- a/src/__tests__/CompareResults/beta/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/beta/__snapshots__/ResultsView.test.tsx.snap
@@ -410,7 +410,7 @@ exports[`Results View Should match snapshot 1`] = `
                   </tr>
                 </thead>
                 <tbody
-                  class="MuiTableBody-root fhjtom1 css-apqrd9-MuiTableBody-root"
+                  class="MuiTableBody-root f15luk9e css-apqrd9-MuiTableBody-root"
                 >
                   <tr
                     class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
@@ -419,7 +419,10 @@ exports[`Results View Should match snapshot 1`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
                       colspan="8"
                     >
-                      Metric 1 
+                      <strong>
+                        Metric 1
+                      </strong>
+                       
                       <a
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
                         href="#"
@@ -453,7 +456,7 @@ exports[`Results View Should match snapshot 1`] = `
                     </td>
                   </tr>
                   <tr
-                    class="MuiTableRow-root f3tz1z9 css-1yt2i5z-MuiTableRow-root"
+                    class="MuiTableRow-root revisionRow fju3wsp css-1yt2i5z-MuiTableRow-root"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium platform css-15mfgc5-MuiTableCell-root"
@@ -478,9 +481,13 @@ exports[`Results View Should match snapshot 1`] = `
                       </div>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium base-value css-15mfgc5-MuiTableCell-root"
                     >
-                      771.39ms
+                      <div
+                        class="base-container"
+                      >
+                        771.39ms
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium comparison-sign css-15mfgc5-MuiTableCell-root"
@@ -508,54 +515,104 @@ exports[`Results View Should match snapshot 1`] = `
                       High
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium total-runs css-15mfgc5-MuiTableCell-root"
                     >
-                      B:23 N:27
+                      <span>
+                        B:
+                      </span>
+                      <strong>
+                        23
+                      </strong>
+                       
+                      <span>
+                        N:
+                      </span>
+                      <strong>
+                        27
+                      </strong>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button graph css-15mfgc5-MuiTableCell-root"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                        data-testid="TimelineIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <div
+                        class="graph-link-button-container"
                       >
-                        <path
-                          d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
-                        />
-                      </svg>
+                        <button
+                          aria-label="graph link"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                            data-testid="TimelineIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
+                            />
+                          </svg>
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </div>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button download css-15mfgc5-MuiTableCell-root"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                        data-testid="FileDownloadOutlinedIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <div
+                        class="download-button-container"
                       >
-                        <path
-                          d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
-                        />
-                      </svg>
+                        <button
+                          aria-label="download"
+                          class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                          disabled=""
+                          tabindex="-1"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                            data-testid="FileDownloadOutlinedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
+                            />
+                          </svg>
+                        </button>
+                      </div>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button total-runs css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button retrigger-button css-15mfgc5-MuiTableCell-root"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                        data-testid="RefreshOutlinedIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <div
+                        class="runs-button-container"
                       >
-                        <path
-                          d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
-                        />
-                      </svg>
+                        <button
+                          aria-label="retrigger button"
+                          class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                          disabled=""
+                          tabindex="-1"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                            data-testid="RefreshOutlinedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                            />
+                          </svg>
+                        </button>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button expand-button css-15mfgc5-MuiTableCell-root"
@@ -588,7 +645,7 @@ exports[`Results View Should match snapshot 1`] = `
                     </td>
                   </tr>
                   <tr
-                    class="MuiTableRow-root f3tz1z9 css-1yt2i5z-MuiTableRow-root"
+                    class="MuiTableRow-root revisionRow fju3wsp css-1yt2i5z-MuiTableRow-root"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium platform css-15mfgc5-MuiTableCell-root"
@@ -613,9 +670,13 @@ exports[`Results View Should match snapshot 1`] = `
                       </div>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium base-value css-15mfgc5-MuiTableCell-root"
                     >
-                      771.39ms
+                      <div
+                        class="base-container"
+                      >
+                        771.39ms
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium comparison-sign css-15mfgc5-MuiTableCell-root"
@@ -643,54 +704,104 @@ exports[`Results View Should match snapshot 1`] = `
                       High
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium total-runs css-15mfgc5-MuiTableCell-root"
                     >
-                      B:23 N:27
+                      <span>
+                        B:
+                      </span>
+                      <strong>
+                        23
+                      </strong>
+                       
+                      <span>
+                        N:
+                      </span>
+                      <strong>
+                        27
+                      </strong>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button graph css-15mfgc5-MuiTableCell-root"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                        data-testid="TimelineIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <div
+                        class="graph-link-button-container"
                       >
-                        <path
-                          d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
-                        />
-                      </svg>
+                        <button
+                          aria-label="graph link"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                            data-testid="TimelineIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
+                            />
+                          </svg>
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </div>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button download css-15mfgc5-MuiTableCell-root"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                        data-testid="FileDownloadOutlinedIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <div
+                        class="download-button-container"
                       >
-                        <path
-                          d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
-                        />
-                      </svg>
+                        <button
+                          aria-label="download"
+                          class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                          disabled=""
+                          tabindex="-1"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                            data-testid="FileDownloadOutlinedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
+                            />
+                          </svg>
+                        </button>
+                      </div>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button total-runs css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button retrigger-button css-15mfgc5-MuiTableCell-root"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                        data-testid="RefreshOutlinedIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <div
+                        class="runs-button-container"
                       >
-                        <path
-                          d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
-                        />
-                      </svg>
+                        <button
+                          aria-label="retrigger button"
+                          class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                          disabled=""
+                          tabindex="-1"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                            data-testid="RefreshOutlinedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                            />
+                          </svg>
+                        </button>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button expand-button css-15mfgc5-MuiTableCell-root"
@@ -723,7 +834,7 @@ exports[`Results View Should match snapshot 1`] = `
                     </td>
                   </tr>
                   <tr
-                    class="MuiTableRow-root f3tz1z9 css-1yt2i5z-MuiTableRow-root"
+                    class="MuiTableRow-root revisionRow fju3wsp css-1yt2i5z-MuiTableRow-root"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium platform css-15mfgc5-MuiTableCell-root"
@@ -748,9 +859,13 @@ exports[`Results View Should match snapshot 1`] = `
                       </div>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium base-value css-15mfgc5-MuiTableCell-root"
                     >
-                      771.39ms
+                      <div
+                        class="base-container"
+                      >
+                        771.39ms
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium comparison-sign css-15mfgc5-MuiTableCell-root"
@@ -778,54 +893,104 @@ exports[`Results View Should match snapshot 1`] = `
                       High
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium total-runs css-15mfgc5-MuiTableCell-root"
                     >
-                      B:23 N:27
+                      <span>
+                        B:
+                      </span>
+                      <strong>
+                        23
+                      </strong>
+                       
+                      <span>
+                        N:
+                      </span>
+                      <strong>
+                        27
+                      </strong>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button graph css-15mfgc5-MuiTableCell-root"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                        data-testid="TimelineIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <div
+                        class="graph-link-button-container"
                       >
-                        <path
-                          d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
-                        />
-                      </svg>
+                        <button
+                          aria-label="graph link"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                            data-testid="TimelineIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
+                            />
+                          </svg>
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </div>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button download css-15mfgc5-MuiTableCell-root"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                        data-testid="FileDownloadOutlinedIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <div
+                        class="download-button-container"
                       >
-                        <path
-                          d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
-                        />
-                      </svg>
+                        <button
+                          aria-label="download"
+                          class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                          disabled=""
+                          tabindex="-1"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                            data-testid="FileDownloadOutlinedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
+                            />
+                          </svg>
+                        </button>
+                      </div>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button total-runs css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button retrigger-button css-15mfgc5-MuiTableCell-root"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                        data-testid="RefreshOutlinedIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <div
+                        class="runs-button-container"
                       >
-                        <path
-                          d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
-                        />
-                      </svg>
+                        <button
+                          aria-label="retrigger button"
+                          class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                          disabled=""
+                          tabindex="-1"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                            data-testid="RefreshOutlinedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                            />
+                          </svg>
+                        </button>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button expand-button css-15mfgc5-MuiTableCell-root"

--- a/src/__tests__/CompareResults/beta/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/__tests__/CompareResults/beta/__snapshots__/SearchInput.test.tsx.snap
@@ -227,7 +227,6 @@ exports[`Search by title/test name Should match snapshot 1`] = `
               data-testid="results-table"
             >
               <table
-                aria-label="collapsible table"
                 class="MuiTable-root css-yso468-MuiTable-root"
               >
                 <thead
@@ -235,14 +234,14 @@ exports[`Search by title/test name Should match snapshot 1`] = `
                   data-testid="table-header"
                 >
                   <tr
-                    class="MuiTableRow-root MuiTableRow-head f81wnp2 css-1yt2i5z-MuiTableRow-root"
+                    class="MuiTableRow-root MuiTableRow-head f1frk9dl css-1yt2i5z-MuiTableRow-root"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium platform-header css-hwty3m-MuiTableCell-root"
                       scope="col"
                     >
                       <div
-                        class="f1076rq5"
+                        class="fzi2oph"
                       >
                         <svg
                           aria-hidden="true"
@@ -272,7 +271,7 @@ exports[`Search by title/test name Should match snapshot 1`] = `
                       </div>
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium base-header css-hwty3m-MuiTableCell-root"
                       scope="col"
                     >
                       <div
@@ -284,7 +283,17 @@ exports[`Search by title/test name Should match snapshot 1`] = `
                       </div>
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium comparisonSign-header css-hwty3m-MuiTableCell-root"
+                      scope="col"
+                    >
+                      <div
+                        class=""
+                      >
+                        <span />
+                      </div>
+                    </th>
+                    <th
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium new-header css-hwty3m-MuiTableCell-root"
                       scope="col"
                     >
                       <div
@@ -296,11 +305,11 @@ exports[`Search by title/test name Should match snapshot 1`] = `
                       </div>
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium status-header css-hwty3m-MuiTableCell-root"
                       scope="col"
                     >
                       <div
-                        class="f1076rq5"
+                        class="fzi2oph"
                       >
                         <svg
                           aria-hidden="true"
@@ -330,7 +339,7 @@ exports[`Search by title/test name Should match snapshot 1`] = `
                       </div>
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium delta-header css-hwty3m-MuiTableCell-root"
                       scope="col"
                     >
                       <div
@@ -342,11 +351,11 @@ exports[`Search by title/test name Should match snapshot 1`] = `
                       </div>
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium confidence-header css-hwty3m-MuiTableCell-root"
                       scope="col"
                     >
                       <div
-                        class="f1076rq5"
+                        class="fzi2oph"
                       >
                         <svg
                           aria-hidden="true"
@@ -376,7 +385,7 @@ exports[`Search by title/test name Should match snapshot 1`] = `
                       </div>
                     </th>
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium runs-header css-hwty3m-MuiTableCell-root"
                       scope="col"
                     >
                       <div
@@ -387,8 +396,468 @@ exports[`Search by title/test name Should match snapshot 1`] = `
                         </span>
                       </div>
                     </th>
+                    <th
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium empty-header css-hwty3m-MuiTableCell-root"
+                      colspan="4"
+                      scope="col"
+                    >
+                      <div
+                        class=""
+                      >
+                        <span />
+                      </div>
+                    </th>
                   </tr>
                 </thead>
+                <tbody
+                  class="MuiTableBody-root fhjtom1 css-apqrd9-MuiTableBody-root"
+                >
+                  <tr
+                    class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
+                  >
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                      colspan="8"
+                    >
+                      Metric 1 
+                      <a
+                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
+                        href="#"
+                      >
+                        0f9ef9ff3ea
+                      </a>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                      colspan="4"
+                    >
+                      <div
+                        class="f1oxa67k"
+                      >
+                        <span
+                          class="f1rpr1m5"
+                        >
+                          e10s
+                        </span>
+                        <span
+                          class="f1rpr1m5"
+                        >
+                          stylo
+                        </span>
+                        <span
+                          class="f1rpr1m5"
+                        >
+                          fission
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="MuiTableRow-root f3tz1z9 css-1yt2i5z-MuiTableRow-root"
+                  >
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium platform css-15mfgc5-MuiTableCell-root"
+                    >
+                      <div
+                        class="platform-container"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                          data-testid="AppleIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"
+                          />
+                        </svg>
+                        <span>
+                          Apple
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                    >
+                      771.39ms
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium comparison-sign css-15mfgc5-MuiTableCell-root"
+                    >
+                      &gt;
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium new-value css-15mfgc5-MuiTableCell-root"
+                    >
+                      771.39ms
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium status css-15mfgc5-MuiTableCell-root"
+                    >
+                      Improvement
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium delta css-15mfgc5-MuiTableCell-root"
+                    >
+                      2.5%
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium confidence css-15mfgc5-MuiTableCell-root"
+                    >
+                      High
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                    >
+                      B:23 N:27
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                        data-testid="TimelineIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
+                        />
+                      </svg>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                        data-testid="FileDownloadOutlinedIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
+                        />
+                      </svg>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button total-runs css-15mfgc5-MuiTableCell-root"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                        data-testid="RefreshOutlinedIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                        />
+                      </svg>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button expand-button css-15mfgc5-MuiTableCell-root"
+                    >
+                      <div
+                        class="expand-button-container"
+                      >
+                        <button
+                          aria-label="expand row"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                            data-testid="KeyboardArrowDownIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                            />
+                          </svg>
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="MuiTableRow-root f3tz1z9 css-1yt2i5z-MuiTableRow-root"
+                  >
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium platform css-15mfgc5-MuiTableCell-root"
+                    >
+                      <div
+                        class="platform-container"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                          data-testid="AppleIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"
+                          />
+                        </svg>
+                        <span>
+                          Apple
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                    >
+                      771.39ms
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium comparison-sign css-15mfgc5-MuiTableCell-root"
+                    >
+                      &gt;
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium new-value css-15mfgc5-MuiTableCell-root"
+                    >
+                      771.39ms
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium status css-15mfgc5-MuiTableCell-root"
+                    >
+                      Improvement
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium delta css-15mfgc5-MuiTableCell-root"
+                    >
+                      2.5%
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium confidence css-15mfgc5-MuiTableCell-root"
+                    >
+                      High
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                    >
+                      B:23 N:27
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                        data-testid="TimelineIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
+                        />
+                      </svg>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                        data-testid="FileDownloadOutlinedIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
+                        />
+                      </svg>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button total-runs css-15mfgc5-MuiTableCell-root"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                        data-testid="RefreshOutlinedIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                        />
+                      </svg>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button expand-button css-15mfgc5-MuiTableCell-root"
+                    >
+                      <div
+                        class="expand-button-container"
+                      >
+                        <button
+                          aria-label="expand row"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                            data-testid="KeyboardArrowDownIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                            />
+                          </svg>
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr
+                    class="MuiTableRow-root f3tz1z9 css-1yt2i5z-MuiTableRow-root"
+                  >
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium platform css-15mfgc5-MuiTableCell-root"
+                    >
+                      <div
+                        class="platform-container"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                          data-testid="AppleIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"
+                          />
+                        </svg>
+                        <span>
+                          Apple
+                        </span>
+                      </div>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                    >
+                      771.39ms
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium comparison-sign css-15mfgc5-MuiTableCell-root"
+                    >
+                      &gt;
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium new-value css-15mfgc5-MuiTableCell-root"
+                    >
+                      771.39ms
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium status css-15mfgc5-MuiTableCell-root"
+                    >
+                      Improvement
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium delta css-15mfgc5-MuiTableCell-root"
+                    >
+                      2.5%
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium confidence css-15mfgc5-MuiTableCell-root"
+                    >
+                      High
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                    >
+                      B:23 N:27
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                        data-testid="TimelineIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
+                        />
+                      </svg>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                        data-testid="FileDownloadOutlinedIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
+                        />
+                      </svg>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button total-runs css-15mfgc5-MuiTableCell-root"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                        data-testid="RefreshOutlinedIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                        />
+                      </svg>
+                    </td>
+                    <td
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button expand-button css-15mfgc5-MuiTableCell-root"
+                    >
+                      <div
+                        class="expand-button-container"
+                      >
+                        <button
+                          aria-label="expand row"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                            data-testid="KeyboardArrowDownIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                            />
+                          </svg>
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
               </table>
             </div>
           </div>

--- a/src/__tests__/CompareResults/beta/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/__tests__/CompareResults/beta/__snapshots__/SearchInput.test.tsx.snap
@@ -410,7 +410,7 @@ exports[`Search by title/test name Should match snapshot 1`] = `
                   </tr>
                 </thead>
                 <tbody
-                  class="MuiTableBody-root fhjtom1 css-apqrd9-MuiTableBody-root"
+                  class="MuiTableBody-root f15luk9e css-apqrd9-MuiTableBody-root"
                 >
                   <tr
                     class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
@@ -419,7 +419,10 @@ exports[`Search by title/test name Should match snapshot 1`] = `
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
                       colspan="8"
                     >
-                      Metric 1 
+                      <strong>
+                        Metric 1
+                      </strong>
+                       
                       <a
                         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
                         href="#"
@@ -453,7 +456,7 @@ exports[`Search by title/test name Should match snapshot 1`] = `
                     </td>
                   </tr>
                   <tr
-                    class="MuiTableRow-root f3tz1z9 css-1yt2i5z-MuiTableRow-root"
+                    class="MuiTableRow-root revisionRow fju3wsp css-1yt2i5z-MuiTableRow-root"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium platform css-15mfgc5-MuiTableCell-root"
@@ -478,9 +481,13 @@ exports[`Search by title/test name Should match snapshot 1`] = `
                       </div>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium base-value css-15mfgc5-MuiTableCell-root"
                     >
-                      771.39ms
+                      <div
+                        class="base-container"
+                      >
+                        771.39ms
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium comparison-sign css-15mfgc5-MuiTableCell-root"
@@ -508,54 +515,104 @@ exports[`Search by title/test name Should match snapshot 1`] = `
                       High
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium total-runs css-15mfgc5-MuiTableCell-root"
                     >
-                      B:23 N:27
+                      <span>
+                        B:
+                      </span>
+                      <strong>
+                        23
+                      </strong>
+                       
+                      <span>
+                        N:
+                      </span>
+                      <strong>
+                        27
+                      </strong>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button graph css-15mfgc5-MuiTableCell-root"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                        data-testid="TimelineIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <div
+                        class="graph-link-button-container"
                       >
-                        <path
-                          d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
-                        />
-                      </svg>
+                        <button
+                          aria-label="graph link"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                            data-testid="TimelineIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
+                            />
+                          </svg>
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </div>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button download css-15mfgc5-MuiTableCell-root"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                        data-testid="FileDownloadOutlinedIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <div
+                        class="download-button-container"
                       >
-                        <path
-                          d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
-                        />
-                      </svg>
+                        <button
+                          aria-label="download"
+                          class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                          disabled=""
+                          tabindex="-1"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                            data-testid="FileDownloadOutlinedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
+                            />
+                          </svg>
+                        </button>
+                      </div>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button total-runs css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button retrigger-button css-15mfgc5-MuiTableCell-root"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                        data-testid="RefreshOutlinedIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <div
+                        class="runs-button-container"
                       >
-                        <path
-                          d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
-                        />
-                      </svg>
+                        <button
+                          aria-label="retrigger button"
+                          class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                          disabled=""
+                          tabindex="-1"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                            data-testid="RefreshOutlinedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                            />
+                          </svg>
+                        </button>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button expand-button css-15mfgc5-MuiTableCell-root"
@@ -588,7 +645,7 @@ exports[`Search by title/test name Should match snapshot 1`] = `
                     </td>
                   </tr>
                   <tr
-                    class="MuiTableRow-root f3tz1z9 css-1yt2i5z-MuiTableRow-root"
+                    class="MuiTableRow-root revisionRow fju3wsp css-1yt2i5z-MuiTableRow-root"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium platform css-15mfgc5-MuiTableCell-root"
@@ -613,9 +670,13 @@ exports[`Search by title/test name Should match snapshot 1`] = `
                       </div>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium base-value css-15mfgc5-MuiTableCell-root"
                     >
-                      771.39ms
+                      <div
+                        class="base-container"
+                      >
+                        771.39ms
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium comparison-sign css-15mfgc5-MuiTableCell-root"
@@ -643,54 +704,104 @@ exports[`Search by title/test name Should match snapshot 1`] = `
                       High
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium total-runs css-15mfgc5-MuiTableCell-root"
                     >
-                      B:23 N:27
+                      <span>
+                        B:
+                      </span>
+                      <strong>
+                        23
+                      </strong>
+                       
+                      <span>
+                        N:
+                      </span>
+                      <strong>
+                        27
+                      </strong>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button graph css-15mfgc5-MuiTableCell-root"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                        data-testid="TimelineIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <div
+                        class="graph-link-button-container"
                       >
-                        <path
-                          d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
-                        />
-                      </svg>
+                        <button
+                          aria-label="graph link"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                            data-testid="TimelineIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
+                            />
+                          </svg>
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </div>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button download css-15mfgc5-MuiTableCell-root"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                        data-testid="FileDownloadOutlinedIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <div
+                        class="download-button-container"
                       >
-                        <path
-                          d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
-                        />
-                      </svg>
+                        <button
+                          aria-label="download"
+                          class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                          disabled=""
+                          tabindex="-1"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                            data-testid="FileDownloadOutlinedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
+                            />
+                          </svg>
+                        </button>
+                      </div>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button total-runs css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button retrigger-button css-15mfgc5-MuiTableCell-root"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                        data-testid="RefreshOutlinedIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <div
+                        class="runs-button-container"
                       >
-                        <path
-                          d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
-                        />
-                      </svg>
+                        <button
+                          aria-label="retrigger button"
+                          class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                          disabled=""
+                          tabindex="-1"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                            data-testid="RefreshOutlinedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                            />
+                          </svg>
+                        </button>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button expand-button css-15mfgc5-MuiTableCell-root"
@@ -723,7 +834,7 @@ exports[`Search by title/test name Should match snapshot 1`] = `
                     </td>
                   </tr>
                   <tr
-                    class="MuiTableRow-root f3tz1z9 css-1yt2i5z-MuiTableRow-root"
+                    class="MuiTableRow-root revisionRow fju3wsp css-1yt2i5z-MuiTableRow-root"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium platform css-15mfgc5-MuiTableCell-root"
@@ -748,9 +859,13 @@ exports[`Search by title/test name Should match snapshot 1`] = `
                       </div>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium base-value css-15mfgc5-MuiTableCell-root"
                     >
-                      771.39ms
+                      <div
+                        class="base-container"
+                      >
+                        771.39ms
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium comparison-sign css-15mfgc5-MuiTableCell-root"
@@ -778,54 +893,104 @@ exports[`Search by title/test name Should match snapshot 1`] = `
                       High
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium total-runs css-15mfgc5-MuiTableCell-root"
                     >
-                      B:23 N:27
+                      <span>
+                        B:
+                      </span>
+                      <strong>
+                        23
+                      </strong>
+                       
+                      <span>
+                        N:
+                      </span>
+                      <strong>
+                        27
+                      </strong>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button graph css-15mfgc5-MuiTableCell-root"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                        data-testid="TimelineIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <div
+                        class="graph-link-button-container"
                       >
-                        <path
-                          d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
-                        />
-                      </svg>
+                        <button
+                          aria-label="graph link"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                            data-testid="TimelineIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
+                            />
+                          </svg>
+                          <span
+                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                          />
+                        </button>
+                      </div>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button download css-15mfgc5-MuiTableCell-root"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                        data-testid="FileDownloadOutlinedIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <div
+                        class="download-button-container"
                       >
-                        <path
-                          d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
-                        />
-                      </svg>
+                        <button
+                          aria-label="download"
+                          class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                          disabled=""
+                          tabindex="-1"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                            data-testid="FileDownloadOutlinedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
+                            />
+                          </svg>
+                        </button>
+                      </div>
                     </td>
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button total-runs css-15mfgc5-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button retrigger-button css-15mfgc5-MuiTableCell-root"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                        data-testid="RefreshOutlinedIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <div
+                        class="runs-button-container"
                       >
-                        <path
-                          d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
-                        />
-                      </svg>
+                        <button
+                          aria-label="retrigger button"
+                          class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall css-181l1t7-MuiButtonBase-root-MuiIconButton-root"
+                          disabled=""
+                          tabindex="-1"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                            data-testid="RefreshOutlinedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                            />
+                          </svg>
+                        </button>
+                      </div>
                     </td>
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell-button expand-button css-15mfgc5-MuiTableCell-root"

--- a/src/__tests__/CompareResults/beta/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/__tests__/CompareResults/beta/__snapshots__/SearchInput.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`Search by title/test name Should match snapshot 1`] = `
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-z2teic-MuiGrid-root"
         >
           <div
-            class="MuiContainer-root MuiContainer-maxWidthLg f1ctei50 css-1tyv3cf-MuiContainer-root"
+            class="MuiContainer-root MuiContainer-maxWidthLg f3atc20 css-1tyv3cf-MuiContainer-root"
             data-testid="results-main"
           >
             <header>
@@ -223,7 +223,7 @@ exports[`Search by title/test name Should match snapshot 1`] = `
               </div>
             </header>
             <div
-              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiTableContainer-root f1otqxop css-pfrgnn-MuiPaper-root-MuiTableContainer-root"
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiTableContainer-root f1cqtmh css-1inhs6f-MuiPaper-root-MuiTableContainer-root"
               data-testid="results-table"
             >
               <table
@@ -234,7 +234,7 @@ exports[`Search by title/test name Should match snapshot 1`] = `
                   data-testid="table-header"
                 >
                   <tr
-                    class="MuiTableRow-root MuiTableRow-head f1frk9dl css-1yt2i5z-MuiTableRow-root"
+                    class="MuiTableRow-root MuiTableRow-head f1ctvkx8 css-1yt2i5z-MuiTableRow-root"
                   >
                     <th
                       class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium platform-header css-hwty3m-MuiTableCell-root"
@@ -410,7 +410,7 @@ exports[`Search by title/test name Should match snapshot 1`] = `
                   </tr>
                 </thead>
                 <tbody
-                  class="MuiTableBody-root f15luk9e css-apqrd9-MuiTableBody-root"
+                  class="MuiTableBody-root f5w6em2 css-apqrd9-MuiTableBody-root"
                 >
                   <tr
                     class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
@@ -456,7 +456,7 @@ exports[`Search by title/test name Should match snapshot 1`] = `
                     </td>
                   </tr>
                   <tr
-                    class="MuiTableRow-root revisionRow fju3wsp css-1yt2i5z-MuiTableRow-root"
+                    class="MuiTableRow-root revisionRow f131cxob css-1yt2i5z-MuiTableRow-root"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium platform css-15mfgc5-MuiTableCell-root"
@@ -645,7 +645,7 @@ exports[`Search by title/test name Should match snapshot 1`] = `
                     </td>
                   </tr>
                   <tr
-                    class="MuiTableRow-root revisionRow fju3wsp css-1yt2i5z-MuiTableRow-root"
+                    class="MuiTableRow-root revisionRow f131cxob css-1yt2i5z-MuiTableRow-root"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium platform css-15mfgc5-MuiTableCell-root"
@@ -834,7 +834,7 @@ exports[`Search by title/test name Should match snapshot 1`] = `
                     </td>
                   </tr>
                   <tr
-                    class="MuiTableRow-root revisionRow fju3wsp css-1yt2i5z-MuiTableRow-root"
+                    class="MuiTableRow-root revisionRow f131cxob css-1yt2i5z-MuiTableRow-root"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium platform css-15mfgc5-MuiTableCell-root"

--- a/src/__tests__/CompareResults/beta/__snapshots__/TableHeader.test.tsx.snap
+++ b/src/__tests__/CompareResults/beta/__snapshots__/TableHeader.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`Table Header Should match snapshot 1`] = `
       data-testid="table-header"
     >
       <tr
-        class="MuiTableRow-root MuiTableRow-head f1frk9dl css-1yt2i5z-MuiTableRow-root"
+        class="MuiTableRow-root MuiTableRow-head f1ctvkx8 css-1yt2i5z-MuiTableRow-root"
       >
         <th
           class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium platform-header css-hwty3m-MuiTableCell-root"

--- a/src/__tests__/CompareResults/beta/__snapshots__/TableHeader.test.tsx.snap
+++ b/src/__tests__/CompareResults/beta/__snapshots__/TableHeader.test.tsx.snap
@@ -9,14 +9,14 @@ exports[`Table Header Should match snapshot 1`] = `
       data-testid="table-header"
     >
       <tr
-        class="MuiTableRow-root MuiTableRow-head f81wnp2 css-1yt2i5z-MuiTableRow-root"
+        class="MuiTableRow-root MuiTableRow-head f1frk9dl css-1yt2i5z-MuiTableRow-root"
       >
         <th
-          class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+          class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium platform-header css-hwty3m-MuiTableCell-root"
           scope="col"
         >
           <div
-            class="f1076rq5"
+            class="fzi2oph"
           >
             <svg
               aria-hidden="true"
@@ -46,7 +46,7 @@ exports[`Table Header Should match snapshot 1`] = `
           </div>
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+          class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium base-header css-hwty3m-MuiTableCell-root"
           scope="col"
         >
           <div
@@ -58,7 +58,17 @@ exports[`Table Header Should match snapshot 1`] = `
           </div>
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+          class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium comparisonSign-header css-hwty3m-MuiTableCell-root"
+          scope="col"
+        >
+          <div
+            class=""
+          >
+            <span />
+          </div>
+        </th>
+        <th
+          class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium new-header css-hwty3m-MuiTableCell-root"
           scope="col"
         >
           <div
@@ -70,11 +80,11 @@ exports[`Table Header Should match snapshot 1`] = `
           </div>
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+          class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium status-header css-hwty3m-MuiTableCell-root"
           scope="col"
         >
           <div
-            class="f1076rq5"
+            class="fzi2oph"
           >
             <svg
               aria-hidden="true"
@@ -104,7 +114,7 @@ exports[`Table Header Should match snapshot 1`] = `
           </div>
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+          class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium delta-header css-hwty3m-MuiTableCell-root"
           scope="col"
         >
           <div
@@ -116,11 +126,11 @@ exports[`Table Header Should match snapshot 1`] = `
           </div>
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+          class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium confidence-header css-hwty3m-MuiTableCell-root"
           scope="col"
         >
           <div
-            class="f1076rq5"
+            class="fzi2oph"
           >
             <svg
               aria-hidden="true"
@@ -150,7 +160,7 @@ exports[`Table Header Should match snapshot 1`] = `
           </div>
         </th>
         <th
-          class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-hwty3m-MuiTableCell-root"
+          class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium runs-header css-hwty3m-MuiTableCell-root"
           scope="col"
         >
           <div
@@ -159,6 +169,17 @@ exports[`Table Header Should match snapshot 1`] = `
             <span>
               Total Runs
             </span>
+          </div>
+        </th>
+        <th
+          class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium empty-header css-hwty3m-MuiTableCell-root"
+          colspan="4"
+          scope="col"
+        >
+          <div
+            class=""
+          >
+            <span />
           </div>
         </th>
       </tr>

--- a/src/components/CompareResults/beta/ResultsMain.tsx
+++ b/src/components/CompareResults/beta/ResultsMain.tsx
@@ -1,18 +1,24 @@
 import { Container } from '@mui/system';
 import { style } from 'typestyle';
 
+import { Colors } from '../../../styles';
 import ResultsHeader from './ResultsHeader';
 import ResultsTable from './ResultsTable';
 
-const styles = {
-  container: style({
-    maxWidth: '950px',
-    margin: '0 auto',
-  }),
-};
-
 function ResultsMain(props: ResultsMainProps) {
   const { themeMode } = props;
+
+  const themeColor100 =
+    themeMode === 'light' ? Colors.Background300 : Colors.Background100Dark;
+
+  const styles = {
+    container: style({
+      backgroundColor: themeColor100,
+      maxWidth: '950px',
+      margin: '0 auto',
+    }),
+  };
+
   return (
     <Container className={styles.container} data-testid='results-main'>
       <ResultsHeader />

--- a/src/components/CompareResults/beta/ResultsTable.tsx
+++ b/src/components/CompareResults/beta/ResultsTable.tsx
@@ -15,13 +15,16 @@ const styles = {
 
 function ResultsTable(props: ResultsTableProps) {
   const { themeMode } = props;
-  
+
   return (
-    <TableContainer component={Paper} className={styles.tableContainer} data-testid='results-table'>
+    <TableContainer
+      component={Paper}
+      className={styles.tableContainer}
+      data-testid='results-table'
+    >
       <Table>
         <TableHeader themeMode={themeMode} />
-        {/* TODO: Add table body */}
-        <TableContent />
+        <TableContent themeMode={themeMode} />
       </Table>
     </TableContainer>
   );

--- a/src/components/CompareResults/beta/ResultsTable.tsx
+++ b/src/components/CompareResults/beta/ResultsTable.tsx
@@ -3,24 +3,39 @@ import Table from '@mui/material/Table';
 import TableContainer from '@mui/material/TableContainer';
 import { style } from 'typestyle';
 
-import { Spacing } from '../../../styles';
+import { Colors, Spacing } from '../../../styles';
 import TableContent from './TableContent';
 import TableHeader from './TableHeader';
 
-const styles = {
-  tableContainer: style({
-    marginTop: Spacing.Large,
-  }),
+
+const customStyles = {
+  boxShadow: 'none',
 };
 
 function ResultsTable(props: ResultsTableProps) {
   const { themeMode } = props;
+
+  const themeColor100 = themeMode === 'light' ? Colors.Background100 : Colors.Background100Dark;
+
+  const styles = {
+    tableContainer: style({
+      backgroundColor: themeColor100,
+      marginTop: Spacing.Large,
+      $nest: {
+        '.MuiTable-root': {
+          borderSpacing: `0 ${Spacing.Small}px`,
+          borderCollapse: 'separate',
+        },
+      },
+    }),
+  };
 
   return (
     <TableContainer
       component={Paper}
       className={styles.tableContainer}
       data-testid='results-table'
+      sx={customStyles}
     >
       <Table>
         <TableHeader themeMode={themeMode} />

--- a/src/components/CompareResults/beta/ResultsTable.tsx
+++ b/src/components/CompareResults/beta/ResultsTable.tsx
@@ -4,6 +4,7 @@ import TableContainer from '@mui/material/TableContainer';
 import { style } from 'typestyle';
 
 import { Spacing } from '../../../styles';
+import TableContent from './TableContent';
 import TableHeader from './TableHeader';
 
 const styles = {
@@ -17,14 +18,14 @@ function ResultsTable(props: ResultsTableProps) {
   
   return (
     <TableContainer component={Paper} className={styles.tableContainer} data-testid='results-table'>
-      <Table aria-label="collapsible table">
+      <Table>
         <TableHeader themeMode={themeMode} />
         {/* TODO: Add table body */}
+        <TableContent />
       </Table>
     </TableContainer>
   );
 }
-
 interface ResultsTableProps {
   themeMode: 'light' | 'dark';
 }

--- a/src/components/CompareResults/beta/RevisionHeader.tsx
+++ b/src/components/CompareResults/beta/RevisionHeader.tsx
@@ -1,0 +1,56 @@
+import { TableRow, TableCell, Link } from '@mui/material';
+import { style } from 'typestyle';
+
+import { Colors, Spacing } from '../../../styles';
+
+const styles = {
+  tagsOptions: style({
+    textAlign: 'right',
+    $nest: {
+      'span:nth-child(3n)': {
+        background: '#592ACB',
+      },
+      'span:nth-child(3n+1)': {
+        background: '#005E5E',
+      },
+      'span:nth-child(3n+2)': {
+        background: '#0250BB',
+      },
+    },
+  }),
+  chip: style({
+    borderRadius: '4px',
+    color: Colors.Background300,
+    // To be removed
+    fontFamily: 'SF Pro',
+    fontStyle: 'normal',
+    fontWeight: 700,
+    fontSize: '8.2px',
+    // End to be removed
+    gap: Spacing.Small + 2,
+    letterSpacing: '0.02em',
+    marginLeft: Spacing.xSmall,
+    padding: Spacing.xSmall,
+    textAlign: 'center',
+    textTransform: 'uppercase',
+  }),
+};
+
+function RevisionHeader() {
+  return (
+    <TableRow className='revision-header'>
+      <TableCell colSpan={8}>
+        Metric 1 <Link href='#'>0f9ef9ff3ea</Link>
+      </TableCell>
+      <TableCell colSpan={4}>
+        <div className={styles.tagsOptions}>
+          <span className={styles.chip}>e10s</span>
+          <span className={styles.chip}>stylo</span>
+          <span className={styles.chip}>fission</span>
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+export default RevisionHeader;

--- a/src/components/CompareResults/beta/RevisionHeader.tsx
+++ b/src/components/CompareResults/beta/RevisionHeader.tsx
@@ -40,7 +40,7 @@ function RevisionHeader() {
   return (
     <TableRow className='revision-header'>
       <TableCell colSpan={8}>
-        Metric 1 <Link href='#'>0f9ef9ff3ea</Link>
+        <strong>Metric 1</strong> <Link href='#'>0f9ef9ff3ea</Link>
       </TableCell>
       <TableCell colSpan={4}>
         <div className={styles.tagsOptions}>

--- a/src/components/CompareResults/beta/RevisionRow.tsx
+++ b/src/components/CompareResults/beta/RevisionRow.tsx
@@ -1,0 +1,85 @@
+import AppleIcon from '@mui/icons-material/Apple';
+import FileDownloadOutlinedIcon from '@mui/icons-material/FileDownloadOutlined';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import RefreshOutlinedIcon from '@mui/icons-material/RefreshOutlined';
+import TimelineIcon from '@mui/icons-material/Timeline';
+import { IconButton, TableRow, TableCell } from '@mui/material';
+import { style } from 'typestyle';
+
+const styles = {
+  revisionRow: style({
+    $nest: {
+      '.confidence': {
+        textAlign: 'center',
+      },
+      '.comparison-sign': {
+        textAlign: 'center',
+      },
+      '.delta': {
+        textAlign: 'center',
+      },
+      '.expand-button-container': {
+        textAlign: 'right',
+      },
+      '.new-value': {
+        textAlign: 'center',
+      },
+      '.platform-container': {
+        display: 'flex',
+      },
+      '.status': {
+        textAlign: 'center',
+      },
+      'total-runs': {
+        textAlign: 'center',
+      },
+      '.cell-button': {
+        textAlign: 'right',
+        width: '16px',
+      },
+    },
+  }),
+};
+
+function RevisionRow() {
+  return (
+    <TableRow className={styles.revisionRow}>
+      <TableCell className='platform'>
+        <div className='platform-container'>
+          <AppleIcon />
+          <span>Apple</span>
+        </div>
+      </TableCell>
+      <TableCell>771.39ms</TableCell>
+      <TableCell className='comparison-sign'>&gt;</TableCell>
+      <TableCell className='new-value'>771.39ms</TableCell>
+      <TableCell className='status'>Improvement</TableCell>
+      <TableCell className='delta'>2.5%</TableCell>
+      <TableCell className='confidence'>High</TableCell>
+      <TableCell>B:23 N:27</TableCell>
+      <TableCell className='cell-button'>
+        <TimelineIcon />
+      </TableCell>
+      <TableCell className='cell-button'>
+        <FileDownloadOutlinedIcon />
+      </TableCell>
+      <TableCell className='cell-button total-runs'>
+        <RefreshOutlinedIcon />
+      </TableCell>
+      <TableCell className='cell-button expand-button'>
+        <div className='expand-button-container'>
+          <IconButton
+            aria-label='expand row'
+            size='small'
+            // onClick={() => setOpen(!open)}
+          >
+            <KeyboardArrowDownIcon />
+            {/* {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />} */}
+          </IconButton>
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+export default RevisionRow;

--- a/src/components/CompareResults/beta/RevisionRow.tsx
+++ b/src/components/CompareResults/beta/RevisionRow.tsx
@@ -11,10 +11,10 @@ import { Colors, Spacing } from '../../../styles';
 function RevisionRow(props: RevisionRowProps) {
   const { themeMode } = props;
 
+  const expandButtonColor =
+    themeMode == 'light' ? Colors.Background300 : Colors.Background100Dark;
   const themeColor200 =
     themeMode == 'light' ? Colors.Background200 : Colors.Background200Dark;
-  const themeColor300 =
-    themeMode == 'light' ? Colors.Background300 : Colors.Background300Dark;
 
   const styles = {
     revisionRow: style({
@@ -69,14 +69,17 @@ function RevisionRow(props: RevisionRowProps) {
           cursor: 'not-allowed',
         },
         '.expand-button': {
-          backgroundColor: themeColor300,
+          backgroundColor: expandButtonColor,
+        },
+        '.MuiTableCell-root': {
+          borderBottom: 'none',
         },
         '.MuiTableCell-root:first-child': {
-          borderRadius: '10px 0 0 10px',
+          borderRadius: '4px 0 0 4px',
           backgroundColor: themeColor200,
         },
         '.MuiTableCell-root:nth-last-child(2)': {
-          borderRadius: '0 10px 10px 0',
+          borderRadius: '0 4px 4px 0',
           backgroundColor: themeColor200,
         },
       },

--- a/src/components/CompareResults/beta/RevisionRow.tsx
+++ b/src/components/CompareResults/beta/RevisionRow.tsx
@@ -6,80 +6,140 @@ import TimelineIcon from '@mui/icons-material/Timeline';
 import { IconButton, TableRow, TableCell } from '@mui/material';
 import { style } from 'typestyle';
 
-const styles = {
-  revisionRow: style({
-    $nest: {
-      '.confidence': {
-        textAlign: 'center',
-      },
-      '.comparison-sign': {
-        textAlign: 'center',
-      },
-      '.delta': {
-        textAlign: 'center',
-      },
-      '.expand-button-container': {
-        textAlign: 'right',
-      },
-      '.new-value': {
-        textAlign: 'center',
-      },
-      '.platform-container': {
-        display: 'flex',
-      },
-      '.status': {
-        textAlign: 'center',
-      },
-      'total-runs': {
-        textAlign: 'center',
-      },
-      '.cell-button': {
-        textAlign: 'right',
-        width: '16px',
-      },
-    },
-  }),
-};
+import { Colors, Spacing } from '../../../styles';
 
-function RevisionRow() {
+function RevisionRow(props: RevisionRowProps) {
+  const { themeMode } = props;
+
+  const themeColor200 =
+    themeMode == 'light' ? Colors.Background200 : Colors.Background200Dark;
+  const themeColor300 =
+    themeMode == 'light' ? Colors.Background300 : Colors.Background300Dark;
+
+  const styles = {
+    revisionRow: style({
+      $nest: {
+        '.base-value': {
+          backgroundColor: themeColor200,
+        },
+        '.confidence': {
+          backgroundColor: themeColor200,
+          textAlign: 'center',
+        },
+        '.comparison-sign': {
+          backgroundColor: themeColor200,
+          textAlign: 'center',
+        },
+        '.delta': {
+          backgroundColor: themeColor200,
+          textAlign: 'center',
+          marginBottom: Spacing.Small,
+        },
+        '.expand-button-container': {
+          textAlign: 'right',
+        },
+        '.new-value': {
+          backgroundColor: themeColor200,
+          textAlign: 'center',
+        },
+        '.platform-container': {
+          alignItems: 'center',
+          backgroundColor: themeColor200,
+          display: 'flex',
+        },
+        '.retrigger-button': {
+          backgroundColor: themeColor200,
+          cursor: 'not-allowed',
+          textAlign: 'center',
+        },
+        '.status': {
+          backgroundColor: themeColor200,
+          textAlign: 'center',
+        },
+        '.total-runs': {
+          backgroundColor: themeColor200,
+        },
+        '.cell-button': {
+          backgroundColor: themeColor200,
+          paddingTop: '3px',
+          textAlign: 'right',
+          width: '16px',
+        },
+        '.download': {
+          cursor: 'not-allowed',
+        },
+        '.expand-button': {
+          backgroundColor: themeColor300,
+        },
+        '.MuiTableCell-root:first-child': {
+          borderRadius: '10px 0 0 10px',
+          backgroundColor: themeColor200,
+        },
+        '.MuiTableCell-root:nth-last-child(2)': {
+          borderRadius: '0 10px 10px 0',
+          backgroundColor: themeColor200,
+        },
+      },
+    }),
+  };
   return (
-    <TableRow className={styles.revisionRow}>
+    <TableRow className={`revisionRow ${styles.revisionRow}`}>
       <TableCell className='platform'>
         <div className='platform-container'>
           <AppleIcon />
           <span>Apple</span>
         </div>
       </TableCell>
-      <TableCell>771.39ms</TableCell>
+      <TableCell className='base-value'>
+        <div className='base-container'>771.39ms</div>
+      </TableCell>
       <TableCell className='comparison-sign'>&gt;</TableCell>
       <TableCell className='new-value'>771.39ms</TableCell>
       <TableCell className='status'>Improvement</TableCell>
       <TableCell className='delta'>2.5%</TableCell>
       <TableCell className='confidence'>High</TableCell>
-      <TableCell>B:23 N:27</TableCell>
-      <TableCell className='cell-button'>
-        <TimelineIcon />
+      <TableCell className='total-runs'>
+        <span>B:</span>
+        <strong>23</strong> <span>N:</span>
+        <strong>27</strong>
       </TableCell>
-      <TableCell className='cell-button'>
-        <FileDownloadOutlinedIcon />
+      <TableCell className='cell-button graph'>
+        <div className='graph-link-button-container'>
+          <IconButton aria-label='graph link' size='small'>
+            <TimelineIcon />
+          </IconButton>
+        </div>
       </TableCell>
-      <TableCell className='cell-button total-runs'>
-        <RefreshOutlinedIcon />
+      <TableCell className='cell-button download'>
+        <div className='download-button-container'>
+          <IconButton aria-label='download' size='small' disabled>
+            <FileDownloadOutlinedIcon />
+          </IconButton>
+        </div>
+      </TableCell>
+      <TableCell className='cell-button retrigger-button'>
+        <div className='runs-button-container'>
+          <IconButton aria-label='retrigger button' size='small' disabled>
+            <RefreshOutlinedIcon />
+          </IconButton>
+        </div>
       </TableCell>
       <TableCell className='cell-button expand-button'>
         <div className='expand-button-container'>
           <IconButton
             aria-label='expand row'
             size='small'
-            // onClick={() => setOpen(!open)}
           >
             <KeyboardArrowDownIcon />
-            {/* {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />} */}
           </IconButton>
         </div>
       </TableCell>
     </TableRow>
   );
+}
+
+interface RevisionRowProps {
+  themeMode: 'light' | 'dark';
 }
 
 export default RevisionRow;

--- a/src/components/CompareResults/beta/TableContent.tsx
+++ b/src/components/CompareResults/beta/TableContent.tsx
@@ -1,38 +1,52 @@
 import { TableBody } from '@mui/material';
 import { style } from 'typestyle';
 
-import { Spacing } from '../../../styles';
+import { Colors, Spacing } from '../../../styles';
 import RevisionHeader from './RevisionHeader';
 import RevisionRow from './RevisionRow';
 
-const styles = {
-  tableBody: style({
-    marginTop: Spacing.Large,
-    $nest: {
-      '.MuiTableCell-root': {
-        padding: 0,
-      },
-      '.revision-header .MuiTableCell-root': {
-        padding: 0,
-        paddingTop: Spacing.Large,
-        paddingBottom: Spacing.Small,
-      },
-      '.platform': {
-        paddingLeft: Spacing.xLarge,
-      },
-    },
-  }),
-};
+function TableContent(props: TableContentProps) {
+  const { themeMode } = props;
 
-function TableContent() {
+  const themeColor300 =
+    themeMode == 'light' ? Colors.Background300 : Colors.Background300Dark;
+
+  const styles = {
+    tableBody: style({
+      marginTop: Spacing.Large,
+      borderSpacing: '0px 4px',
+      $nest: {
+        '.MuiTableCell-root': {
+          padding: 0,
+        },
+        '.revision-header .MuiTableCell-root': {
+          padding: 0,
+          paddingTop: Spacing.Large,
+          paddingBottom: Spacing.Small,
+        },
+        '.platform': {
+          paddingLeft: Spacing.xLarge,
+        },
+        '.revisionRow': {
+          borderBottom: `${Spacing.Small}px solid ${themeColor300}`,
+          backgroundColor: Colors.Background200,
+          margin: '4px 0px',
+        },
+      },
+    }),
+  };
   return (
     <TableBody className={styles.tableBody}>
       <RevisionHeader />
-      <RevisionRow />
-      <RevisionRow />
-      <RevisionRow />
+      <RevisionRow themeMode={themeMode} />
+      <RevisionRow themeMode={themeMode} />
+      <RevisionRow themeMode={themeMode} />
     </TableBody>
   );
+}
+
+interface TableContentProps {
+  themeMode: 'light' | 'dark';
 }
 
 export default TableContent;

--- a/src/components/CompareResults/beta/TableContent.tsx
+++ b/src/components/CompareResults/beta/TableContent.tsx
@@ -1,0 +1,38 @@
+import { TableBody } from '@mui/material';
+import { style } from 'typestyle';
+
+import { Spacing } from '../../../styles';
+import RevisionHeader from './RevisionHeader';
+import RevisionRow from './RevisionRow';
+
+const styles = {
+  tableBody: style({
+    marginTop: Spacing.Large,
+    $nest: {
+      '.MuiTableCell-root': {
+        padding: 0,
+      },
+      '.revision-header .MuiTableCell-root': {
+        padding: 0,
+        paddingTop: Spacing.Large,
+        paddingBottom: Spacing.Small,
+      },
+      '.platform': {
+        paddingLeft: Spacing.xLarge,
+      },
+    },
+  }),
+};
+
+function TableContent() {
+  return (
+    <TableBody className={styles.tableBody}>
+      <RevisionHeader />
+      <RevisionRow />
+      <RevisionRow />
+      <RevisionRow />
+    </TableBody>
+  );
+}
+
+export default TableContent;

--- a/src/components/CompareResults/beta/TableContent.tsx
+++ b/src/components/CompareResults/beta/TableContent.tsx
@@ -8,13 +8,9 @@ import RevisionRow from './RevisionRow';
 function TableContent(props: TableContentProps) {
   const { themeMode } = props;
 
-  const themeColor300 =
-    themeMode == 'light' ? Colors.Background300 : Colors.Background300Dark;
-
   const styles = {
     tableBody: style({
       marginTop: Spacing.Large,
-      borderSpacing: '0px 4px',
       $nest: {
         '.MuiTableCell-root': {
           padding: 0,
@@ -28,9 +24,8 @@ function TableContent(props: TableContentProps) {
           paddingLeft: Spacing.xLarge,
         },
         '.revisionRow': {
-          borderBottom: `${Spacing.Small}px solid ${themeColor300}`,
           backgroundColor: Colors.Background200,
-          margin: '4px 0px',
+          margin: `${Spacing.Small}px 0px`,
         },
       },
     }),

--- a/src/components/CompareResults/beta/TableHeader.tsx
+++ b/src/components/CompareResults/beta/TableHeader.tsx
@@ -39,9 +39,16 @@ function TableHeader(props: TableHeaderProps) {
           textAlign: 'left',
         },
         '.MuiTableCell-root': {
+          borderBottom: 'none',
           padding: 0,
           margin: 0,
           textAlign: 'center',
+        },
+        '.MuiTableCell-root:first-child': {
+          borderRadius: '4px 0 0 4px',
+        },
+        '.MuiTableCell-root:last-child': {
+          borderRadius: '0 4px 4px 0',
         },
       },
     }),

--- a/src/components/CompareResults/beta/TableHeader.tsx
+++ b/src/components/CompareResults/beta/TableHeader.tsx
@@ -1,8 +1,6 @@
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import SortIcon from '@mui/icons-material/Sort';
-import TableCell from '@mui/material/TableCell';
-import TableHead from '@mui/material/TableHead';
-import TableRow from '@mui/material/TableRow';
+import { TableRow, TableCell, TableHead } from '@mui/material';
 import { style } from 'typestyle';
 
 import { Colors, Spacing } from '../../../styles';
@@ -14,11 +12,40 @@ function TableHeader(props: TableHeaderProps) {
       background:
         themeMode == 'light' ? Colors.Background100 : Colors.Background300Dark,
       borderRadius: '4px',
-      display: 'flex',
+      // To be removed
+      fontFamily: 'SF Pro',
+      fontStyle: 'normal',
+      fontWeight: 590,
+      fontSize: '13px',
+      lineHeight: '16px',
+      // End to be removed
       flexDirection: 'row',
       maxWidth: '950px',
       padding: Spacing.Small,
+      $nest: {
+        '.platform-header, .confidence-header': {
+          width: '120px',
+        },
+        '.status-header': {
+          width: '110px',
+        },
+        '.base-header, .new-header, .delta-header': {
+          width: '85px',
+        },
+        '.confidence-header': {
+          width: '140px',
+        },
+        '.MuiTableCell-root.runs-header': {
+          textAlign: 'left',
+        },
+        '.MuiTableCell-root': {
+          padding: 0,
+          margin: 0,
+          textAlign: 'center',
+        },
+      },
     }),
+
     filter: style({
       background:
         themeMode == 'light' ? Colors.Background200 : Colors.Background200Dark,
@@ -26,7 +53,9 @@ function TableHeader(props: TableHeaderProps) {
       cursor: 'not-allowed',
       display: 'flex',
       gap: Spacing.Small,
-      padding: `${Spacing.Small}px ${Spacing.Medium}px`,
+      margin: Spacing.Small,
+      padding: `${Spacing.Small}px ${Spacing.Small}px`,
+      width: 'fit-content',
     }),
   };
 
@@ -35,34 +64,45 @@ function TableHeader(props: TableHeaderProps) {
       name: 'Platform',
       disable: true,
       filter: true,
+      key: 'platform',
       sort: true,
     },
     {
       name: 'Base',
+      key: 'base',
     },
-    { name: 'New' },
+    { key: 'comparisonSign' },
+    { name: 'New', key: 'new' },
     {
       name: 'Status',
       disable: true,
       filter: true,
+      key: 'status',
       sort: true,
     },
     {
       name: 'Delta(%)',
+      key: 'delta',
     },
     {
       name: 'Confidence',
       disable: true,
       filter: true,
+      key: 'confidence',
       sort: true,
     },
-    { name: 'Total Runs' },
+    { name: 'Total Runs', key: 'runs' },
+    { colSpan: 4, key: 'empty' },
   ];
   return (
     <TableHead data-testid='table-header'>
       <TableRow className={styles.headerRow}>
         {headerCells.map((header) => (
-          <TableCell key={header.name + 'Header'}>
+          <TableCell
+            key={`${header.key}`}
+            className={`${header.key}-header`}
+            colSpan={header.colSpan || undefined}
+          >
             <div className={header.filter ? styles.filter : ''}>
               {header.sort ? <SortIcon /> : null}
               <span>{header.name}</span>

--- a/src/styles/Document.ts
+++ b/src/styles/Document.ts
@@ -1,6 +1,6 @@
 import { cssRule } from 'typestyle';
 
-cssRule('html, body, .perf-body', {
+cssRule('html, body', {
   margin: 0,
   padding: 0,
 });

--- a/src/styles/Document.ts
+++ b/src/styles/Document.ts
@@ -1,6 +1,6 @@
 import { cssRule } from 'typestyle';
 
-cssRule('html, body', {
+cssRule('html, body, .perf-body', {
   margin: 0,
   padding: 0,
 });


### PR DESCRIPTION
This can be tested on route /#/beta/compare-results

This PR fulfills  [PCF-227 Results: Display single table component for revision test result](https://mozilla-hub.atlassian.net/browse/PCF-227)

- [ ] Display the tables
- [ ] Graph link
- [ ] Profiles download buttons for base and new revision displayed in disable mode
- [ ] Retrigger button displayed in disable mode
- [ ] Arrow icon for expanding the rows
- [ ] Header contains metric name, revision hash and options

![image](https://github.com/mozilla/perfcompare/assets/63001299/93d3e221-52de-46c3-bac2-643c61ca61eb)
