### PR TITLE
Fix test

### DIFF
--- a/src/__tests__/accessiblity/accessibility.test.tsx
+++ b/src/__tests__/accessiblity/accessibility.test.tsx
@@ -14,11 +14,11 @@ import { renderWithRouter, store } from '../utils/setupTests';
 expect.extend(toHaveNoViolations);
 
 describe('Accessibility', () => {
-  beforeAll(() => {
+  beforeEach(() => {
     jest.useRealTimers();
   });
 
-  afterAll(() => {
+  afterEach(() => {
     jest.useFakeTimers();
   });
 


### PR DESCRIPTION
I noticed, after updating my local staging branch, that the accessibility test times out due to one of the changes in the recent #317. I was not able to figure out the reason for that change.
This PR simply reverses the change involved and all tests are, once again, running to completion (and passing).