### PR TITLE
Fix: Fonts not loading on deployment

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -34,6 +34,9 @@ const config: Config.InitialOptions = {
     '^react-native$': 'react-native-web',
     '^.+\\.module\\.(css|sass|scss)$': 'identity-obj-proxy',
     '\\.(css)$': 'identity-obj-proxy',
+    '\\.(woff|woff2|ttf)$': '<rootDir>/src/mockData/mockedFonts/Metropolis-Bold.woff2',
+  
+
   },
   moduleFileExtensions: [
     'js',

--- a/src/mockData/mockedFonts/Metropolis-Bold.woff2
+++ b/src/mockData/mockedFonts/Metropolis-Bold.woff2
@@ -1,0 +1,1 @@
+module.exports = '../../../public/fonts/Metropolis-Bold.woff2';

--- a/src/styles/Fonts.ts
+++ b/src/styles/Fonts.ts
@@ -1,15 +1,17 @@
 import { style, fontFace } from 'typestyle';
 
+import metropolisFontURL from '../../public/fonts/Metropolis-Bold.woff2';
+import sfFontURL from '../../public/fonts/sf-pro-text-regular.woff';
 import { Colors } from './Colors';
 
 fontFace({
   fontFamily: 'Metropolis',
-  src: 'url("fonts/Metropolis-Bold.woff2") format("woff2")',
+  src: `url(${metropolisFontURL}) format("woff2")`,
 });
 
 fontFace({
   fontFamily: 'SF Pro',
-  src: 'url("fonts/sf-pro-text-regular.woff") format("woff")',
+  src: `url(${sfFontURL}) format("woff")`,
 });
 
 const sharedFontStyles = {

--- a/src/types/custom.d.ts
+++ b/src/types/custom.d.ts
@@ -2,3 +2,13 @@ declare module '*.svg' {
   const content: React.FunctionComponent<React.SVGAttributes<SVGElement>>;
   export default content;
 }
+
+declare module '*.woff' {
+  const content: string;
+  export = content;
+}
+
+declare module '*.woff2' {
+  const content: string;
+  export = content;
+}


### PR DESCRIPTION
## In this pull request

#### The font not downloading issue #477  in the deployed application has been fixed.

**Problem**
 The location of the local fonts when referenced from the typestyle's method `fontFace` did not work well with the webpack configuration.
 
 **Fix**
Multiple fixes were tried but the best possible solution was found on the **typestyle** github repository in a closed [issue](https://github.com/typestyle/typestyle/issues). 

- [x] Imported the font URLs and added them as variables in `styles/Fonts.ts` to be used by Typestyle's fontFace() method as its url. 

```

// Imports just the URL
import metropolisFontURL from '../../public/fonts/Metropolis-Bold.woff2';
import sfFontURL from '../../public/fonts/sf-pro-text-regular.woff';

```

- [x] Added types for fonts in `src/types/custom.d.ts`.

- [x] Added config in `jest.config.js` and its corresponding mock font file in the `src/mockData` directory to make sure the tests are running properly. 
