### PR TITLE
Add no results found message

### DIFF
--- a/src/components/CompareResults/beta/NoResultsFound.tsx
+++ b/src/components/CompareResults/beta/NoResultsFound.tsx
@@ -1,0 +1,31 @@
+import SearchIcon from '@mui/icons-material/Search';
+import Grid from '@mui/material/Grid';
+import { Container } from '@mui/system';
+import { style } from 'typestyle';
+
+import { Strings } from '../../../resources/Strings';
+
+function NoResultsFound() {
+  const noResultsFound = Strings.components.noResultsFound;
+
+  const styles = {
+    text: style({
+        textAlign: 'center',
+        marginBottom: '80px',
+    }),
+  }; 
+
+  return (
+    <Container>
+      <Grid container alignItems='center' justifyContent='center'>
+        <div className={`${styles.text}`}>
+            <div><SearchIcon fontSize="large" /><br /></div>
+            <b>{noResultsFound.mainMessage}</b><br />
+            {noResultsFound.note}<br />
+        </div>
+      </Grid>
+    </Container>
+  );
+}
+
+export default NoResultsFound;

--- a/src/resources/Strings.tsx
+++ b/src/resources/Strings.tsx
@@ -59,5 +59,9 @@ export const Strings = {
        PLEASE CHECK THE HISTORICAL GRAPH ABOVE TO VALIDATE THIS RESULT \
        ("NOISY" TESTS MAY RETURN INCONSISTENT RESULTS).',
     },
+    noResultsFound: {
+      mainMessage: 'No results found',
+      note: 'For the selected revision(s), no results when compared to the base revision.',
+    },
   },
 };


### PR DESCRIPTION
![no-results-found](https://github.com/mozilla/perfcompare/assets/69891317/bcdba25f-796f-42a2-82a2-cc4f5a495805)
