### PR TITLE
Update tests for the new SearchView component

### DIFF
--- a/src/__tests__/Search/SearchViewBeta.test.tsx
+++ b/src/__tests__/Search/SearchViewBeta.test.tsx
@@ -1,26 +1,276 @@
 import { renderHook } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { act } from 'react-dom/test-utils';
 
 import SearchViewBeta from '../../components/Search/beta/SearchView';
 import useProtocolTheme from '../../theme/protocolTheme';
-import { renderWithRouter } from '../utils/setupTests';
+import { Revision } from '../../types/state';
+import getTestData from '../utils/fixtures';
+import { renderWithRouter, store } from '../utils/setupTests';
+import { screen } from '../utils/test-utils';
+
+const protocolTheme = renderHook(() => useProtocolTheme()).result.current
+.protocolTheme;
+
+const toggleColorMode = renderHook(() => useProtocolTheme()).result.current
+.toggleColorMode;
+function renderComponent() {
+
+  
+  renderWithRouter(
+    <SearchViewBeta
+      toggleColorMode={toggleColorMode}
+      protocolTheme={protocolTheme}
+    />,
+  );
+}
+
+
+function fetchTestData(data: Revision[]) {
+  
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      json: () => ({
+        results: data,
+      }),
+    }),
+  ) as jest.Mock;
+  jest.spyOn(global, 'fetch');
+}
 
 describe('Search View', () => {
-  const protocolTheme = renderHook(() => useProtocolTheme()).result.current
-    .protocolTheme;
 
-  const toggleColorMode = renderHook(() => useProtocolTheme()).result.current
-    .toggleColorMode;
 
   it('renders correctly when there are no results', async () => {
-    renderWithRouter(
-      <SearchViewBeta
-        toggleColorMode={toggleColorMode}
-        protocolTheme={protocolTheme}
-      />,
-    );
+renderComponent();
+
+    // We have to account for the dropdown position
+    //Shift focus to base search
 
     expect(document.body).toMatchSnapshot();
     await act(async () => void jest.runOnlyPendingTimers());
   });
+
+
+});
+
+describe('Search Container', ()=> {
+
+
+it('renders compare with base', async ()=> {
+  renderComponent();
+
+  const title = screen.getByText('Compare with a base');
+  const baseInput = screen.getByPlaceholderText('Search base by ID number or author email');
+  const repoDropdown = screen.getByTestId('dropdown-select');
+
+  expect(title).toBeInTheDocument(); 
+  expect(baseInput).toBeInTheDocument(); 
+  expect(repoDropdown).toBeInTheDocument();
+  screen.debug();
+});
+});
+
+describe('Base Search', ()=> {
+it('renders repository dropdown in closed condition', async ()=> {
+
+  renderComponent();
+  // 'try' is selected by default and dropdown is not visible
+      expect(screen.queryByText(/try/i)).toBeInTheDocument();
+      expect(screen.queryByText(/autoland/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/mozilla-central/i)).not.toBeInTheDocument();
+
+          // Search input appears
+    expect(
+      screen.getByPlaceholderText(/Search base by ID number or author email/i),
+    ).toBeInTheDocument();
+
+    // No list items should appear
+    expect(screen.queryByRole('listitem')).not.toBeInTheDocument();
+
+    await act(async () => void jest.runOnlyPendingTimers());
+});
+
+
+it('should hide search results when clicking outside of search input', async ()=>{
+  const { testData } = getTestData();
+    fetchTestData(testData);
+    // set delay to null to prevent test time-out due to useFakeTimers
+    const user = userEvent.setup({ delay: null });
+    renderComponent();
+
+    //Click inside the input box to show search results.
+
+    const searchInput = screen.getByRole('textbox');
+    await user.click(searchInput);
+
+    expect(store.getState().search.searchResults).toStrictEqual(testData);
+   
+    const comment = await screen.findAllByText("you've got no arms left!");
+    expect(comment[0]).toBeInTheDocument();
+
+    //Click outside the input box to hide search results.
+
+    const label = screen.getByLabelText('Base');
+    await user.click(label);
+    expect(comment[0]).not.toBeInTheDocument();
+
+
+
+});
+
+it('Should hide the search results when Escape key is pressed', async ()=>{
+  const { testData } = getTestData();
+ fetchTestData(testData);
+  // set delay to null to prevent test time-out due to useFakeTimers
+  const user = userEvent.setup({ delay: null });
+  renderComponent();
+
+   //Click inside the input box to show search results.
+
+   const searchInput = screen.getByRole('textbox');
+   await user.click(searchInput);
+
+   expect(store.getState().search.searchResults).toStrictEqual(testData);
+
+   const comment = await screen.findAllByText("you've got no arms left!");
+   expect(comment[0]).toBeInTheDocument();
+
+   //Press Escape key to hide search results.
+
+   await user.keyboard('{Escape}');
+   expect(comment[0]).not.toBeInTheDocument();
+
+});
+
+it('Should not call fetch if search value is not a hash or email', async ()=>{
+  const spyOnFetch = jest.spyOn(global, 'fetch');
+  // set delay to null to prevent test time-out due to useFakeTimers
+  const user = userEvent.setup({ delay: null });
+  renderComponent();
+
+  const searchInput = screen.getByRole('textbox');
+
+  await user.type(searchInput, 'coconut');
+  await user.clear(searchInput);
+
+  await user.type(searchInput, 'spam@eggs');
+  await user.clear(searchInput);
+  await user.type(searchInput, 'spamspamspamand@eggs.');
+  await user.clear(searchInput);
+  await user.type(searchInput, 'iamalmostlongenoughtobeahashbutnotquite');
+
+  await screen.findByText(
+    'Search must be a 12- or 40-character hash, or email address',
+  );
+
+  // fetch should only be called on initial load
+  expect(spyOnFetch).toHaveBeenCalledTimes(1);
+});
+
+
+it('Should clear search results if the search value is cleared', async ()=>{
+  const { testData } = getTestData();
+ fetchTestData(testData);
+  // set delay to null to prevent test time-out due to useFakeTimers
+  const user = userEvent.setup({ delay: null });
+  renderComponent();
+
+  // await screen.findByRole('button', { name: 'repository' })
+
+  const searchInput = screen.getByRole('textbox');
+  await user.type(searchInput, 'terryjones@python.com');
+  jest.runOnlyPendingTimers();
+  const spyOnFetch = jest.spyOn(global, 'fetch');
+
+  expect(spyOnFetch).toHaveBeenCalledWith(
+    'https://treeherder.mozilla.org/api/project/try/push/?author=terryjones@python.com',
+  );
+
+  await screen.findAllByText("you've got no arms left!");
+  expect(store.getState().search.searchResults).toStrictEqual(testData);
+  await user.clear(searchInput);
+  expect(store.getState().search.searchResults).toStrictEqual([]);
+  expect(
+    screen.queryByText("you've got no arms left!"),
+  ).not.toBeInTheDocument();
+});
+
+
+it('should not hide search results when clicking search results', async ()=>{
+  const { testData } = getTestData();
+ fetchTestData(testData);
+  // set delay to null to prevent test time-out due to useFakeTimers
+  const user = userEvent.setup({ delay: null });
+  renderComponent();
+
+   // focus input to show results
+   const searchInput = screen.getByRole('textbox');
+   await user.click(searchInput);
+
+   await screen.findAllByText("you've got no arms left!");
+   expect(
+     screen.getAllByText("it's just a flesh wound")[0],
+   ).toBeInTheDocument();
+   await user.click(screen.getAllByText("you've got no arms left!")[0]);
+   await user.click(screen.getAllByTestId('CheckBoxOutlineBlankIcon')[0]);
+
+   expect(
+     screen.queryAllByText("you've got no arms left!")[0],
+   ).toBeInTheDocument();
+   expect(
+     screen.queryAllByText("it's just a flesh wound")[0],
+   ).toBeInTheDocument();
+
+
+});
+
+it('should update error state with generic message if fetch error is undefined', async () => {
+  global.fetch = jest.fn(() => Promise.reject(new Error())) as jest.Mock;
+  const spyOnFetch = jest.spyOn(global, 'fetch');
+  renderComponent();
+
+  await act(async () => void jest.runOnlyPendingTimers());
+
+  expect(spyOnFetch).toHaveBeenCalledWith(
+    'https://treeherder.mozilla.org/api/project/try/push/?hide_reviewbot_pushes=true',
+  );
+  expect(store.getState().search.searchResults).toStrictEqual([]);
+  expect(store.getState().search.inputError).toBe(true);
+  expect(store.getState().search.inputHelperText).toBe(
+    'An error has occurred',
+  );
+});
+
+
+it('disable adding more than one revision for the base search', async ()=>{
+  const { testData } = getTestData();
+ fetchTestData(testData);
+  // set delay to null to prevent test time-out due to useFakeTimers
+  const user = userEvent.setup({ delay: null });
+  renderComponent();
+
+   // focus input to show results
+   const searchInput = screen.getByRole('textbox');
+   await user.click(searchInput);
+
+   await screen.findAllByText("you've got no arms left!");
+   expect(
+     screen.getAllByText("it's just a flesh wound")[0],
+   ).toBeInTheDocument();
+   await user.click(screen.getAllByText("you've got no arms left!")[0]);
+   await user.click(screen.getAllByText("it's just a flesh wound")[0]);
+
+  const error = screen.getByText(/maximum 1 revision\(s\)\./i);
+
+   expect(error).toBeInTheDocument();
+   expect(
+     screen.queryAllByText("you've got no arms left!")[0],
+   ).toBeInTheDocument();
+   expect(
+     screen.queryAllByText("it's just a flesh wound")[0],
+   ).toBeInTheDocument();
+
+
+});
 });

