### PR TITLE
Implement aria-live attribute for notistack alerts

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -63,6 +63,7 @@ module.exports = {
       rules: {
         // https://github.com/typescript-eslint/typescript-eslint/issues/1824
         '@typescript-eslint/indent': 'off',
+        'react/prop-types': ['off']
       },
     },
     {

--- a/src/__tests__/Snackbar.test.tsx
+++ b/src/__tests__/Snackbar.test.tsx
@@ -46,6 +46,31 @@ describe('Snackbar', () => {
     expect(alert).not.toBeInTheDocument();
   });
 
+  it('should have aria-live attribute', async () => {
+    const { testData } = getTestData();
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () => ({
+          results: testData,
+        }),
+      }),
+    ) as jest.Mock;
+    // set delay to null to prevent test time-out due to useFakeTimers
+    const user = userEvent.setup({ delay: null });
+
+    render(<App />);
+
+    // focus input to show results
+    const searchInput = screen.getAllByRole('textbox')[0];
+    await user.click(searchInput);
+
+    await user.click(screen.getAllByTestId('checkbox-0')[0]);
+    await user.click(screen.getAllByTestId('checkbox-1')[0]);
+
+    const alert = screen.getAllByRole('alert')[0];
+    expect(alert).toHaveAttribute('aria-live');
+  });
+
   it('should dismiss an alert after 6 seconds', async () => {
     const { testData } = getTestData();
     global.fetch = jest.fn(() =>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -31,7 +31,7 @@ const AlertContainer = React.forwardRef<HTMLDivElement>((props, ref) => (
 AlertContainer.displayName = 'AlertContainer';
 
 function App() {
-  const [alertContainer, setAlertContainer] = useState<HTMLDivElement | null>(null)
+  const [alertContainer, setAlertContainer] = useState<HTMLDivElement | null>(null);
   const { protocolTheme, toggleColorMode } = useProtocolTheme();
   return (
     <ThemeProvider theme={protocolTheme}>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,3 +1,5 @@
+import React, { useState } from 'react';
+
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import CssBaseline from '@mui/material/CssBaseline';
@@ -19,11 +21,25 @@ const strings: BannerStrings = {
   linkText: Strings.components.topBanner.linkText,
   href: Strings.components.topBanner.href,
 };
+
+const AlertContainer = React.forwardRef<HTMLDivElement>((props, ref) => (
+  <div ref={ref}  className="alert-container" role='alert' aria-live={'assertive'}>
+      {props.children}
+  </div>
+));
+
+AlertContainer.displayName = 'AlertContainer';
+
 function App() {
+  const [alertContainer, setAlertContainer] = useState<HTMLDivElement | null>(null)
   const { protocolTheme, toggleColorMode } = useProtocolTheme();
   return (
     <ThemeProvider theme={protocolTheme}>
+      
+      <AlertContainer ref={setAlertContainer}/>
+      {alertContainer ?
       <SnackbarProvider
+        domRoot={alertContainer}
         maxSnack={3}
         autoHideDuration={6000}
         action={(snackbarKey) => (
@@ -64,6 +80,7 @@ function App() {
           </Routes>
         </Router>
       </SnackbarProvider>
+      : null }
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
## This PR adds `aria-live` attribute to notistack alerts. 
Is part of solution for #486 issue.
### Context
It is very important for a user with visual impairment to know how the interface is reacting to their requests in real-time. It requires us to make sure that alerts are announced to someone using assistive technologies such as a screen reader. For this reason, we use the `aria-live` attribute. 
Aria-live attribute exposes the alert message in the accessibility tree so the screen reader can announce the message in real-time as the alert goes off.

### How it was implemented

Faced with the issue that custom attributes cannot be added to notistack alert itself. The `domRoot` attribute made available by notistack  in `<snackbarProvider>` is passed with an alert container that contains the alert and holds the `aria-live` attribute.
A component is used for this container. This component forwards its `div` element via `forwardRef`. Finally, the element is managed with the `useState()` hook.

- Added `'react/prop-types' : [ 'off' ]` to eslint configuration as the type checking for props is present by default in TypeScript.

- Added test to check for `aria-live` attribute in the notistack alerts in `Snackbar.test.tsx`.

![image](https://github.com/mozilla/perfcompare/assets/60618877/be6b420c-a32a-4301-9db0-e717bb966978)



   