### PR TITLE
Update version of typescript target and slightly update babel config

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,13 +1,5 @@
 {
   "targets": ["last 2 chrome versions", "last 2 firefox versions"],
-  "plugins": [
-    [
-      "@babel/plugin-transform-runtime",
-      {
-        "regenerator": true
-      }
-    ]
-  ],
   "presets": [
     "@babel/preset-env",
     ["@babel/preset-react", { "runtime": "automatic" }],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "allowJs": true, // allow a partial TypeScript and JavaScript codebase
     "esModuleInterop": true,
     "jsx": "react-jsx", // use typescript to transpile jsx to js
-    "module": "es6", // specify module code generation
+    "module": "es2022", // specify module code generation
     "moduleResolution": "node",
     "noEmit": true, // do not emit output files
     "outDir": "./build/", // path to output directory
@@ -12,7 +12,7 @@
     "skipLibCheck": true, // skip type checking of default library declaration files
     "strict": true,
     "strictNullChecks": true, // enable strict null checks as a best practice
-    "target": "es5" // specify ECMAScript target version
+    "target": "es2022" // specify ECMAScript target version
   },
   "include": ["./src/"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
tsconfig was targeting an old version of javascript, which could trigger typescript error when using newer features of javascript.

I checked on https://kangax.github.io/compat-table/es2016plus/, and it looks like all browsers support es2022 just fine, except one minor thing in RegExp that we don't use.

I also removed an outdated configuration in babel.

I checked that all scripts were still working correctly and that the project would build. Please double check and with your IDE too, to see if everything looks right on your end too!