--- a/src/__tests__/Search/__snapshots__/SearchViewBeta.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchViewBeta.test.tsx.snap
@@ -153,6 +153,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                       </label>
                       <div
                         class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl dropdown-select css-1q6aue5-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+                        data-testid="dropdown-select"
                       >
                         <div
                           aria-expanded="false"

--- a/src/components/Search/beta/SearchDropdown.tsx
+++ b/src/components/Search/beta/SearchDropdown.tsx
@@ -90,6 +90,7 @@ function SearchDropdown(props: SearchDropdownProps) {
           </Tooltip>
         </InputLabel>
         <Select
+        data-testid = "dropdown-select"
           label={selectLabel}
           value={repository}
           labelId='select-repository-label'


### PR DESCRIPTION
## Hi ✋ 
# In this pull request

### The following tests were updated for the Search View Beta component.

- Searchview renders correctly when there are no results.
- Search container renders "compare with base".
- Base Search renders repository dropdown in closed condition.
- Base Search should hide search results when clicking outside of search input.
- Base Search should hide the search results when Escape key is pressed.
- Base Search should not call fetch if search value is not a hash or email.
- Base search should clear search results if the search value is cleared.
- Base search should not hide search results when clicking search results.
- Base search should update error state with generic message if fetch error is undefined.
- Base search should disable adding more than one revision for the base search.

**Note:** Similar tests were previously used for the search view component, they have been updated and configured to test the new `SearchViewBeta` component.
For now, only the Base search has been tested. Later the tests for Revision Search will also be added. 


### Refactors

- Search view component render operation has been abstracted away with a reusable function `renderComponent()`.
- Test data fetch operation has been abstracted away with a reusable function `fetchTestData()` which takes `data` as its argument.

![image](https://github.com/mozilla/perfcompare/assets/60618877/66b192fc-f8b2-47e7-8181-a3a924478b56)

