### PR TITLE
selected revisions in results view

### DIFF
--- a/src/__tests__/CompareResults/beta/ResultsView.test.tsx
+++ b/src/__tests__/CompareResults/beta/ResultsView.test.tsx
@@ -71,6 +71,7 @@ describe('Results View', () => {
     expect(
       screen.getAllByTestId('selected-revs-compare-results')[0],
     ).toBeInTheDocument();
+    expect(screen.getAllByTestId('selected-rev-item')[0]).toBeInTheDocument();
   });
 
   it('should remove the selected revision once X button is clicked', async () => {
@@ -105,16 +106,17 @@ describe('Results View', () => {
       '[aria-label="close-button"]',
     );
 
-    expect(
-      screen.getAllByTestId('selected-revs-compare-results')[0],
-    ).toBeInTheDocument();
+    const removeIcon = screen.getByTestId('close-icon');
+    expect(removeIcon).toBeInTheDocument();
+    expect(screen.getAllByTestId('selected-rev-item')[1]).toBeInTheDocument();
 
     await user.click(removeButton[0]);
 
     act(() => {
       expect(store.getState().selectedRevisions.new).toEqual([]);
     });
-    expect(screen.queryAllByTestId('selected-rev-item')[0]).toBeUndefined();
+
+    expect(screen.queryAllByTestId('selected-rev-item')[1]).toBeUndefined();
   });
 
   it('Should expand on click', async () => {

--- a/src/__tests__/CompareResults/beta/ResultsView.test.tsx
+++ b/src/__tests__/CompareResults/beta/ResultsView.test.tsx
@@ -55,12 +55,10 @@ describe('Results View', () => {
     jest.spyOn(global, 'fetch');
 
     renderWithRouter(
-      <>
-        <ResultsView
-          protocolTheme={protocolTheme}
-          toggleColorMode={toggleColorMode}
-        />
-      </>,
+      <ResultsView
+        protocolTheme={protocolTheme}
+        toggleColorMode={toggleColorMode}
+      />,
     );
 
     const selectedRevisions = testData.slice(0, 5);
@@ -73,6 +71,50 @@ describe('Results View', () => {
     expect(
       screen.getAllByTestId('selected-revs-compare-results')[0],
     ).toBeInTheDocument();
+  });
+
+  it('should remove the selected revision once X button is clicked', async () => {
+    const { testData } = getTestData();
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () => ({
+          results: testData,
+        }),
+      }),
+    ) as jest.Mock;
+    jest.spyOn(global, 'fetch');
+
+    // set delay to null to prevent test time-out due to useFakeTimers
+    const user = userEvent.setup({ delay: null });
+
+    const selectedRevisions = testData.slice(0, 2);
+    await act(async () => {
+      store.dispatch(
+        setSelectedRevisions({ selectedRevisions: selectedRevisions }),
+      );
+    });
+
+    renderWithRouter(
+      <ResultsView
+        protocolTheme={protocolTheme}
+        toggleColorMode={toggleColorMode}
+      />,
+    );
+
+    const removeButton = document.querySelectorAll(
+      '[aria-label="close-button"]',
+    );
+
+    expect(
+      screen.getAllByTestId('selected-revs-compare-results')[0],
+    ).toBeInTheDocument();
+
+    await user.click(removeButton[0]);
+
+    act(() => {
+      expect(store.getState().selectedRevisions.new).toEqual([]);
+    });
+    expect(screen.queryAllByTestId('selected-rev-item')[0]).toBeUndefined();
   });
 
   it('Should expand on click', async () => {

--- a/src/__tests__/CompareResults/beta/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/beta/__snapshots__/ResultsView.test.tsx.snap
@@ -105,264 +105,56 @@ exports[`Results View Should match snapshot 1`] = `
                 class="MuiGrid-root component_f14z0jsa css-plh9qo-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-container container_f790aiy css-1ljzhs0-MuiGrid-root"
-                  id="base-search-container"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_ffz7cf5 css-13eijkh-MuiGrid-root"
+                  id="base_search-dropdown"
                 >
-                  <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_ffz7cf5 css-1awobkc-MuiGrid-root"
-                    id="base_search-dropdown"
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
+                    id="select-repository-label"
                   >
-                    <div>
-                      <div
-                        class="MuiFormControl-root search-dropdown fzaj1pt css-1nrlq1o-MuiFormControl-root"
-                      >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined dropdown-select-label css-11mbixr-MuiFormLabel-root-MuiInputLabel-root"
-                          data-shrink="true"
-                          id="select-repository-label"
-                        >
-                          Base
-                          <svg
-                            aria-hidden="true"
-                            aria-label="The baseline revision (no changes) your revision will be compared against."
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
-                            data-mui-internal-clone-element="true"
-                            data-testid="InfoOutlinedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
-                            />
-                          </svg>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall dropdown-select css-1q6aue5-MuiInputBase-root-MuiInput-root-MuiSelect-root"
-                          data-testid="dropdown-select-base"
-                        >
-                          <div
-                            aria-expanded="false"
-                            aria-haspopup="listbox"
-                            aria-labelledby="select-repository-label"
-                            class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input MuiInputBase-inputSizeSmall css-1co7s6p-MuiSelect-select-MuiInputBase-input-MuiInput-input"
-                            role="button"
-                            tabindex="0"
-                          >
-                            try
-                          </div>
-                          <input
-                            aria-hidden="true"
-                            class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
-                            tabindex="-1"
-                            value="try"
-                          />
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-o3okz2-MuiSvgIcon-root-MuiSelect-icon"
-                            data-testid="ArrowDropDownIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M7 10l5 5 5-5z"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_fim9qh9 css-17gmabg-MuiGrid-root"
-                    id="base_search-input"
-                  >
-                    <div
-                      class="MuiFormControl-root MuiFormControl-fullWidth fv98i7o css-q8hpuo-MuiFormControl-root"
+                    Base
+                    <svg
+                      aria-hidden="true"
+                      aria-label="The baseline revision (no changes) your revision will be compared against."
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+                      data-mui-internal-clone-element="true"
+                      data-testid="InfoOutlinedIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
                     >
-                      <div
-                        class="hide"
-                      >
-                        Block
-                      </div>
-                      <div
-                        class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
-                      >
-                        <div
-                          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart css-1vjgbo6-MuiInputBase-root-MuiOutlinedInput-root"
-                        >
-                          <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-yzzuft-MuiInputAdornment-root"
-                          >
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                              data-testid="SearchIcon"
-                              focusable="false"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-                              />
-                            </svg>
-                          </div>
-                          <input
-                            aria-invalid="false"
-                            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart css-jrmsot-MuiInputBase-input-MuiOutlinedInput-input"
-                            id="search-base-input"
-                            name="baseSearch"
-                            placeholder="Search base by ID number or author email"
-                            type="text"
-                            value=""
-                          />
-                          <fieldset
-                            aria-hidden="true"
-                            class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-                          >
-                            <legend
-                              class="css-ihdtdm"
-                            >
-                              <span
-                                class="notranslate"
-                              >
-                                ​
-                              </span>
-                            </legend>
-                          </fieldset>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
+                      <path
+                        d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+                      />
+                    </svg>
+                  </label>
                 </div>
               </div>
               <div
                 class="MuiGrid-root component_f14z0jsa css-plh9qo-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-container container_f790aiy css-1ljzhs0-MuiGrid-root"
-                  id="new-search-container"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_ffz7cf5 css-13eijkh-MuiGrid-root"
+                  id="new_search-dropdown"
                 >
-                  <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_ffz7cf5 css-1awobkc-MuiGrid-root"
-                    id="new_search-dropdown"
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
+                    id="select-repository-label"
                   >
-                    <div>
-                      <div
-                        class="MuiFormControl-root search-dropdown fzaj1pt css-1nrlq1o-MuiFormControl-root"
-                      >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined dropdown-select-label css-11mbixr-MuiFormLabel-root-MuiInputLabel-root"
-                          data-shrink="true"
-                          id="select-repository-label"
-                        >
-                          Revisions
-                          <svg
-                            aria-hidden="true"
-                            aria-label="Revisions (typically including your changes) to compare against the selected base revision."
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
-                            data-mui-internal-clone-element="true"
-                            data-testid="InfoOutlinedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
-                            />
-                          </svg>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall dropdown-select css-1q6aue5-MuiInputBase-root-MuiInput-root-MuiSelect-root"
-                          data-testid="dropdown-select-new"
-                        >
-                          <div
-                            aria-expanded="false"
-                            aria-haspopup="listbox"
-                            aria-labelledby="select-repository-label"
-                            class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input MuiInputBase-inputSizeSmall css-1co7s6p-MuiSelect-select-MuiInputBase-input-MuiInput-input"
-                            role="button"
-                            tabindex="0"
-                          >
-                            try
-                          </div>
-                          <input
-                            aria-hidden="true"
-                            class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
-                            tabindex="-1"
-                            value="try"
-                          />
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-o3okz2-MuiSvgIcon-root-MuiSelect-icon"
-                            data-testid="ArrowDropDownIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M7 10l5 5 5-5z"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_fim9qh9 css-17gmabg-MuiGrid-root"
-                    id="new_search-input"
-                  >
-                    <div
-                      class="MuiFormControl-root MuiFormControl-fullWidth fv98i7o css-q8hpuo-MuiFormControl-root"
+                    Revisions
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Revisions (typically including your changes) to compare against the selected base revision."
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+                      data-mui-internal-clone-element="true"
+                      data-testid="InfoOutlinedIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
                     >
-                      <div
-                        class="hide"
-                      >
-                        Block
-                      </div>
-                      <div
-                        class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
-                      >
-                        <div
-                          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart css-1vjgbo6-MuiInputBase-root-MuiOutlinedInput-root"
-                        >
-                          <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-yzzuft-MuiInputAdornment-root"
-                          >
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                              data-testid="SearchIcon"
-                              focusable="false"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-                              />
-                            </svg>
-                          </div>
-                          <input
-                            aria-invalid="false"
-                            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart css-jrmsot-MuiInputBase-input-MuiOutlinedInput-input"
-                            id="search-new-input"
-                            name="newSearch"
-                            placeholder="Search revision by ID number or author email"
-                            type="text"
-                            value=""
-                          />
-                          <fieldset
-                            aria-hidden="true"
-                            class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-                          >
-                            <legend
-                              class="css-ihdtdm"
-                            >
-                              <span
-                                class="notranslate"
-                              >
-                                ​
-                              </span>
-                            </legend>
-                          </fieldset>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
+                      <path
+                        d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+                      />
+                    </svg>
+                  </label>
                 </div>
               </div>
               <div
@@ -1141,7 +933,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -0.34
-                              % 
+                              %
+                               
                               better
                                (
                               -2.14
@@ -1434,7 +1227,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -0.49
-                              % 
+                              %
+                               
                               better
                                (
                               -1.81
@@ -1727,7 +1521,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -0.07
-                              % 
+                              %
+                               
                               better
                                (
                               -0.27
@@ -2084,7 +1879,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               1.68
-                              % 
+                              %
+                               
                               worse
                                (
                               0.35
@@ -2379,7 +2175,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -80.68
-                              % 
+                              %
+                               
                               better
                                (
                               -18.63
@@ -2674,7 +2471,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -2.57
-                              % 
+                              %
+                               
                               better
                                (
                               -0.41
@@ -2969,7 +2767,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               0.78
-                              % 
+                              %
+                               
                               worse
                                (
                               0.03
@@ -3319,7 +3118,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -12.01
-                              % 
+                              %
+                               
                               better
                                (
                               -40960
@@ -3676,7 +3476,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               1.8
-                              % 
+                              %
+                               
                               better
                                (
                               0.11
@@ -3971,7 +3772,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               355.78
-                              % 
+                              %
+                               
                               better
                                (
                               6.75
@@ -4266,7 +4068,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -8.11
-                              % 
+                              %
+                               
                               worse
                                (
                               -1.19
@@ -4561,7 +4364,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               0.58
-                              % 
+                              %
+                               
                               better
                                (
                               0.07
@@ -4911,7 +4715,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               3.84
-                              % 
+                              %
+                               
                               worse
                                (
                               113.05
@@ -5204,7 +5009,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               7.44
-                              % 
+                              %
+                               
                               worse
                                (
                               131.67
@@ -5497,7 +5303,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               2.35
-                              % 
+                              %
+                               
                               worse
                                (
                               54.63
@@ -5847,7 +5654,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               2.73
-                              % 
+                              %
+                               
                               better
                                (
                               77.15
@@ -6199,7 +6007,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               0.21
-                              % 
+                              %
+                               
                               worse
                                (
                               0.04
@@ -6494,7 +6303,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -0.74
-                              % 
+                              %
+                               
                               better
                                (
                               -0.21
@@ -6789,7 +6599,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               2.15
-                              % 
+                              %
+                               
                               worse
                                (
                               0.09
@@ -7141,7 +6952,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               2.15
-                              % 
+                              %
+                               
                               worse
                                (
                               0.09
@@ -7491,7 +7303,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -1.7
-                              % 
+                              %
+                               
                               better
                                (
                               -6.04
@@ -7898,7 +7711,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               1.7
-                              % 
+                              %
+                               
                               worse
                                (
                               10.1
@@ -8191,7 +8005,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -2.81
-                              % 
+                              %
+                               
                               better
                                (
                               -11.64
@@ -8543,7 +8358,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               0.15
-                              % 
+                              %
+                               
                               worse
                                (
                               0.42
@@ -8837,7 +8653,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -100
-                              % 
+                              %
+                               
                               better
                                (
                               -290.4
@@ -8848,7 +8665,8 @@ exports[`Results View Should match snapshot 1`] = `
                                 <b>
                                   Confidence
                                 </b>
-                                : Not available 
+                                : Not available
+                                 
                               </div>
                             </div>
                           </div>
@@ -9120,7 +8938,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               104.96
-                              % 
+                              %
+                               
                               worse
                                (
                               201.74
@@ -9415,7 +9234,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               91.35
-                              % 
+                              %
+                               
                               worse
                                (
                               184.56
@@ -9824,7 +9644,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               2.4
-                              % 
+                              %
+                               
                               worse
                                (
                               7
@@ -10119,7 +9940,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -0.69
-                              % 
+                              %
+                               
                               better
                                (
                               -1.96
@@ -10476,7 +10298,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               436.18
-                              % 
+                              %
+                               
                               worse
                                (
                               19.6
@@ -10771,7 +10594,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -1.73
-                              % 
+                              %
+                               
                               better
                                (
                               -0.07
@@ -11066,7 +10890,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -4.82
-                              % 
+                              %
+                               
                               better
                                (
                               -1.01
@@ -11361,7 +11186,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               1.66
-                              % 
+                              %
+                               
                               worse
                                (
                               0.25
@@ -11656,7 +11482,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -80.69
-                              % 
+                              %
+                               
                               better
                                (
                               -18.89
@@ -11951,7 +11778,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               1.14
-                              % 
+                              %
+                               
                               worse
                                (
                               0.05
@@ -12246,7 +12074,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               2.05
-                              % 
+                              %
+                               
                               worse
                                (
                               0.41
@@ -12541,7 +12370,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -2.6
-                              % 
+                              %
+                               
                               better
                                (
                               -0.74
@@ -12891,7 +12721,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               0
-                              % 
+                              %
+                               
                               worse
                                (
                               5.93
@@ -13241,7 +13072,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               17.37
-                              % 
+                              %
+                               
                               worse
                                (
                               0.24
@@ -13534,7 +13366,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               1.69
-                              % 
+                              %
+                               
                               worse
                                (
                               0.04
@@ -13827,7 +13660,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -0.7
-                              % 
+                              %
+                               
                               better
                                (
                               -0.01
@@ -14184,7 +14018,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               346.79
-                              % 
+                              %
+                               
                               better
                                (
                               6.45
@@ -14479,7 +14314,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               3.34
-                              % 
+                              %
+                               
                               better
                                (
                               0.4
@@ -14774,7 +14610,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               5.17
-                              % 
+                              %
+                               
                               better
                                (
                               0.28
@@ -15069,7 +14906,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -8.29
-                              % 
+                              %
+                               
                               worse
                                (
                               -1.39
@@ -15421,7 +15259,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               3
-                              % 
+                              %
+                               
                               worse
                                (
                               3
@@ -15830,7 +15669,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -1.65
-                              % 
+                              %
+                               
                               better
                                (
                               -1.4
@@ -16125,7 +15965,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -3.23
-                              % 
+                              %
+                               
                               better
                                (
                               -2
@@ -16475,7 +16316,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -14.48
-                              % 
+                              %
+                               
                               better
                                (
                               -51.99
@@ -16768,7 +16610,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               1.23
-                              % 
+                              %
+                               
                               worse
                                (
                               7.61
@@ -17061,7 +16904,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               0.15
-                              % 
+                              %
+                               
                               worse
                                (
                               0.61
@@ -17411,7 +17255,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               3.19
-                              % 
+                              %
+                               
                               worse
                                (
                               11.54
@@ -17704,7 +17549,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               0.44
-                              % 
+                              %
+                               
                               worse
                                (
                               2.75
@@ -17997,7 +17843,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -1.57
-                              % 
+                              %
+                               
                               better
                                (
                               -6.6
@@ -18349,7 +18196,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               2.02
-                              % 
+                              %
+                               
                               worse
                                (
                               2
@@ -18644,7 +18492,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               3.85
-                              % 
+                              %
+                               
                               worse
                                (
                               3
@@ -18939,7 +18788,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -7.58
-                              % 
+                              %
+                               
                               better
                                (
                               -5
@@ -19296,7 +19146,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -1.56
-                              % 
+                              %
+                               
                               better
                                (
                               -0.43
@@ -19591,7 +19442,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               415.37
-                              % 
+                              %
+                               
                               worse
                                (
                               18.58
@@ -19886,7 +19738,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -3.05
-                              % 
+                              %
+                               
                               better
                                (
                               -0.63
@@ -20181,7 +20034,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -0.72
-                              % 
+                              %
+                               
                               better
                                (
                               -0.03
@@ -20533,7 +20387,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -45.46
-                              % 
+                              %
+                               
                               better
                                (
                               -12.62
@@ -20828,7 +20683,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               0.77
-                              % 
+                              %
+                               
                               worse
                                (
                               0.16
@@ -21123,7 +20979,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -0.16
-                              % 
+                              %
+                               
                               better
                                (
                               -0.01
@@ -21473,7 +21330,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -0.56
-                              % 
+                              %
+                               
                               better
                                (
                               -7.7
@@ -21766,7 +21624,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               5.3
-                              % 
+                              %
+                               
                               worse
                                (
                               69.4
@@ -22059,7 +21918,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               0.38
-                              % 
+                              %
+                               
                               worse
                                (
                               4.4
@@ -22416,7 +22276,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -3.8
-                              % 
+                              %
+                               
                               worse
                                (
                               -0.65
@@ -22711,7 +22572,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -77.85
-                              % 
+                              %
+                               
                               worse
                                (
                               -6.77
@@ -23006,7 +22868,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -9.62
-                              % 
+                              %
+                               
                               worse
                                (
                               -0.6
@@ -23301,7 +23164,8 @@ exports[`Results View Should match snapshot 1`] = `
                               </b>
                               : 
                               -2.59
-                              % 
+                              %
+                               
                               worse
                                (
                               -0.32

--- a/src/__tests__/CompareResults/beta/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/__tests__/CompareResults/beta/__snapshots__/SearchInput.test.tsx.snap
@@ -105,264 +105,56 @@ exports[`Search by title/test name Should match snapshot 1`] = `
                 class="MuiGrid-root component_f14z0jsa css-plh9qo-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-container container_f790aiy css-1ljzhs0-MuiGrid-root"
-                  id="base-search-container"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_ffz7cf5 css-13eijkh-MuiGrid-root"
+                  id="base_search-dropdown"
                 >
-                  <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_ffz7cf5 css-1awobkc-MuiGrid-root"
-                    id="base_search-dropdown"
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
+                    id="select-repository-label"
                   >
-                    <div>
-                      <div
-                        class="MuiFormControl-root search-dropdown fzaj1pt css-1nrlq1o-MuiFormControl-root"
-                      >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined dropdown-select-label css-11mbixr-MuiFormLabel-root-MuiInputLabel-root"
-                          data-shrink="true"
-                          id="select-repository-label"
-                        >
-                          Base
-                          <svg
-                            aria-hidden="true"
-                            aria-label="The baseline revision (no changes) your revision will be compared against."
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
-                            data-mui-internal-clone-element="true"
-                            data-testid="InfoOutlinedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
-                            />
-                          </svg>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall dropdown-select css-1q6aue5-MuiInputBase-root-MuiInput-root-MuiSelect-root"
-                          data-testid="dropdown-select-base"
-                        >
-                          <div
-                            aria-expanded="false"
-                            aria-haspopup="listbox"
-                            aria-labelledby="select-repository-label"
-                            class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input MuiInputBase-inputSizeSmall css-1co7s6p-MuiSelect-select-MuiInputBase-input-MuiInput-input"
-                            role="button"
-                            tabindex="0"
-                          >
-                            try
-                          </div>
-                          <input
-                            aria-hidden="true"
-                            class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
-                            tabindex="-1"
-                            value="try"
-                          />
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-o3okz2-MuiSvgIcon-root-MuiSelect-icon"
-                            data-testid="ArrowDropDownIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M7 10l5 5 5-5z"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_fim9qh9 css-17gmabg-MuiGrid-root"
-                    id="base_search-input"
-                  >
-                    <div
-                      class="MuiFormControl-root MuiFormControl-fullWidth fv98i7o css-q8hpuo-MuiFormControl-root"
+                    Base
+                    <svg
+                      aria-hidden="true"
+                      aria-label="The baseline revision (no changes) your revision will be compared against."
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+                      data-mui-internal-clone-element="true"
+                      data-testid="InfoOutlinedIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
                     >
-                      <div
-                        class="hide"
-                      >
-                        Block
-                      </div>
-                      <div
-                        class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
-                      >
-                        <div
-                          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart css-1vjgbo6-MuiInputBase-root-MuiOutlinedInput-root"
-                        >
-                          <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-yzzuft-MuiInputAdornment-root"
-                          >
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                              data-testid="SearchIcon"
-                              focusable="false"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-                              />
-                            </svg>
-                          </div>
-                          <input
-                            aria-invalid="false"
-                            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart css-jrmsot-MuiInputBase-input-MuiOutlinedInput-input"
-                            id="search-base-input"
-                            name="baseSearch"
-                            placeholder="Search base by ID number or author email"
-                            type="text"
-                            value=""
-                          />
-                          <fieldset
-                            aria-hidden="true"
-                            class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-                          >
-                            <legend
-                              class="css-ihdtdm"
-                            >
-                              <span
-                                class="notranslate"
-                              >
-                                ​
-                              </span>
-                            </legend>
-                          </fieldset>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
+                      <path
+                        d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+                      />
+                    </svg>
+                  </label>
                 </div>
               </div>
               <div
                 class="MuiGrid-root component_f14z0jsa css-plh9qo-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-container container_f790aiy css-1ljzhs0-MuiGrid-root"
-                  id="new-search-container"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_ffz7cf5 css-13eijkh-MuiGrid-root"
+                  id="new_search-dropdown"
                 >
-                  <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_ffz7cf5 css-1awobkc-MuiGrid-root"
-                    id="new_search-dropdown"
+                  <label
+                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
+                    id="select-repository-label"
                   >
-                    <div>
-                      <div
-                        class="MuiFormControl-root search-dropdown fzaj1pt css-1nrlq1o-MuiFormControl-root"
-                      >
-                        <label
-                          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined dropdown-select-label css-11mbixr-MuiFormLabel-root-MuiInputLabel-root"
-                          data-shrink="true"
-                          id="select-repository-label"
-                        >
-                          Revisions
-                          <svg
-                            aria-hidden="true"
-                            aria-label="Revisions (typically including your changes) to compare against the selected base revision."
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
-                            data-mui-internal-clone-element="true"
-                            data-testid="InfoOutlinedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
-                            />
-                          </svg>
-                        </label>
-                        <div
-                          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall dropdown-select css-1q6aue5-MuiInputBase-root-MuiInput-root-MuiSelect-root"
-                          data-testid="dropdown-select-new"
-                        >
-                          <div
-                            aria-expanded="false"
-                            aria-haspopup="listbox"
-                            aria-labelledby="select-repository-label"
-                            class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input MuiInputBase-inputSizeSmall css-1co7s6p-MuiSelect-select-MuiInputBase-input-MuiInput-input"
-                            role="button"
-                            tabindex="0"
-                          >
-                            try
-                          </div>
-                          <input
-                            aria-hidden="true"
-                            class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
-                            tabindex="-1"
-                            value="try"
-                          />
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-o3okz2-MuiSvgIcon-root-MuiSelect-icon"
-                            data-testid="ArrowDropDownIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M7 10l5 5 5-5z"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_fim9qh9 css-17gmabg-MuiGrid-root"
-                    id="new_search-input"
-                  >
-                    <div
-                      class="MuiFormControl-root MuiFormControl-fullWidth fv98i7o css-q8hpuo-MuiFormControl-root"
+                    Revisions
+                    <svg
+                      aria-hidden="true"
+                      aria-label="Revisions (typically including your changes) to compare against the selected base revision."
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+                      data-mui-internal-clone-element="true"
+                      data-testid="InfoOutlinedIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
                     >
-                      <div
-                        class="hide"
-                      >
-                        Block
-                      </div>
-                      <div
-                        class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
-                      >
-                        <div
-                          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart css-1vjgbo6-MuiInputBase-root-MuiOutlinedInput-root"
-                        >
-                          <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-yzzuft-MuiInputAdornment-root"
-                          >
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                              data-testid="SearchIcon"
-                              focusable="false"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-                              />
-                            </svg>
-                          </div>
-                          <input
-                            aria-invalid="false"
-                            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart css-jrmsot-MuiInputBase-input-MuiOutlinedInput-input"
-                            id="search-new-input"
-                            name="newSearch"
-                            placeholder="Search revision by ID number or author email"
-                            type="text"
-                            value=""
-                          />
-                          <fieldset
-                            aria-hidden="true"
-                            class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-                          >
-                            <legend
-                              class="css-ihdtdm"
-                            >
-                              <span
-                                class="notranslate"
-                              >
-                                ​
-                              </span>
-                            </legend>
-                          </fieldset>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
+                      <path
+                        d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+                      />
+                    </svg>
+                  </label>
                 </div>
               </div>
               <div

--- a/src/__tests__/Search/CompareWithBase.test.tsx
+++ b/src/__tests__/Search/CompareWithBase.test.tsx
@@ -103,7 +103,7 @@ describe('Compare With Base', () => {
     expect(screen.queryAllByText(/build_metrics/i)[0]).toBeInTheDocument();
   });
 
-  it('shows correct selected revisions when view is  `search` or `compare-results`', async () => {
+  it('shows correct selected revisions when view is `search` or `compare-results`', async () => {
     const { testData } = getTestData();
     const baseChecked = testData.slice(0, 1);
     const newChecked = testData.slice(1, 2);

--- a/src/__tests__/Search/SearchComponent.test.tsx
+++ b/src/__tests__/Search/SearchComponent.test.tsx
@@ -2,7 +2,7 @@ import { act } from 'react-dom/test-utils';
 
 import SearchComponent from '../../components/Search/SearchComponent';
 import { Strings } from '../../resources/Strings';
-import { InputType } from '../../types/state';
+import { InputType, ModeType } from '../../types/state';
 import { renderWithRouter } from '../utils/setupTests';
 
 const stringsBase = Strings.components.searchDefault.base.collapsed.base;
@@ -11,7 +11,7 @@ describe('Search View', () => {
   it('renders correctly when there are no results', async () => {
     const SearchPropsBase = {
       searchType: 'base' as InputType,
-      mode: 'light' as 'light' | 'dark',
+      mode: 'light' as ModeType,
       view: 'search' as 'search' | 'compare-results',
       isWarning: false,
       ...stringsBase,

--- a/src/__tests__/Search/SearchComponent.test.tsx
+++ b/src/__tests__/Search/SearchComponent.test.tsx
@@ -2,7 +2,7 @@ import { act } from 'react-dom/test-utils';
 
 import SearchComponent from '../../components/Search/SearchComponent';
 import { Strings } from '../../resources/Strings';
-import { InputType, ModeType } from '../../types/state';
+import { InputType, ThemeMode } from '../../types/state';
 import { renderWithRouter } from '../utils/setupTests';
 
 const stringsBase = Strings.components.searchDefault.base.collapsed.base;
@@ -11,7 +11,7 @@ describe('Search View', () => {
   it('renders correctly when there are no results', async () => {
     const SearchPropsBase = {
       searchType: 'base' as InputType,
-      mode: 'light' as ModeType,
+      mode: 'light' as ThemeMode,
       view: 'search' as 'search' | 'compare-results',
       isWarning: false,
       ...stringsBase,

--- a/src/__tests__/Search/SearchView.test.tsx
+++ b/src/__tests__/Search/SearchView.test.tsx
@@ -7,7 +7,7 @@ import SearchView from '../../components/Search/SearchView';
 import { setSelectedRevisions } from '../../reducers/SelectedRevisionsSlice';
 import { Strings } from '../../resources/Strings';
 import useProtocolTheme from '../../theme/protocolTheme';
-import { RevisionsList, InputType, ModeType } from '../../types/state';
+import { RevisionsList, InputType, ThemeMode } from '../../types/state';
 import getTestData from '../utils/fixtures';
 import { renderWithRouter, store } from '../utils/setupTests';
 import { screen, waitFor } from '../utils/test-utils';
@@ -261,7 +261,7 @@ describe('Base Search', () => {
     const spyOnFetch = jest.spyOn(global, 'fetch');
     const SearchPropsBase = {
       searchType,
-      mode: 'light' as ModeType,
+      mode: 'light' as ThemeMode,
       view: 'search' as 'search' | 'compare-results',
       isWarning: false,
       ...stringsBase,

--- a/src/__tests__/Search/SearchView.test.tsx
+++ b/src/__tests__/Search/SearchView.test.tsx
@@ -7,7 +7,7 @@ import SearchView from '../../components/Search/SearchView';
 import { setSelectedRevisions } from '../../reducers/SelectedRevisionsSlice';
 import { Strings } from '../../resources/Strings';
 import useProtocolTheme from '../../theme/protocolTheme';
-import { RevisionsList, InputType } from '../../types/state';
+import { RevisionsList, InputType, ModeType } from '../../types/state';
 import getTestData from '../utils/fixtures';
 import { renderWithRouter, store } from '../utils/setupTests';
 import { screen, waitFor } from '../utils/test-utils';
@@ -52,14 +52,16 @@ describe('Search View', () => {
 
   it('renders skip to search link correctly', async () => {
     renderComponent();
-    expect(screen.getByRole('link', { name: /skip to search/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /skip to search/i }),
+    ).toBeInTheDocument();
   });
 
-  it('renders a skip link that sends the focus directly to search container', async ()=>{
+  it('renders a skip link that sends the focus directly to search container', async () => {
     renderComponent();
-    await waitFor(()=> userEvent.tab() ); 
-   await waitFor(()=> userEvent.keyboard('{Enter}'));
-   expect(screen.queryByTestId('search-section')).toHaveFocus();    
+    await waitFor(() => userEvent.tab());
+    await waitFor(() => userEvent.keyboard('{Enter}'));
+    expect(screen.queryByTestId('search-section')).toHaveFocus();
   });
 });
 
@@ -259,7 +261,7 @@ describe('Base Search', () => {
     const spyOnFetch = jest.spyOn(global, 'fetch');
     const SearchPropsBase = {
       searchType,
-      mode: 'light' as 'light' | 'dark',
+      mode: 'light' as ModeType,
       view: 'search' as 'search' | 'compare-results',
       isWarning: false,
       ...stringsBase,

--- a/src/__tests__/Search/SelectedRevision.test.tsx
+++ b/src/__tests__/Search/SelectedRevision.test.tsx
@@ -82,6 +82,8 @@ describe('SelectedRevision', () => {
       '[aria-label="close-button"]',
     );
 
+    const removeIcon = screen.getByTestId('close-icon');
+    expect(removeIcon).toBeInTheDocument();
     expect(screen.getAllByTestId('selected-rev-item')[0]).toBeInTheDocument();
 
     await user.click(removeButton[0]);

--- a/src/__tests__/Search/SelectedRevision.test.tsx
+++ b/src/__tests__/Search/SelectedRevision.test.tsx
@@ -67,12 +67,13 @@ describe('SelectedRevision', () => {
       }),
     ) as jest.Mock;
     jest.spyOn(global, 'fetch');
-    // set delay to null to prevent test time-out due to useFakeTimers
+
     const newChecked = testData.slice(0, 1);
     act(() => {
       store.dispatch(updateCheckedRevisions({ newChecked, searchType }));
     });
 
+    // set delay to null to prevent test time-out due to useFakeTimers
     const user = userEvent.setup({ delay: null });
 
     renderComponent();

--- a/src/__tests__/Search/__snapshots__/SelectedRevision.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SelectedRevision.test.tsx.snap
@@ -755,7 +755,7 @@ exports[`SelectedRevision should show the selected checked revisions once a resu
                       class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
                     >
                       <div
-                        class="item-container"
+                        class="item-container item-0 item-base"
                         data-testid="selected-rev-item"
                       >
                         <div
@@ -843,7 +843,7 @@ exports[`SelectedRevision should show the selected checked revisions once a resu
                                 <svg
                                   aria-hidden="true"
                                   class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall close-icon css-1mecf1h-MuiSvgIcon-root"
-                                  data-testid="CloseOutlinedIcon"
+                                  data-testid="close-icon"
                                   focusable="false"
                                   viewBox="0 0 24 24"
                                 >

--- a/src/__tests__/Search/__snapshots__/SelectedRevision.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SelectedRevision.test.tsx.snap
@@ -840,17 +840,6 @@ exports[`SelectedRevision should show the selected checked revisions once a resu
                                 tabindex="0"
                                 type="button"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall close-icon css-1mecf1h-MuiSvgIcon-root"
-                                  data-testid="CloseOutlinedIcon"
-                                  focusable="false"
-                                  viewBox="0 0 24 24"
-                                >
-                                  <path
-                                    d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"
-                                  />
-                                </svg>
                                 <span
                                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                                 />

--- a/src/__tests__/Search/__snapshots__/SelectedRevision.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SelectedRevision.test.tsx.snap
@@ -840,6 +840,17 @@ exports[`SelectedRevision should show the selected checked revisions once a resu
                                 tabindex="0"
                                 type="button"
                               >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall close-icon css-1mecf1h-MuiSvgIcon-root"
+                                  data-testid="CloseOutlinedIcon"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"
+                                  />
+                                </svg>
                                 <span
                                   class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                                 />

--- a/src/__tests__/Search/fetchRecentRevisions.test.tsx
+++ b/src/__tests__/Search/fetchRecentRevisions.test.tsx
@@ -6,7 +6,7 @@ import SearchComponent from '../../components/Search/SearchComponent';
 import SearchView from '../../components/Search/SearchView';
 import { Strings } from '../../resources/Strings';
 import useProtocolTheme from '../../theme/protocolTheme';
-import { InputType, ModeType } from '../../types/state';
+import { InputType, ThemeMode } from '../../types/state';
 import getTestData from '../utils/fixtures';
 import { renderWithRouter, store } from '../utils/setupTests';
 import { screen } from '../utils/test-utils';
@@ -91,7 +91,7 @@ describe('SearchView/fetchRecentRevisions', () => {
     const spyOnFetch = jest.spyOn(global, 'fetch');
     const SearchPropsBase = {
       searchType,
-      mode: 'light' as ModeType,
+      mode: 'light' as ThemeMode,
       view: 'search' as 'search' | 'compare-results',
       isWarning: false,
       ...stringsBase,
@@ -125,7 +125,7 @@ describe('SearchView/fetchRecentRevisions', () => {
     const spyOnFetch = jest.spyOn(global, 'fetch');
     const SearchPropsBase = {
       searchType,
-      mode: 'light' as ModeType,
+      mode: 'light' as ThemeMode,
       view: 'search' as 'search' | 'compare-results',
       isWarning: false,
       ...stringsBase,

--- a/src/__tests__/Search/fetchRecentRevisions.test.tsx
+++ b/src/__tests__/Search/fetchRecentRevisions.test.tsx
@@ -6,7 +6,7 @@ import SearchComponent from '../../components/Search/SearchComponent';
 import SearchView from '../../components/Search/SearchView';
 import { Strings } from '../../resources/Strings';
 import useProtocolTheme from '../../theme/protocolTheme';
-import { InputType } from '../../types/state';
+import { InputType, ModeType } from '../../types/state';
 import getTestData from '../utils/fixtures';
 import { renderWithRouter, store } from '../utils/setupTests';
 import { screen } from '../utils/test-utils';
@@ -67,7 +67,6 @@ describe('SearchView/fetchRecentRevisions', () => {
       );
     });
 
-
     const searchInput = screen.getAllByRole('textbox')[0];
     await user.click(searchInput);
     await screen.findAllByText("you've got no arms left!");
@@ -92,7 +91,7 @@ describe('SearchView/fetchRecentRevisions', () => {
     const spyOnFetch = jest.spyOn(global, 'fetch');
     const SearchPropsBase = {
       searchType,
-      mode: 'light' as 'light' | 'dark',
+      mode: 'light' as ModeType,
       view: 'search' as 'search' | 'compare-results',
       isWarning: false,
       ...stringsBase,
@@ -126,7 +125,7 @@ describe('SearchView/fetchRecentRevisions', () => {
     const spyOnFetch = jest.spyOn(global, 'fetch');
     const SearchPropsBase = {
       searchType,
-      mode: 'light' as 'light' | 'dark',
+      mode: 'light' as ModeType,
       view: 'search' as 'search' | 'compare-results',
       isWarning: false,
       ...stringsBase,

--- a/src/__tests__/Search/fetchRevisionsByAuthor.test.tsx
+++ b/src/__tests__/Search/fetchRevisionsByAuthor.test.tsx
@@ -7,6 +7,7 @@ import SearchView from '../../components/Search/SearchView';
 import { Strings } from '../../resources/Strings';
 import useProtocolTheme from '../../theme/protocolTheme';
 import { InputType } from '../../types/state';
+import type { ModeType } from '../../types/state';
 import getTestData from '../utils/fixtures';
 import { renderWithRouter, store } from '../utils/setupTests';
 import { screen } from '../utils/test-utils';
@@ -138,7 +139,7 @@ describe('SearchView/fetchRevisionsByAuthor', () => {
     const searchType = 'base' as InputType;
     const SearchPropsBase = {
       searchType,
-      mode: 'light' as 'light' | 'dark',
+      mode: 'light' as ModeType,
       view: 'search' as 'search' | 'compare-results',
       isWarning: false,
       ...stringsBase,

--- a/src/__tests__/Search/fetchRevisionsByAuthor.test.tsx
+++ b/src/__tests__/Search/fetchRevisionsByAuthor.test.tsx
@@ -7,7 +7,7 @@ import SearchView from '../../components/Search/SearchView';
 import { Strings } from '../../resources/Strings';
 import useProtocolTheme from '../../theme/protocolTheme';
 import { InputType } from '../../types/state';
-import type { ModeType } from '../../types/state';
+import type { ThemeMode } from '../../types/state';
 import getTestData from '../utils/fixtures';
 import { renderWithRouter, store } from '../utils/setupTests';
 import { screen } from '../utils/test-utils';
@@ -139,7 +139,7 @@ describe('SearchView/fetchRevisionsByAuthor', () => {
     const searchType = 'base' as InputType;
     const SearchPropsBase = {
       searchType,
-      mode: 'light' as ModeType,
+      mode: 'light' as ThemeMode,
       view: 'search' as 'search' | 'compare-results',
       isWarning: false,
       ...stringsBase,

--- a/src/components/CompareResults/beta/ResultsMain.tsx
+++ b/src/components/CompareResults/beta/ResultsMain.tsx
@@ -2,7 +2,7 @@ import { Container } from '@mui/system';
 import { style } from 'typestyle';
 
 import { Colors } from '../../../styles';
-import type { ModeType } from '../../../types/state';
+import type { ThemeMode } from '../../../types/state';
 import ResultsHeader from './ResultsHeader';
 import ResultsTable from './ResultsTable';
 
@@ -30,7 +30,7 @@ function ResultsMain(props: ResultsMainProps) {
 }
 
 interface ResultsMainProps {
-  themeMode: ModeType;
+  themeMode: ThemeMode;
 }
 
 export default ResultsMain;

--- a/src/components/CompareResults/beta/ResultsMain.tsx
+++ b/src/components/CompareResults/beta/ResultsMain.tsx
@@ -2,6 +2,7 @@ import { Container } from '@mui/system';
 import { style } from 'typestyle';
 
 import { Colors } from '../../../styles';
+import type { ModeType } from '../../../types/state';
 import ResultsHeader from './ResultsHeader';
 import ResultsTable from './ResultsTable';
 
@@ -29,7 +30,7 @@ function ResultsMain(props: ResultsMainProps) {
 }
 
 interface ResultsMainProps {
-  themeMode: 'light' | 'dark';
+  themeMode: ModeType;
 }
 
 export default ResultsMain;

--- a/src/components/CompareResults/beta/ResultsTable.tsx
+++ b/src/components/CompareResults/beta/ResultsTable.tsx
@@ -6,7 +6,11 @@ import { style } from 'typestyle';
 import { RootState } from '../../../common/store';
 import { useAppSelector } from '../../../hooks/app';
 import { Colors, Spacing } from '../../../styles';
-import type { CompareResultsItem, RevisionsHeader } from '../../../types/state';
+import type {
+  CompareResultsItem,
+  RevisionsHeader,
+  ModeType,
+} from '../../../types/state';
 import NoResultsFound from './NoResultsFound';
 import TableContent from './TableContent';
 import TableHeader from './TableHeader';
@@ -94,7 +98,7 @@ function ResultsTable(props: ResultsTableProps) {
   );
 }
 interface ResultsTableProps {
-  themeMode: 'light' | 'dark';
+  themeMode: ModeType;
 }
 
 export default ResultsTable;

--- a/src/components/CompareResults/beta/ResultsTable.tsx
+++ b/src/components/CompareResults/beta/ResultsTable.tsx
@@ -9,7 +9,7 @@ import { Colors, Spacing } from '../../../styles';
 import type {
   CompareResultsItem,
   RevisionsHeader,
-  ModeType,
+  ThemeMode,
 } from '../../../types/state';
 import NoResultsFound from './NoResultsFound';
 import TableContent from './TableContent';
@@ -25,35 +25,41 @@ type Results = {
   revisionHeader: RevisionsHeader;
 };
 
-
 function processResults(results: CompareResultsItem[]) {
-  const processedResults: Map<string, CompareResultsItem[]> = new Map<string, CompareResultsItem[]>();
-  results.forEach(result => {
-      const { new_rev: newRevision, header_name: header } = result;
-      const rowIdentifier = header.concat(' ', newRevision);
-      if (processedResults.has(rowIdentifier)) {
-        (processedResults.get(rowIdentifier) as CompareResultsItem[]).push(result);
-      } else {
-        processedResults.set(rowIdentifier, [result]);
-      }
-    });
-    const restructuredResults: Results[] = Array.from(processedResults, function (entry) {
-      return { 
+  const processedResults: Map<string, CompareResultsItem[]> = new Map<
+    string,
+    CompareResultsItem[]
+  >();
+  results.forEach((result) => {
+    const { new_rev: newRevision, header_name: header } = result;
+    const rowIdentifier = header.concat(' ', newRevision);
+    if (processedResults.has(rowIdentifier)) {
+      (processedResults.get(rowIdentifier) as CompareResultsItem[]).push(
+        result,
+      );
+    } else {
+      processedResults.set(rowIdentifier, [result]);
+    }
+  });
+  const restructuredResults: Results[] = Array.from(
+    processedResults,
+    function (entry) {
+      return {
         key: entry[0],
         value: entry[1],
         revisionHeader: {
-         suite: entry[1][0].suite,
-         test: entry[1][0].test,
-         option_name: entry[1][0].option_name,
-         extra_options: entry[1][0].extra_options,
-         new_rev: entry[1][0].new_rev,
-         new_repo: entry[1][0].new_repository_name,
+          suite: entry[1][0].suite,
+          test: entry[1][0].test,
+          option_name: entry[1][0].option_name,
+          extra_options: entry[1][0].extra_options,
+          new_rev: entry[1][0].new_rev,
+          new_repo: entry[1][0].new_repository_name,
         },
       };
-    });
+    },
+  );
 
   return restructuredResults;
-
 }
 
 function ResultsTable(props: ResultsTableProps) {
@@ -63,8 +69,8 @@ function ResultsTable(props: ResultsTableProps) {
   );
   const processedResults = processResults(compareResults);
 
-
-  const themeColor100 = themeMode === 'light' ? Colors.Background100 : Colors.Background100Dark;
+  const themeColor100 =
+    themeMode === 'light' ? Colors.Background100 : Colors.Background100Dark;
 
   const styles = {
     tableContainer: style({
@@ -90,15 +96,20 @@ function ResultsTable(props: ResultsTableProps) {
       <Table>
         <TableHeader themeMode={themeMode} />
         {processedResults.map((res, index) => (
-            <TableContent themeMode={themeMode} key={index} header={res.revisionHeader} results={res.value} />
-      ))}
+          <TableContent
+            themeMode={themeMode}
+            key={index}
+            header={res.revisionHeader}
+            results={res.value}
+          />
+        ))}
       </Table>
-      {processedResults.length == 0 && <NoResultsFound/>}
+      {processedResults.length == 0 && <NoResultsFound />}
     </TableContainer>
   );
 }
 interface ResultsTableProps {
-  themeMode: ModeType;
+  themeMode: ThemeMode;
 }
 
 export default ResultsTable;

--- a/src/components/CompareResults/beta/ResultsView.tsx
+++ b/src/components/CompareResults/beta/ResultsView.tsx
@@ -13,7 +13,7 @@ import useHandleChangeSearch from '../../../hooks/useHandleChangeSearch';
 import { switchToFakeData } from '../../../reducers/CompareResults';
 import { SearchContainerStyles } from '../../../styles';
 import { background } from '../../../styles';
-import { Repository } from '../../../types/state';
+import { Repository, View } from '../../../types/state';
 import CompareWithBase from '../../Search/CompareWithBase';
 import PerfCompareHeader from '../../Shared/PerfCompareHeader';
 import ResultsMain from './ResultsMain';
@@ -81,10 +81,10 @@ function ResultsView(props: ResultsViewProps) {
       <PerfCompareHeader
         themeMode={themeMode}
         toggleColorMode={toggleColorMode}
-        view={compareView}
+        view={compareView as View}
       />
       <section className={sectionStyles.container}>
-        <CompareWithBase mode={themeMode} view={compareView} />
+        <CompareWithBase mode={themeMode} view={compareView as View} />
       </section>
       <Grid container alignItems='center' justifyContent='center'>
         <Grid item xs={12}>

--- a/src/components/CompareResults/beta/RevisionRow.tsx
+++ b/src/components/CompareResults/beta/RevisionRow.tsx
@@ -12,7 +12,7 @@ import { style } from 'typestyle';
 
 import { Colors, Spacing } from '../../../styles';
 import { ExpandableRowStyles } from '../../../styles';
-import type { CompareResultsItem, ModeType } from '../../../types/state';
+import type { CompareResultsItem, ThemeMode } from '../../../types/state';
 import RevisionRowExpandable from './RevisionRowExpandable';
 
 interface Expanded {
@@ -235,7 +235,7 @@ function RevisionRow(props: RevisionRowProps) {
 }
 
 interface RevisionRowProps {
-  themeMode: ModeType;
+  themeMode: ThemeMode;
   result: CompareResultsItem;
 }
 

--- a/src/components/CompareResults/beta/RevisionRow.tsx
+++ b/src/components/CompareResults/beta/RevisionRow.tsx
@@ -12,7 +12,7 @@ import { style } from 'typestyle';
 
 import { Colors, Spacing } from '../../../styles';
 import { ExpandableRowStyles } from '../../../styles';
-import type { CompareResultsItem } from '../../../types/state';
+import type { CompareResultsItem, ModeType } from '../../../types/state';
 import RevisionRowExpandable from './RevisionRowExpandable';
 
 interface Expanded {
@@ -46,7 +46,20 @@ function determineSign(baseMedianValue: number, newMedianValue: number) {
 
 function RevisionRow(props: RevisionRowProps) {
   const { themeMode, result } = props;
-  const { platform, base_median_value: baseMedianValue, base_measurement_unit: baseUnit, new_median_value: newMedianValue, new_measurement_unit: newUnit, is_improvement: improvement, is_regression: regression, delta_percentage: deltaPercent, confidence_text: confidenceText, base_runs: baseRuns, new_runs: newRuns, graphs_link: graphLink } = result;
+  const {
+    platform,
+    base_median_value: baseMedianValue,
+    base_measurement_unit: baseUnit,
+    new_median_value: newMedianValue,
+    new_measurement_unit: newUnit,
+    is_improvement: improvement,
+    is_regression: regression,
+    delta_percentage: deltaPercent,
+    confidence_text: confidenceText,
+    base_runs: baseRuns,
+    new_runs: newRuns,
+    graphs_link: graphLink,
+  } = result;
   const shortPlatform = platformMapping(platform);
 
   const [row, setExpanded] = useState<Expanded>({
@@ -139,89 +152,90 @@ function RevisionRow(props: RevisionRowProps) {
   };
   return (
     <>
-    <TableRow className={`revisionRow ${styles.revisionRow}`}>
-      <TableCell className='platform'>
-        <div className='platform-container'>
-          <AppleIcon />
-          <span>{shortPlatform}</span>
-        </div>
-      </TableCell>
-      <TableCell className='base-value'>
-        <div className='base-container'> {baseMedianValue} {baseUnit} </div>
-      </TableCell>
-      {/* TODO: Add logic for comparison sign */}
-      <TableCell className='comparison-sign'>{determineSign(baseMedianValue, newMedianValue)}</TableCell>
-      <TableCell className='new-value'> {newMedianValue} {newUnit}</TableCell>
-      <TableCell className='status'> {determineStatus(improvement, regression)} </TableCell> 
-      <TableCell className='delta'> {deltaPercent} % </TableCell>
-      <TableCell className='confidence'> {confidenceText} </TableCell>
-      <TableCell className='total-runs'>
-        <span>B:</span>
-        <strong> {baseRuns.length} </strong> <span> N: </span>
-        <strong> {newRuns.length} </strong>
-      </TableCell>
-      <TableCell className='cell-button graph'>
-        <div className='graph-link-button-container'>
-          <IconButton aria-label='graph link' size='small'>
-            <Link href={graphLink} target="_blank" >
-              <TimelineIcon />
-            </Link>
-          </IconButton>
-        </div>
-      </TableCell>
-      <TableCell className='cell-button download'>
-        <div className='download-button-container'>
-          <IconButton aria-label='download' size='small'>
-            <FileDownloadOutlinedIcon />
-          </IconButton>
-        </div>
-      </TableCell>
-      <TableCell className='cell-button retrigger-button'>
-        <div className='runs-button-container'>
-          <IconButton aria-label='retrigger button' size='small'>
-            <RefreshOutlinedIcon />
-          </IconButton>
-        </div>
-      </TableCell>
-      <TableCell className='cell-button expand-button'>
-        <div className='expand-button-container' 
-             onClick={toggleIsExpanded}
-             data-testid='expand-revision-button'
-        >
-          <IconButton
-            aria-label='expand row'
-            size='small'
+      <TableRow className={`revisionRow ${styles.revisionRow}`}>
+        <TableCell className='platform'>
+          <div className='platform-container'>
+            <AppleIcon />
+            <span>{shortPlatform}</span>
+          </div>
+        </TableCell>
+        <TableCell className='base-value'>
+          <div className='base-container'>
+            {' '}
+            {baseMedianValue} {baseUnit}{' '}
+          </div>
+        </TableCell>
+        {/* TODO: Add logic for comparison sign */}
+        <TableCell className='comparison-sign'>
+          {determineSign(baseMedianValue, newMedianValue)}
+        </TableCell>
+        <TableCell className='new-value'>
+          {' '}
+          {newMedianValue} {newUnit}
+        </TableCell>
+        <TableCell className='status'>
+          {' '}
+          {determineStatus(improvement, regression)}{' '}
+        </TableCell>
+        <TableCell className='delta'> {deltaPercent} % </TableCell>
+        <TableCell className='confidence'> {confidenceText} </TableCell>
+        <TableCell className='total-runs'>
+          <span>B:</span>
+          <strong> {baseRuns.length} </strong> <span> N: </span>
+          <strong> {newRuns.length} </strong>
+        </TableCell>
+        <TableCell className='cell-button graph'>
+          <div className='graph-link-button-container'>
+            <IconButton aria-label='graph link' size='small'>
+              <Link href={graphLink} target='_blank'>
+                <TimelineIcon />
+              </Link>
+            </IconButton>
+          </div>
+        </TableCell>
+        <TableCell className='cell-button download'>
+          <div className='download-button-container'>
+            <IconButton aria-label='download' size='small'>
+              <FileDownloadOutlinedIcon />
+            </IconButton>
+          </div>
+        </TableCell>
+        <TableCell className='cell-button retrigger-button'>
+          <div className='runs-button-container'>
+            <IconButton aria-label='retrigger button' size='small'>
+              <RefreshOutlinedIcon />
+            </IconButton>
+          </div>
+        </TableCell>
+        <TableCell className='cell-button expand-button'>
+          <div
+            className='expand-button-container'
+            onClick={toggleIsExpanded}
+            data-testid='expand-revision-button'
           >
-            {
-              row.expanded ?
-              <ExpandLessIcon /> :
-              <ExpandMoreIcon />
-            }
-          </IconButton>
-        </div>
-      </TableCell>
-    </TableRow>
-    
-    <TableRow className={`revisionRow ${styles.revisionRow}`}>
-      <TableCell colSpan={11}>
-      <div 
-          className={`content-row content-row--${row.class} ${stylesCard.container} `}
-          data-testid='expanded-row-content'
-      >
-        <RevisionRowExpandable 
-        themeMode={themeMode} 
-        result={result}
-        />
-      </div>
-      </TableCell>
-    </TableRow>
-    
+            <IconButton aria-label='expand row' size='small'>
+              {row.expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+            </IconButton>
+          </div>
+        </TableCell>
+      </TableRow>
+
+      <TableRow className={`revisionRow ${styles.revisionRow}`}>
+        <TableCell colSpan={11}>
+          <div
+            className={`content-row content-row--${row.class} ${stylesCard.container} `}
+            data-testid='expanded-row-content'
+          >
+            <RevisionRowExpandable themeMode={themeMode} result={result} />
+          </div>
+        </TableCell>
+      </TableRow>
     </>
   );
 }
 
 interface RevisionRowProps {
-  themeMode: 'light' | 'dark';
+  themeMode: ModeType;
   result: CompareResultsItem;
 }
 

--- a/src/components/CompareResults/beta/RevisionRowExpandable.tsx
+++ b/src/components/CompareResults/beta/RevisionRowExpandable.tsx
@@ -3,7 +3,7 @@ import { style } from 'typestyle';
 
 import { Strings } from '../../../resources/Strings';
 import { Colors, Spacing } from '../../../styles';
-import type { CompareResultsItem, ModeType } from '../../../types/state';
+import type { CompareResultsItem, ThemeMode } from '../../../types/state';
 import Distribution from './Distribution';
 
 const strings = Strings.components.expandableRow;
@@ -101,7 +101,7 @@ function RevisionRowExpandable(props: RevisionRowExpandableProps) {
 }
 
 interface RevisionRowExpandableProps {
-  themeMode: ModeType;
+  themeMode: ThemeMode;
   result: CompareResultsItem;
 }
 

--- a/src/components/CompareResults/beta/RevisionRowExpandable.tsx
+++ b/src/components/CompareResults/beta/RevisionRowExpandable.tsx
@@ -3,22 +3,31 @@ import { style } from 'typestyle';
 
 import { Strings } from '../../../resources/Strings';
 import { Colors, Spacing } from '../../../styles';
-import type { CompareResultsItem } from '../../../types/state';
+import type { CompareResultsItem, ModeType } from '../../../types/state';
 import Distribution from './Distribution';
 
 const strings = Strings.components.expandableRow;
 const { singleRun } = strings;
 
-function shouldDisplayGraphDistribution(baseRuns: Array<number>, newRuns: Array<number>): boolean {
-  if (baseRuns.length > 1 || newRuns.length > 1)
-    return true;
+function shouldDisplayGraphDistribution(
+  baseRuns: Array<number>,
+  newRuns: Array<number>,
+): boolean {
+  if (baseRuns.length > 1 || newRuns.length > 1) return true;
   return false;
 }
 
-
 function RevisionRowExpandable(props: RevisionRowExpandableProps) {
   const { themeMode, result } = props;
-  const { platform, delta_percentage: deltaPercent, delta_value: delta, confidence_text: confidenceText, base_runs: baseRuns, new_runs: newRuns, new_is_better: newIsBetter } = result;
+  const {
+    platform,
+    delta_percentage: deltaPercent,
+    delta_value: delta,
+    confidence_text: confidenceText,
+    base_runs: baseRuns,
+    new_runs: newRuns,
+    new_is_better: newIsBetter,
+  } = result;
   const shouldDisplayGraph = shouldDisplayGraphDistribution(baseRuns, newRuns);
 
   const themeColor200 =
@@ -44,39 +53,55 @@ function RevisionRowExpandable(props: RevisionRowExpandableProps) {
       fontSize: '10px',
       textTransform: 'uppercase',
     }),
-  }; 
+  };
 
   return (
     <div className={`${styles.expandedRow}`}>
       <div className={`${styles.content}`}>
-        <div className={`${styles.bottomSpace}`}><b>{platform}</b> <br /></div>
-        {
-          shouldDisplayGraph &&
-            <div>
-              <div className={`${styles.bottomSpace}`}><Divider /> </div>
-              <Distribution result={result}/>
+        <div className={`${styles.bottomSpace}`}>
+          <b>{platform}</b> <br />
+        </div>
+        {shouldDisplayGraph && (
+          <div>
+            <div className={`${styles.bottomSpace}`}>
+              <Divider />{' '}
             </div>
-        }
-        <div className={`${styles.bottomSpace}`}><Divider /> </div>
-        {!shouldDisplayGraph && <div className={`${styles.bottomSpace}`}>{singleRun}</div> }
-        <div className={`${styles.bottomSpace}`}><b>Mean Difference</b>: {deltaPercent}% {newIsBetter ? 'better' : 'worse'} ({delta})</div>
-        {
-          confidenceText ?
+            <Distribution result={result} />
+          </div>
+        )}
+        <div className={`${styles.bottomSpace}`}>
+          <Divider />{' '}
+        </div>
+        {!shouldDisplayGraph && (
+          <div className={`${styles.bottomSpace}`}>{singleRun}</div>
+        )}
+        <div className={`${styles.bottomSpace}`}>
+          <b>Mean Difference</b>: {deltaPercent}%{' '}
+          {newIsBetter ? 'better' : 'worse'} ({delta})
+        </div>
+        {confidenceText ? (
+          <div>
             <div>
-                <div><b>Confidence</b>: {confidenceText} </div>
-                <div className={styles.note}><b>**Note</b>: {strings[confidenceText]} </div>
-            </div> :
-            <div>
-                <div><b>Confidence</b>: Not available </div>
+              <b>Confidence</b>: {confidenceText}{' '}
             </div>
-        }
+            <div className={styles.note}>
+              <b>**Note</b>: {strings[confidenceText]}{' '}
+            </div>
+          </div>
+        ) : (
+          <div>
+            <div>
+              <b>Confidence</b>: Not available{' '}
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );
 }
 
 interface RevisionRowExpandableProps {
-  themeMode: 'light' | 'dark';
+  themeMode: ModeType;
   result: CompareResultsItem;
 }
 

--- a/src/components/CompareResults/beta/TableContent.tsx
+++ b/src/components/CompareResults/beta/TableContent.tsx
@@ -5,15 +5,14 @@ import { Colors, Spacing } from '../../../styles';
 import type {
   CompareResultsItem,
   RevisionsHeader,
-  ModeType,
+  ThemeMode,
 } from '../../../types/state';
 import RevisionHeader from './RevisionHeader';
 import RevisionRow from './RevisionRow';
 
-
 function TableContent(props: TableContentProps) {
   const { themeMode, results, header } = props;
-  
+
   const styles = {
     tableBody: style({
       marginTop: Spacing.Large,
@@ -40,19 +39,15 @@ function TableContent(props: TableContentProps) {
     <TableBody className={styles.tableBody}>
       <RevisionHeader header={header} />
       {results.length > 0 &&
-            results.map((result, index) => (
-              <RevisionRow 
-                themeMode={themeMode}  
-                key={index}
-                result={result}
-              />
-            ))}
+        results.map((result, index) => (
+          <RevisionRow themeMode={themeMode} key={index} result={result} />
+        ))}
     </TableBody>
   );
 }
 
 interface TableContentProps {
-  themeMode: ModeType;
+  themeMode: ThemeMode;
   results: CompareResultsItem[];
   header: RevisionsHeader;
 }

--- a/src/components/CompareResults/beta/TableContent.tsx
+++ b/src/components/CompareResults/beta/TableContent.tsx
@@ -2,7 +2,11 @@ import { TableBody } from '@mui/material';
 import { style } from 'typestyle';
 
 import { Colors, Spacing } from '../../../styles';
-import type { CompareResultsItem, RevisionsHeader } from '../../../types/state';
+import type {
+  CompareResultsItem,
+  RevisionsHeader,
+  ModeType,
+} from '../../../types/state';
 import RevisionHeader from './RevisionHeader';
 import RevisionRow from './RevisionRow';
 
@@ -48,10 +52,9 @@ function TableContent(props: TableContentProps) {
 }
 
 interface TableContentProps {
-  themeMode: 'light' | 'dark';
+  themeMode: ModeType;
   results: CompareResultsItem[];
   header: RevisionsHeader;
-
 }
 
 export default TableContent;

--- a/src/components/CompareResults/beta/TableHeader.tsx
+++ b/src/components/CompareResults/beta/TableHeader.tsx
@@ -4,6 +4,7 @@ import { TableRow, TableCell, TableHead } from '@mui/material';
 import { style } from 'typestyle';
 
 import { Colors, Spacing } from '../../../styles';
+import type { ModeType } from '../../../types/state';
 
 function TableHeader(props: TableHeaderProps) {
   const { themeMode } = props;
@@ -123,7 +124,7 @@ function TableHeader(props: TableHeaderProps) {
 }
 
 interface TableHeaderProps {
-  themeMode: 'light' | 'dark';
+  themeMode: ModeType;
 }
 
 export default TableHeader;

--- a/src/components/CompareResults/beta/TableHeader.tsx
+++ b/src/components/CompareResults/beta/TableHeader.tsx
@@ -4,7 +4,7 @@ import { TableRow, TableCell, TableHead } from '@mui/material';
 import { style } from 'typestyle';
 
 import { Colors, Spacing } from '../../../styles';
-import type { ModeType } from '../../../types/state';
+import type { ThemeMode } from '../../../types/state';
 
 function TableHeader(props: TableHeaderProps) {
   const { themeMode } = props;
@@ -124,7 +124,7 @@ function TableHeader(props: TableHeaderProps) {
 }
 
 interface TableHeaderProps {
-  themeMode: ModeType;
+  themeMode: ThemeMode;
 }
 
 export default TableHeader;

--- a/src/components/Search/CompareButton.tsx
+++ b/src/components/Search/CompareButton.tsx
@@ -4,11 +4,11 @@ import { style } from 'typestyle';
 import useSelectRevision from '../../hooks/useSelectedRevisions';
 import { Strings } from '../../resources/Strings';
 import { ButtonStyles } from '../../styles';
-import type { ModeType } from '../../types/state';
+import type { ThemeMode, View } from '../../types/state';
 
 interface CompareButtonProps {
-  mode: ModeType;
-  view: 'search' | 'compare-results';
+  mode: ThemeMode;
+  view: View;
 }
 
 const strings = Strings.components.searchDefault.sharedCollasped;

--- a/src/components/Search/CompareButton.tsx
+++ b/src/components/Search/CompareButton.tsx
@@ -4,9 +4,10 @@ import { style } from 'typestyle';
 import useSelectRevision from '../../hooks/useSelectedRevisions';
 import { Strings } from '../../resources/Strings';
 import { ButtonStyles } from '../../styles';
+import type { ModeType } from '../../types/state';
 
 interface CompareButtonProps {
-  mode: 'light' | 'dark';
+  mode: ModeType;
   view: 'search' | 'compare-results';
 }
 

--- a/src/components/Search/CompareOverTime.tsx
+++ b/src/components/Search/CompareOverTime.tsx
@@ -1,6 +1,6 @@
 import { Strings } from '../../resources/Strings';
 import { CompareCardsStyles } from '../../styles';
-import type { ModeType } from '../../types/state';
+import type { ThemeMode } from '../../types/state';
 
 const strings = Strings.components.searchDefault;
 
@@ -24,7 +24,7 @@ function CompareOverTime(props: CompareOverTimeProps) {
 }
 
 interface CompareOverTimeProps {
-  mode: ModeType;
+  mode: ThemeMode;
 }
 
 export default CompareOverTime;

--- a/src/components/Search/CompareOverTime.tsx
+++ b/src/components/Search/CompareOverTime.tsx
@@ -1,5 +1,6 @@
 import { Strings } from '../../resources/Strings';
 import { CompareCardsStyles } from '../../styles';
+import type { ModeType } from '../../types/state';
 
 const strings = Strings.components.searchDefault;
 

--- a/src/components/Search/CompareOverTime.tsx
+++ b/src/components/Search/CompareOverTime.tsx
@@ -23,7 +23,7 @@ function CompareOverTime(props: CompareOverTimeProps) {
 }
 
 interface CompareOverTimeProps {
-  mode: 'light' | 'dark';
+  mode: ModeType;
 }
 
 export default CompareOverTime;

--- a/src/components/Search/CompareWithBase.tsx
+++ b/src/components/Search/CompareWithBase.tsx
@@ -9,7 +9,7 @@ import { useAppSelector } from '../../hooks/app';
 import { Strings } from '../../resources/Strings';
 import { CompareCardsStyles } from '../../styles';
 import { SearchStyles } from '../../styles';
-import { InputType } from '../../types/state';
+import type { ModeType } from '../../types/state';
 import CompareButton from './CompareButton';
 import FrameworkDropdown from './FrameworkDropdown';
 import SearchComponent from './SearchComponent';
@@ -21,7 +21,7 @@ const stringsRevision =
 const warning = strings.base.collapsed.warnings.comparison;
 
 interface CompareWithBaseProps {
-  mode: 'light' | 'dark';
+  mode: ModeType;
   view: 'search' | 'compare-results';
 }
 
@@ -108,12 +108,12 @@ function CompareWithBase({ mode, view }: CompareWithBaseProps) {
         <Divider className='divider' />
         <div ref={formWrapperRef} className='form-wrapper'>
           <SearchComponent
-            searchType={'base' as InputType}
+            searchType='base'
             {...stringsBase}
             {...searchCompCommonProps}
           />
           <SearchComponent
-            searchType={'new' as InputType}
+            searchType='new'
             {...stringsRevision}
             {...searchCompCommonProps}
           />

--- a/src/components/Search/CompareWithBase.tsx
+++ b/src/components/Search/CompareWithBase.tsx
@@ -9,7 +9,7 @@ import { useAppSelector } from '../../hooks/app';
 import { Strings } from '../../resources/Strings';
 import { CompareCardsStyles } from '../../styles';
 import { SearchStyles } from '../../styles';
-import type { ModeType } from '../../types/state';
+import type { ThemeMode, View } from '../../types/state';
 import CompareButton from './CompareButton';
 import FrameworkDropdown from './FrameworkDropdown';
 import SearchComponent from './SearchComponent';
@@ -21,8 +21,8 @@ const stringsRevision =
 const warning = strings.base.collapsed.warnings.comparison;
 
 interface CompareWithBaseProps {
-  mode: ModeType;
-  view: 'search' | 'compare-results';
+  mode: ThemeMode;
+  view: View;
 }
 
 interface Expanded {

--- a/src/components/Search/FrameworkDropdown.tsx
+++ b/src/components/Search/FrameworkDropdown.tsx
@@ -21,6 +21,7 @@ import {
   DropDownMenuRaw,
   DropDownItemRaw,
 } from '../../styles';
+import type { ModeType } from '../../types/state';
 
 interface FrameworkDropdownProps {
   view: 'compare-results' | 'search';

--- a/src/components/Search/FrameworkDropdown.tsx
+++ b/src/components/Search/FrameworkDropdown.tsx
@@ -21,11 +21,11 @@ import {
   DropDownMenuRaw,
   DropDownItemRaw,
 } from '../../styles';
-import type { ModeType } from '../../types/state';
+import type { ThemeMode, View } from '../../types/state';
 
 interface FrameworkDropdownProps {
-  view: 'compare-results' | 'search';
-  mode: ModeType;
+  view: View;
+  mode: ThemeMode;
 }
 
 const strings = Strings.components.searchDefault.sharedCollasped.framkework;

--- a/src/components/Search/FrameworkDropdown.tsx
+++ b/src/components/Search/FrameworkDropdown.tsx
@@ -24,7 +24,7 @@ import {
 
 interface FrameworkDropdownProps {
   view: 'compare-results' | 'search';
-  mode: 'light' | 'dark';
+  mode: ModeType;
 }
 
 const strings = Strings.components.searchDefault.sharedCollasped.framkework;

--- a/src/components/Search/SearchComponent.tsx
+++ b/src/components/Search/SearchComponent.tsx
@@ -6,20 +6,25 @@ import {
   useState,
 } from 'react';
 
+import InfoIcon from '@mui/icons-material/InfoOutlined';
 import Grid from '@mui/material/Grid';
+import InputLabel from '@mui/material/InputLabel';
+import Tooltip from '@mui/material/Tooltip';
 import useMediaQuery from '@mui/material/useMediaQuery';
+import { cssRule } from 'typestyle';
 
 import { RootState } from '../../common/store';
 import { useAppSelector } from '../../hooks/app';
 import { SearchStyles } from '../../styles';
-import type { RevisionsList, InputType } from '../../types/state';
+import { Spacing, DropDownMenuRaw, DropDownItemRaw } from '../../styles';
+import type { RevisionsList, InputType, ModeType } from '../../types/state';
 import SearchDropdown from './SearchDropdown';
 import SearchInput from './SearchInput';
 import SearchResultsList from './SearchResultsList';
 import SelectedRevisions from './SelectedRevisions';
 
 interface SearchProps {
-  mode: 'light' | 'dark';
+  mode: ModeType;
   view: 'compare-results' | 'search';
   setPopoverIsOpen?: Dispatch<SetStateAction<boolean>>;
   prevRevision?: RevisionsList;
@@ -39,6 +44,26 @@ function SearchComponent({
   searchType,
   isWarning,
 }: SearchProps) {
+  cssRule('.MuiPopover-root', {
+    $nest: {
+      '.MuiPaper-root': {
+        flexDirection: 'column',
+        ...(mode === 'light' ? DropDownMenuRaw.Light : DropDownMenuRaw.Dark),
+        $nest: {
+          '.MuiList-root': {
+            padding: `${Spacing.Small}px ${Spacing.xSmall}px`,
+            $nest: {
+              '.MuiMenuItem-root': {
+                ...(mode === 'light'
+                  ? DropDownItemRaw.Light
+                  : DropDownItemRaw.Dark),
+              },
+            },
+          },
+        },
+      },
+    },
+  });
   const styles = SearchStyles(mode);
   const checkedRevisionsList = useAppSelector(
     (state: RootState) => state.search[searchType].checkedRevisions,
@@ -96,51 +121,73 @@ function SearchComponent({
 
   return (
     <Grid className={styles.component}>
-      <Grid
-        container
-        alignItems='flex-start'
-        id={`${searchType}-search-container`}
-        className={styles.container}
-        ref={containerRef}
-      >
+      {view == 'search' && (
+        <Grid
+          container
+          alignItems='flex-start'
+          id={`${searchType}-search-container`}
+          className={styles.container}
+          ref={containerRef}
+        >
+          <Grid
+            item
+            xs={2}
+            id={`${searchType}_search-dropdown`}
+            className={`${searchType}-search-dropdown ${styles.dropDown}`}
+          >
+            <SearchDropdown
+              view={view}
+              selectLabel={selectLabel}
+              tooltipText={tooltip}
+              mode={mode}
+              searchType={searchType}
+            />
+          </Grid>
+
+          <Grid
+            item
+            xs={7}
+            id={`${searchType}_search-input`}
+            className={`${searchType}-search-input ${
+              matchesQuery ? `${searchType}-search-input--mobile` : ''
+            } ${styles.baseSearchInput}`}
+          >
+            <SearchInput
+              mode={mode}
+              setFocused={setFocused}
+              view={view}
+              inputPlaceholder={inputPlaceholder}
+              searchType={searchType}
+            />
+            {searchResults.length > 0 && focused && (
+              <SearchResultsList
+                mode={mode}
+                view={view}
+                searchType={searchType}
+              />
+            )}
+          </Grid>
+        </Grid>
+      )}
+
+      {view == 'compare-results' && (
         <Grid
           item
           xs={2}
           id={`${searchType}_search-dropdown`}
           className={`${searchType}-search-dropdown ${styles.dropDown}`}
         >
-          <SearchDropdown
-            view={view}
-            selectLabel={selectLabel}
-            tooltipText={tooltip}
-            mode={mode}
-            searchType={searchType}
-          />
+          <InputLabel
+            id='select-repository-label'
+            className='dropdown-select-label'
+          >
+            {selectLabel}
+            <Tooltip placement='top' title={tooltip}>
+              <InfoIcon fontSize='small' className='dropdown-info-icon' />
+            </Tooltip>
+          </InputLabel>
         </Grid>
-        <Grid
-          item
-          xs={7}
-          id={`${searchType}_search-input`}
-          className={`${searchType}-search-input ${
-            matchesQuery ? `${searchType}-search-input--mobile` : ''
-          } ${styles.baseSearchInput}`}
-        >
-          <SearchInput
-            mode={mode}
-            setFocused={setFocused}
-            view={view}
-            inputPlaceholder={inputPlaceholder}
-            searchType={searchType}
-          />
-          {searchResults.length > 0 && focused && (
-            <SearchResultsList
-              mode={mode}
-              view={view}
-              searchType={searchType}
-            />
-          )}
-        </Grid>
-      </Grid>
+      )}
 
       {(checkedRevisionsList.length > 0 ||
         (selectedRevisions && selectedRevisions.length > 0)) && (

--- a/src/components/Search/SearchComponent.tsx
+++ b/src/components/Search/SearchComponent.tsx
@@ -17,15 +17,20 @@ import { RootState } from '../../common/store';
 import { useAppSelector } from '../../hooks/app';
 import { SearchStyles } from '../../styles';
 import { Spacing, DropDownMenuRaw, DropDownItemRaw } from '../../styles';
-import type { RevisionsList, InputType, ModeType } from '../../types/state';
+import type {
+  RevisionsList,
+  InputType,
+  ThemeMode,
+  View,
+} from '../../types/state';
 import SearchDropdown from './SearchDropdown';
 import SearchInput from './SearchInput';
 import SearchResultsList from './SearchResultsList';
 import SelectedRevisions from './SelectedRevisions';
 
 interface SearchProps {
-  mode: ModeType;
-  view: 'compare-results' | 'search';
+  mode: ThemeMode;
+  view: View;
   setPopoverIsOpen?: Dispatch<SetStateAction<boolean>>;
   prevRevision?: RevisionsList;
   selectLabel: string;
@@ -44,6 +49,7 @@ function SearchComponent({
   searchType,
   isWarning,
 }: SearchProps) {
+  /* These rules update the theme mode by accessing the otherwise inaccessible MUI tooltip styles*/
   cssRule('.MuiPopover-root', {
     $nest: {
       '.MuiPaper-root': {

--- a/src/components/Search/SearchContainer.tsx
+++ b/src/components/Search/SearchContainer.tsx
@@ -5,7 +5,7 @@ import Typography from '@mui/material/Typography';
 
 import { Strings } from '../../resources/Strings';
 import { SearchContainerStyles } from '../../styles';
-import type { ModeType } from '../../types/state';
+import type { ThemeMode, View } from '../../types/state';
 import CompareOverTime from './CompareOverTime';
 import CompareWithBase from './CompareWithBase';
 
@@ -13,7 +13,7 @@ const strings = Strings.components.searchDefault;
 
 function SearchContainer(props: SearchViewProps) {
   const { themeMode } = props;
-  const view = 'search';
+  const view = 'search' as View;
 
   const styles = SearchContainerStyles(themeMode, view);
 
@@ -32,7 +32,7 @@ function SearchContainer(props: SearchViewProps) {
 }
 
 interface SearchViewProps {
-  themeMode: ModeType;
+  themeMode: ThemeMode;
   containerRef: React.RefObject<HTMLElement>;
 }
 

--- a/src/components/Search/SearchContainer.tsx
+++ b/src/components/Search/SearchContainer.tsx
@@ -5,6 +5,7 @@ import Typography from '@mui/material/Typography';
 
 import { Strings } from '../../resources/Strings';
 import { SearchContainerStyles } from '../../styles';
+import type { ModeType } from '../../types/state';
 import CompareOverTime from './CompareOverTime';
 import CompareWithBase from './CompareWithBase';
 
@@ -17,7 +18,11 @@ function SearchContainer(props: SearchViewProps) {
   const styles = SearchContainerStyles(themeMode, view);
 
   return (
-    <section data-testid="search-section" ref={props.containerRef} className={styles.container}>
+    <section
+      data-testid='search-section'
+      ref={props.containerRef}
+      className={styles.container}
+    >
       <Typography className='search-default-title'>{strings.title}</Typography>
       <CompareWithBase mode={themeMode} view={view} />
       {/* hidden until post-mvp release */}
@@ -27,8 +32,8 @@ function SearchContainer(props: SearchViewProps) {
 }
 
 interface SearchViewProps {
-  themeMode: 'light' | 'dark';
-  containerRef: React.RefObject<HTMLElement>
+  themeMode: ModeType;
+  containerRef: React.RefObject<HTMLElement>;
 }
 
 export default SearchContainer;

--- a/src/components/Search/SearchDropdown.tsx
+++ b/src/components/Search/SearchDropdown.tsx
@@ -19,13 +19,13 @@ import {
   FontsRaw,
   Colors,
 } from '../../styles';
-import { InputType, ModeType } from '../../types/state';
+import { InputType, ThemeMode, View } from '../../types/state';
 
 interface SearchDropdownProps {
-  view: 'compare-results' | 'search';
+  view: View;
   selectLabel: string;
   tooltipText: string;
-  mode: ModeType;
+  mode: ThemeMode;
   searchType: InputType;
 }
 

--- a/src/components/Search/SearchDropdown.tsx
+++ b/src/components/Search/SearchDropdown.tsx
@@ -7,6 +7,7 @@ import Tooltip from '@mui/material/Tooltip';
 import { style, cssRule } from 'typestyle';
 
 import { repoMap } from '../../common/constants';
+import { compareView } from '../../common/constants';
 import { RootState } from '../../common/store';
 import { useAppSelector } from '../../hooks/app';
 import useHandleChangeDropdown from '../../hooks/useHandleChangeDropdown';
@@ -17,16 +18,14 @@ import {
   TooltipRaw,
   FontsRaw,
   Colors,
-  DropDownMenuRaw,
-  DropDownItemRaw,
 } from '../../styles';
-import { InputType } from '../../types/state';
+import { InputType, ModeType } from '../../types/state';
 
 interface SearchDropdownProps {
   view: 'compare-results' | 'search';
   selectLabel: string;
   tooltipText: string;
-  mode: 'light' | 'dark';
+  mode: ModeType;
   searchType: InputType;
 }
 
@@ -37,7 +36,7 @@ function SearchDropdown({
   mode,
   searchType,
 }: SearchDropdownProps) {
-  const size = view == 'compare-results' ? 'small' : undefined;
+  const size = view == compareView ? 'small' : undefined;
   const { handleChangeDropdown } = useHandleChangeDropdown();
   const searchState = useAppSelector(
     (state: RootState) => state.search[searchType],
@@ -61,27 +60,6 @@ function SearchDropdown({
     },
   });
 
-  cssRule('.MuiPopover-root', {
-    $nest: {
-      '.MuiPaper-root': {
-        flexDirection: 'column',
-        ...(mode === 'light' ? DropDownMenuRaw.Light : DropDownMenuRaw.Dark),
-        $nest: {
-          '.MuiList-root': {
-            padding: `${Spacing.Small}px ${Spacing.xSmall}px`,
-            $nest: {
-              '.MuiMenuItem-root': {
-                ...(mode === 'light'
-                  ? DropDownItemRaw.Light
-                  : DropDownItemRaw.Dark),
-              },
-            },
-          },
-        },
-      },
-    },
-  });
-
   const styles = {
     container: style({
       width: '100%',
@@ -96,7 +74,6 @@ function SearchDropdown({
       },
     }),
   };
-
 
   return (
     <div>

--- a/src/components/Search/SearchInput.tsx
+++ b/src/components/Search/SearchInput.tsx
@@ -10,13 +10,13 @@ import { RootState } from '../../common/store';
 import { useAppSelector } from '../../hooks/app';
 import useHandleChangeSearch from '../../hooks/useHandleChangeSearch';
 import { InputStylesRaw, Spacing } from '../../styles';
-import { InputType } from '../../types/state';
+import { InputType, ModeType } from '../../types/state';
 
 interface SearchInputProps {
   setFocused: Dispatch<SetStateAction<boolean>>;
   inputPlaceholder: string;
   view: 'compare-results' | 'search';
-  mode: 'light' | 'dark';
+  mode: ModeType;
   searchType: InputType;
 }
 

--- a/src/components/Search/SearchInput.tsx
+++ b/src/components/Search/SearchInput.tsx
@@ -10,13 +10,13 @@ import { RootState } from '../../common/store';
 import { useAppSelector } from '../../hooks/app';
 import useHandleChangeSearch from '../../hooks/useHandleChangeSearch';
 import { InputStylesRaw, Spacing } from '../../styles';
-import { InputType, ModeType } from '../../types/state';
+import { InputType, ThemeMode, View } from '../../types/state';
 
 interface SearchInputProps {
   setFocused: Dispatch<SetStateAction<boolean>>;
   inputPlaceholder: string;
-  view: 'compare-results' | 'search';
-  mode: ModeType;
+  view: View;
+  mode: ThemeMode;
   searchType: InputType;
 }
 

--- a/src/components/Search/SearchResultsList.tsx
+++ b/src/components/Search/SearchResultsList.tsx
@@ -4,12 +4,12 @@ import List from '@mui/material/List';
 import { RootState } from '../../common/store';
 import { useAppSelector } from '../../hooks/app';
 import { SelectListStyles } from '../../styles';
-import { InputType } from '../../types/state';
+import { InputType, ModeType } from '../../types/state';
 import SearchResultsListItem from './SearchResultsListItem';
 
 interface SearchResultsListProps {
   view: 'compare-results' | 'search';
-  mode: 'light' | 'dark';
+  mode: ModeType;
   searchType: InputType;
 }
 

--- a/src/components/Search/SearchResultsList.tsx
+++ b/src/components/Search/SearchResultsList.tsx
@@ -4,12 +4,12 @@ import List from '@mui/material/List';
 import { RootState } from '../../common/store';
 import { useAppSelector } from '../../hooks/app';
 import { SelectListStyles } from '../../styles';
-import { InputType, ModeType } from '../../types/state';
+import { InputType, ThemeMode, View } from '../../types/state';
 import SearchResultsListItem from './SearchResultsListItem';
 
 interface SearchResultsListProps {
-  view: 'compare-results' | 'search';
-  mode: ModeType;
+  view: View;
+  mode: ThemeMode;
   searchType: InputType;
 }
 

--- a/src/components/Search/SearchView.tsx
+++ b/src/components/Search/SearchView.tsx
@@ -1,16 +1,16 @@
-import { useRef } from 'react';
-import { useEffect } from 'react';
+import { useRef, useEffect } from 'react';
 
 import type { Theme } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { style } from 'typestyle';
 
 import { repoMap } from '../../common/constants';
+import { searchView } from '../../common/constants';
 import { RootState } from '../../common/store';
 import { useAppSelector } from '../../hooks/app';
 import { background } from '../../styles';
 import { skipLink } from '../../styles';
-import { RevisionsList } from '../../types/state';
+import { RevisionsList, View } from '../../types/state';
 import SkipLink from '../Accessibility/SkipLink';
 import PerfCompareHeader from '../Shared/PerfCompareHeader';
 import SearchContainer from './SearchContainer';
@@ -48,12 +48,14 @@ function SearchView(props: SearchViewProps) {
   return (
     <div className={styles.container}>
       <SkipLink containerRef={containerRef}>
-        <button className={skipLink} role="link" tabIndex={1}>Skip to search</button>
-        </SkipLink>
+        <button className={skipLink} role='link' tabIndex={1}>
+          Skip to search
+        </button>
+      </SkipLink>
       <PerfCompareHeader
         themeMode={themeMode}
         toggleColorMode={toggleColorMode}
-        view='search'
+        view={searchView as View}
       />
       <SearchViewInit />
       <SearchContainer containerRef={containerRef} themeMode={themeMode} />

--- a/src/components/Search/SelectedRevisionItem.tsx
+++ b/src/components/Search/SelectedRevisionItem.tsx
@@ -17,7 +17,7 @@ import useCheckRevision from '../../hooks/useCheckRevision';
 import { Strings } from '../../resources/Strings';
 import { SelectRevsStyles } from '../../styles';
 import type { RevisionsList } from '../../types/state';
-import { InputType } from '../../types/state';
+import { InputType, ModeType } from '../../types/state';
 import { truncateHash, getLatestCommitMessage } from '../../utils/helpers';
 
 const warning =
@@ -26,10 +26,11 @@ const warning =
 interface SelectedRevisionItemProps {
   index: number;
   item: RevisionsList;
-  mode: 'light' | 'dark';
+  mode: ModeType;
   repository: string | undefined;
   searchType: InputType;
   isWarning?: boolean;
+  view: 'compare-results' | 'search';
 }
 
 function SelectedRevisionItem({
@@ -39,6 +40,7 @@ function SelectedRevisionItem({
   repository,
   searchType,
   isWarning,
+  view,
 }: SelectedRevisionItemProps) {
   const styles = SelectRevsStyles(mode);
   const revisionHash = truncateHash(item.revision);
@@ -100,6 +102,7 @@ function SelectedRevisionItem({
             primaryTypographyProps={{ noWrap: true }}
             secondaryTypographyProps={{ noWrap: true }}
           />
+
           <ListItemIcon className='search-revision-item-icon search-revision'>
             <Button
               role='button'
@@ -107,7 +110,9 @@ function SelectedRevisionItem({
               aria-label='close-button'
               onClick={() => handleRemoveRevision(item)}
             >
-              <CloseOutlined className='close-icon' fontSize='small' />
+              {view === 'compare-results' && searchType == 'new' && (
+                <CloseOutlined className='close-icon' fontSize='small' />
+              )}
             </Button>
           </ListItemIcon>
         </ListItem>

--- a/src/components/Search/SelectedRevisionItem.tsx
+++ b/src/components/Search/SelectedRevisionItem.tsx
@@ -91,7 +91,10 @@ function SelectedRevisionItem({
   };
 
   return (
-    <div className='item-container' data-testid='selected-rev-item'>
+    <div
+      className={`item-container item-${index} item-${searchType}`}
+      data-testid='selected-rev-item'
+    >
       <div className={styles.repo}>
         <div>{repository || 'unknown'}</div>
         {isWarning && repository === 'try' && (
@@ -153,11 +156,19 @@ function SelectedRevisionItem({
               onClick={handleClose}
             >
               {view == 'search' && (
-                <CloseOutlined className='close-icon' fontSize='small' />
+                <CloseOutlined
+                  className='close-icon'
+                  fontSize='small'
+                  data-testid='close-icon'
+                />
               )}
 
               {view == 'compare-results' && searchType == 'new' && (
-                <CloseOutlined className='close-icon' fontSize='small' />
+                <CloseOutlined
+                  className='icon icon-close'
+                  fontSize='small'
+                  data-testid='close-icon'
+                />
               )}
             </Button>
           </ListItemIcon>

--- a/src/components/Search/SelectedRevisions.tsx
+++ b/src/components/Search/SelectedRevisions.tsx
@@ -9,18 +9,18 @@ import { useAppSelector } from '../../hooks/app';
 import { SelectRevsStyles } from '../../styles';
 import {
   InputType,
-  ViewType,
+  View,
   RevisionsList,
   Repository,
-  ModeType,
+  ThemeMode,
 } from '../../types/state';
 import SelectedRevisionItem from './SelectedRevisionItem';
 
 interface SelectedRevisionsProps {
-  mode: ModeType;
+  mode: ThemeMode;
   searchType: InputType;
   isWarning: boolean;
-  view: ViewType;
+  view: View;
 }
 
 function SelectedRevisions({

--- a/src/components/Search/SelectedRevisions.tsx
+++ b/src/components/Search/SelectedRevisions.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import Box from '@mui/material/Box';
 import List from '@mui/material/List';
 
@@ -5,14 +7,20 @@ import { repoMap } from '../../common/constants';
 import { RootState } from '../../common/store';
 import { useAppSelector } from '../../hooks/app';
 import { SelectRevsStyles } from '../../styles';
-import { InputType } from '../../types/state';
+import {
+  InputType,
+  ViewType,
+  RevisionsList,
+  Repository,
+  ModeType,
+} from '../../types/state';
 import SelectedRevisionItem from './SelectedRevisionItem';
 
 interface SelectedRevisionsProps {
-  mode: 'light' | 'dark';
+  mode: ModeType;
   searchType: InputType;
   isWarning: boolean;
-  view: 'compare-results' | 'search';
+  view: ViewType;
 }
 
 function SelectedRevisions({
@@ -21,8 +29,9 @@ function SelectedRevisions({
   isWarning,
   view,
 }: SelectedRevisionsProps) {
-
   const styles = SelectRevsStyles(mode);
+  const [revisions, setRevisions] = useState<RevisionsList[]>([]);
+  const [repositories, setRepositories] = useState<Repository['name'][]>([]);
   const checkedRevisionsList = useAppSelector(
     (state: RootState) => state.search[searchType].checkedRevisions,
   );
@@ -35,7 +44,7 @@ function SelectedRevisions({
     (state: RootState) => state.selectedRevisions[searchType],
   );
 
-  const repository = checkedRevisionsList.map((item) => {
+  const checkedRepositories = checkedRevisionsList.map((item) => {
     const selectedRep = repoMap[item.repository_id];
     return selectedRep;
   });
@@ -45,36 +54,33 @@ function SelectedRevisions({
     return selectedRep;
   });
 
+  useEffect(() => {
+    if (view == 'search') {
+      setRevisions(checkedRevisionsList);
+      setRepositories(checkedRepositories as Repository['name'][]);
+    }
+
+    if (view == 'compare-results') {
+      setRevisions(displayedSelectedRevisions);
+      setRepositories(selectedRevRepo as Repository['name'][]);
+    }
+  }, [checkedRevisionsList, selectedRevisions]);
+
   return (
     <Box className={styles.box} data-testid={`selected-revs-${view}`}>
       <List>
-        {view == 'search' &&
-          checkedRevisionsList.map((item, index) => (
-            <SelectedRevisionItem
-              key={item.id}
-              index={index}
-              item={item}
-              mode={mode}
-              repository={repository[index]}
-              searchType={searchType}
-              isWarning={isWarning}
-            />
-          ))}
-
-        {view == 'compare-results' &&
-          displayedSelectedRevisions.map((item, index) => (
-            // This line will be ignored by code coverage
-            // istanbul ignore next
-            <SelectedRevisionItem
-              key={item.id}
-              index={index}
-              item={item}
-              mode={mode}
-              repository={selectedRevRepo && selectedRevRepo[index]}
-              searchType={searchType}
-              isWarning={isWarning}
-            />
-          ))}
+        {revisions.map((item, index) => (
+          <SelectedRevisionItem
+            key={item.id}
+            index={index}
+            item={item}
+            mode={mode}
+            repository={repositories[index]}
+            searchType={searchType}
+            isWarning={isWarning}
+            view={view}
+          />
+        ))}
       </List>
     </Box>
   );

--- a/src/components/Shared/PerfCompareHeader.tsx
+++ b/src/components/Shared/PerfCompareHeader.tsx
@@ -8,7 +8,7 @@ import { HeaderStyles } from '../../styles';
 import ToggleDarkMode from './ToggleDarkModeButton';
 
 interface PerfCompareHeaderProps {
-  themeMode: 'light' | 'dark';
+  themeMode: ModeType;
   toggleColorMode: () => void;
   view: 'search' | 'compare-results';
 }

--- a/src/components/Shared/PerfCompareHeader.tsx
+++ b/src/components/Shared/PerfCompareHeader.tsx
@@ -5,6 +5,7 @@ import Typography from '@mui/material/Typography';
 
 import { Strings } from '../../resources/Strings';
 import { HeaderStyles } from '../../styles';
+import type { ModeType } from '../../types/state';
 import ToggleDarkMode from './ToggleDarkModeButton';
 
 interface PerfCompareHeaderProps {

--- a/src/components/Shared/PerfCompareHeader.tsx
+++ b/src/components/Shared/PerfCompareHeader.tsx
@@ -5,11 +5,11 @@ import Typography from '@mui/material/Typography';
 
 import { Strings } from '../../resources/Strings';
 import { HeaderStyles } from '../../styles';
-import type { ModeType } from '../../types/state';
+import type { ThemeMode } from '../../types/state';
 import ToggleDarkMode from './ToggleDarkModeButton';
 
 interface PerfCompareHeaderProps {
-  themeMode: ModeType;
+  themeMode: ThemeMode;
   toggleColorMode: () => void;
   view: 'search' | 'compare-results';
 }

--- a/src/components/Shared/ToggleDarkModeButton.tsx
+++ b/src/components/Shared/ToggleDarkModeButton.tsx
@@ -7,7 +7,7 @@ import { style } from 'typestyle';
 
 import { Strings } from '../../resources/Strings';
 import { Spacing, FontsRaw, SwitchRaw } from '../../styles';
-import type { ModeType } from '../../types/state';
+import type { ThemeMode } from '../../types/state';
 
 const strings = Strings.components.header;
 const label = { inputProps: { 'aria-label': 'Dark mode switch' } };
@@ -66,7 +66,7 @@ function ToggleDarkMode(props: ToggleDarkModeProps) {
   );
 }
 interface ToggleDarkModeProps {
-  theme: ModeType;
+  theme: ThemeMode;
   toggleColorMode: () => void;
 }
 

--- a/src/components/Shared/ToggleDarkModeButton.tsx
+++ b/src/components/Shared/ToggleDarkModeButton.tsx
@@ -7,6 +7,7 @@ import { style } from 'typestyle';
 
 import { Strings } from '../../resources/Strings';
 import { Spacing, FontsRaw, SwitchRaw } from '../../styles';
+import type { ModeType } from '../../types/state';
 
 const strings = Strings.components.header;
 const label = { inputProps: { 'aria-label': 'Dark mode switch' } };
@@ -65,7 +66,7 @@ function ToggleDarkMode(props: ToggleDarkModeProps) {
   );
 }
 interface ToggleDarkModeProps {
-  theme: 'light' | 'dark';
+  theme: ModeType;
   toggleColorMode: () => void;
 }
 

--- a/src/hooks/useSelectedRevisions.ts
+++ b/src/hooks/useSelectedRevisions.ts
@@ -1,4 +1,7 @@
-import { setSelectedRevisions } from '../reducers/SelectedRevisionsSlice';
+import {
+  setSelectedRevisions,
+  deleteRevision,
+} from '../reducers/SelectedRevisionsSlice';
 import { RevisionsList } from '../types/state';
 import { useAppDispatch, useAppSelector } from './app';
 
@@ -29,7 +32,13 @@ const useSelectRevision = () => {
     dispatch(setSelectedRevisions({ selectedRevisions: filteredSelected }));
   };
 
-  return { addSelectedRevisions };
+  const deleteSelectedRevisions = (revision: RevisionsList) => {
+    const newSelected = [...selectedRevisions];
+    newSelected.splice(selectedRevisions.indexOf(revision), 1);
+    dispatch(deleteRevision({ selectedRevisions: newSelected }));
+  };
+
+  return { addSelectedRevisions, deleteSelectedRevisions };
 };
 
 export default useSelectRevision;

--- a/src/reducers/SelectedRevisionsSlice.ts
+++ b/src/reducers/SelectedRevisionsSlice.ts
@@ -20,6 +20,10 @@ const selectedRevisions = createSlice({
       }>,
     ) {
       state.revisions = action.payload.selectedRevisions;
+      state.base = [action.payload.selectedRevisions[0]];
+      state.new = action.payload.selectedRevisions.filter(
+        (_, index) => index !== 0,
+      );
     },
     deleteRevision(
       state,

--- a/src/reducers/SelectedRevisionsSlice.ts
+++ b/src/reducers/SelectedRevisionsSlice.ts
@@ -23,13 +23,14 @@ const selectedRevisions = createSlice({
     },
     deleteRevision(
       state,
-      action: PayloadAction<{ selectedRevision: RevisionsList }>,
+      action: PayloadAction<{
+        selectedRevisions: RevisionsList[];
+      }>,
     ) {
       return {
         ...state,
-        revisions: state.revisions.filter(
-          (revision) => revision.id !== action.payload.selectedRevision.id,
-        ),
+        revisions: action.payload.selectedRevisions,
+        new: action.payload.selectedRevisions.filter((_, index) => index !== 0),
       };
     },
 

--- a/src/styles/SelectList.ts
+++ b/src/styles/SelectList.ts
@@ -1,6 +1,6 @@
 import { style } from 'typestyle';
 
-import { ModeType } from '../types/state';
+import { ThemeMode } from '../types/state';
 import { Colors } from './Colors';
 import { FontsRaw } from './Fonts';
 import { Spacing } from './Spacing';
@@ -137,6 +137,6 @@ export const SelectListDark = style({
 });
 
 export const SelectListStyles = (mode: string) => {
-  const themeMode = mode as ModeType;
+  const themeMode = mode as ThemeMode;
   return themeMode === 'light' ? SelectListLight : SelectListDark;
 };

--- a/src/styles/SelectList.ts
+++ b/src/styles/SelectList.ts
@@ -1,5 +1,6 @@
 import { style } from 'typestyle';
 
+import { ModeType } from '../types/state';
 import { Colors } from './Colors';
 import { FontsRaw } from './Fonts';
 import { Spacing } from './Spacing';
@@ -136,6 +137,6 @@ export const SelectListDark = style({
 });
 
 export const SelectListStyles = (mode: string) => {
-  const themeMode = mode as 'light' | 'dark';
+  const themeMode = mode as ModeType;
   return themeMode === 'light' ? SelectListLight : SelectListDark;
 };

--- a/src/theme/protocolTheme.ts
+++ b/src/theme/protocolTheme.ts
@@ -5,6 +5,7 @@ import { useMemo, useState, useEffect } from 'react';
 import { createTheme, Theme } from '@mui/material/styles';
 
 import { Colors } from '../styles';
+import type { ModeType } from '../types/state';
 import components from './components';
 import typography from './typography';
 
@@ -52,7 +53,7 @@ const darkMode = {
   },
 };
 
-const getDesignTokens = (modeVal: 'light' | 'dark') => ({
+const getDesignTokens = (modeVal: ModeType) => ({
   palette: {
     mode: modeVal,
     ...(modeVal === 'light' ? lightMode : darkMode),
@@ -61,7 +62,7 @@ const getDesignTokens = (modeVal: 'light' | 'dark') => ({
 
 const useProtocolTheme = () => {
   const storedMode = localStorage.getItem('theme') || 'light';
-  const [mode, setMode] = useState((storedMode as 'light' | 'dark') || 'light');
+  const [mode, setMode] = useState((storedMode as ModeType) || 'light');
 
   useEffect(() => {
     localStorage.setItem('theme', mode);

--- a/src/theme/protocolTheme.ts
+++ b/src/theme/protocolTheme.ts
@@ -5,7 +5,7 @@ import { useMemo, useState, useEffect } from 'react';
 import { createTheme, Theme } from '@mui/material/styles';
 
 import { Colors } from '../styles';
-import type { ModeType } from '../types/state';
+import type { ThemeMode } from '../types/state';
 import components from './components';
 import typography from './typography';
 
@@ -53,7 +53,7 @@ const darkMode = {
   },
 };
 
-const getDesignTokens = (modeVal: ModeType) => ({
+const getDesignTokens = (modeVal: ThemeMode) => ({
   palette: {
     mode: modeVal,
     ...(modeVal === 'light' ? lightMode : darkMode),
@@ -62,7 +62,7 @@ const getDesignTokens = (modeVal: ModeType) => ({
 
 const useProtocolTheme = () => {
   const storedMode = localStorage.getItem('theme') || 'light';
-  const [mode, setMode] = useState((storedMode as ModeType) || 'light');
+  const [mode, setMode] = useState((storedMode as ThemeMode) || 'light');
 
   useEffect(() => {
     localStorage.setItem('theme', mode);

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -101,6 +101,10 @@ export type SearchStateForInput = {
 
 export type InputType = 'base' | 'new';
 
+export type ViewType = 'compare-results' | 'search';
+
+export type ModeType = 'light' | 'dark'; 
+
 export type SearchState = Record<InputType, SearchStateForInput>;
 
 export type SelectedRevisionsState = {

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -101,9 +101,9 @@ export type SearchStateForInput = {
 
 export type InputType = 'base' | 'new';
 
-export type ViewType = 'compare-results' | 'search';
+export type View = 'compare-results' | 'search';
 
-export type ModeType = 'light' | 'dark'; 
+export type ThemeMode = 'light' | 'dark';
 
 export type SearchState = Record<InputType, SearchStateForInput>;
 


### PR DESCRIPTION
This PR fulfills task [Show expanded base component with selected revisions](https://mozilla-hub.atlassian.net/browse/PCF-268) for the epic [Results: Display the inputs selected for Compare with a base](https://mozilla-hub.atlassian.net/browse/PCF-215).

Note: This patch has a lot of file changes because I change type `'light' | 'dark'` to `ModeType`. To see relevant changes related to this patch please looks at: 

- ` src/components/Search/SelectedRevisions.tsx`
- `src/components/Search/SelectedRevisionItem.tsx`
- `src/components/Search/SearchComponent.tsx`

<img width="1669" alt="Screenshot 2023-07-20 at 14 17 25" src="https://github.com/mozilla/perfcompare/assets/88336547/a78f4722-b7a3-4f4a-8ff7-b733684ae4ba">
