### PR TITLE
Results: Integrate results data

### DIFF
--- a/src/__tests__/Search/CompareWithBase.test.tsx
+++ b/src/__tests__/Search/CompareWithBase.test.tsx
@@ -144,7 +144,7 @@ describe('Compare With Base 3', () => {
     expect(history.location.pathname).toEqual('/compare-results');
 
     expect(history.location.search).toEqual(
-      '?revs=coconut,spam&repos=try,mozilla-central',
+      '?revs=coconut,spam&repos=try,mozilla-central&framework=1',
     );
 
     renderWithRouter(

--- a/src/__tests__/Search/SearchView.test.tsx
+++ b/src/__tests__/Search/SearchView.test.tsx
@@ -316,7 +316,7 @@ describe('Base Search', () => {
 
     expect(history.location.pathname).toEqual('/compare-results');
     expect(history.location.search).toEqual(
-      '?revs=coconut,spam&repos=try,mozilla-central',
+      '?revs=coconut,spam&repos=try,mozilla-central&framework=1',
     );
   });
 });

--- a/src/__tests__/hooks/useFetchCompareResults.test.ts
+++ b/src/__tests__/hooks/useFetchCompareResults.test.ts
@@ -23,7 +23,7 @@ describe('Tests useFetchCompareResults', () => {
       },
     } = renderHook(() => useFetchCompareResults(), { wrapper: StoreProvider });
     const spyOnFetch = jest.spyOn(global, 'fetch');
-    await dispatchFetchCompareResults(['fenix'], ['testRev']);
+    await dispatchFetchCompareResults(['fenix'], ['testRev'], '1');
     const url = new URL(spyOnFetch.mock.calls[0][0] as string);
     const searchParams = new URLSearchParams(url.search);
     expect(searchParams.get('base_revision')).toBe('testRev');
@@ -41,6 +41,7 @@ describe('Tests useFetchCompareResults', () => {
     await dispatchFetchCompareResults(
       ['fenix', 'try'],
       ['testRev1', 'testRev2'],
+      '1',
     );
     const url = new URL(spyOnFetch.mock.calls[0][0] as string);
     const searchParams = new URLSearchParams(url.search);
@@ -49,7 +50,7 @@ describe('Tests useFetchCompareResults', () => {
     expect(searchParams.get('base_repository')).toBe('fenix');
     expect(searchParams.get('new_repository')).toBe('try');
   });
-  it('Should not fetch if provided with 3 or more revs', async () => {
+  it('Should fetch if provided with 4 revs', async () => {
     const {
       result: {
         current: { dispatchFetchCompareResults },
@@ -57,8 +58,23 @@ describe('Tests useFetchCompareResults', () => {
     } = renderHook(() => useFetchCompareResults(), { wrapper: StoreProvider });
     const spyOnFetch = jest.spyOn(global, 'fetch');
     await dispatchFetchCompareResults(
-      ['fenix', 'try'],
-      ['testRev1', 'testRev2', 'testRev3'],
+      ['fenix', 'try', 'mozilla-beta', 'autoland'],
+      ['testRev1', 'testRev2', 'testRev3', 'testRev4'],
+      '1',
+    );
+    expect(spyOnFetch).toBeCalledTimes(3);
+  });
+  it('Should not fetch if provided with 5 or more revs', async () => {
+    const {
+      result: {
+        current: { dispatchFetchCompareResults },
+      },
+    } = renderHook(() => useFetchCompareResults(), { wrapper: StoreProvider });
+    const spyOnFetch = jest.spyOn(global, 'fetch');
+    await dispatchFetchCompareResults(
+      ['fenix', 'try', 'mozilla-beta', 'autoland', 'mozilla-central'],
+      ['testRev1', 'testRev2', 'testRev3', 'testRev4', 'testRev5'],
+      '1',
     );
     expect(spyOnFetch).not.toBeCalled();
   });

--- a/src/__tests__/hooks/useFetchCompareResults.ts
+++ b/src/__tests__/hooks/useFetchCompareResults.ts
@@ -25,7 +25,7 @@ describe('Tests useFetchCompareResults', () => {
       wrapper: StoreProvider,
     });
     const spyOnFetch = jest.spyOn(global, 'fetch');
-    await dispatchFetchCompareResults(['fenix'], ['testRev']);
+    await dispatchFetchCompareResults(['fenix'], ['testRev'], '1');
     expect(spyOnFetch).toBeCalledTimes(1);
   });
 });

--- a/src/components/CompareResults/beta/ResultsTable.tsx
+++ b/src/components/CompareResults/beta/ResultsTable.tsx
@@ -43,7 +43,6 @@ function processResults(results: CompareResultsItem[]) {
       processedResults.set(rowIdentifier, [result]);
     }
   });
-
   const restructuredResults: Results[] = Array.from(
     processedResults,
     function (entry) {
@@ -126,10 +125,9 @@ function ResultsTable(props: ResultsTableProps) {
               results={res.value}
             />
           ))}
-          {/* )} */}
         </Table>
       )}
-      {processedResults.length == 0 && <NoResultsFound />}
+      {!loading && processedResults.length == 0 && <NoResultsFound />}
     </TableContainer>
   );
 }

--- a/src/components/CompareResults/beta/ResultsTable.tsx
+++ b/src/components/CompareResults/beta/ResultsTable.tsx
@@ -77,7 +77,9 @@ function ResultsTable(props: ResultsTableProps) {
     const { activeComparison } = state.comparison;
 
     if (activeComparison === allRevisionsOption) {
-      const allResults = [].concat(...Object.values(data));
+      const allResults = ([] as CompareResultsItem[]).concat(
+        ...Object.values(data),
+      );
       return processResults(allResults);
     } else {
       const results = data[activeComparison];

--- a/src/components/CompareResults/beta/ResultsTable.tsx
+++ b/src/components/CompareResults/beta/ResultsTable.tsx
@@ -1,3 +1,5 @@
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
 import Paper from '@mui/material/Paper';
 import Table from '@mui/material/Table';
 import TableContainer from '@mui/material/TableContainer';
@@ -11,7 +13,6 @@ import type {
   RevisionsHeader,
   ThemeMode,
 } from '../../../types/state';
-import { truncateHash } from '../../../utils/helpers';
 import NoResultsFound from './NoResultsFound';
 import TableContent from './TableContent';
 import TableHeader from './TableHeader';
@@ -42,6 +43,7 @@ function processResults(results: CompareResultsItem[]) {
       processedResults.set(rowIdentifier, [result]);
     }
   });
+
   const restructuredResults: Results[] = Array.from(
     processedResults,
     function (entry) {
@@ -68,17 +70,17 @@ function ResultsTable(props: ResultsTableProps) {
   const allRevisionsOption =
     Strings.components.comparisonRevisionDropdown.allRevisions;
 
+  const loading = useAppSelector((state) => state.compareResults.loading);
+
   const processedResults = useAppSelector((state) => {
     const { data } = state.compareResults;
     const { activeComparison } = state.comparison;
 
     if (activeComparison === allRevisionsOption) {
-      return processResults(data);
+      const allResults = [].concat(...Object.values(data));
+      return processResults(allResults);
     } else {
-      const results = data.filter(
-        (rev) => truncateHash(rev.new_rev) === activeComparison,
-      );
-
+      const results = data[activeComparison];
       return processResults(results);
     }
   });
@@ -107,17 +109,24 @@ function ResultsTable(props: ResultsTableProps) {
       data-testid='results-table'
       sx={customStyles}
     >
-      <Table>
-        <TableHeader themeMode={themeMode} />
-        {processedResults.map((res, index) => (
-          <TableContent
-            themeMode={themeMode}
-            key={index}
-            header={res.revisionHeader}
-            results={res.value}
-          />
-        ))}
-      </Table>
+      {loading ? (
+        <Box display='flex' justifyContent='center' alignItems='center'>
+          <CircularProgress />
+        </Box>
+      ) : (
+        <Table>
+          <TableHeader themeMode={themeMode} />
+          {processedResults.map((res, index) => (
+            <TableContent
+              themeMode={themeMode}
+              key={index}
+              header={res.revisionHeader}
+              results={res.value}
+            />
+          ))}
+          {/* )} */}
+        </Table>
+      )}
       {processedResults.length == 0 && <NoResultsFound />}
     </TableContainer>
   );

--- a/src/components/CompareResults/beta/ResultsView.tsx
+++ b/src/components/CompareResults/beta/ResultsView.tsx
@@ -44,17 +44,18 @@ function ResultsView(props: ResultsViewProps) {
   const [searchParams] = useSearchParams();
   const fakeDataParam: string | null = searchParams.get('fakedata');
 
-  const comparisonResults = firstRevisionResults.concat(
-    secondRevisionResults,
-    thirdRevisionResults,
-  );
+  const comparisonResults = {
+    bb6a5e451dac: firstRevisionResults,
+    '9d5066525489': secondRevisionResults,
+    a998c42399a8: thirdRevisionResults,
+  };
 
   // TODO: Populate store with real data or fake data pased on URL params
   useEffect(() => {
     if (fakeDataParam === 'true') {
       dispatch(setCompareData({ data: comparisonResults }));
     } else {
-      dispatch(setCompareData({ data: [] }));
+      dispatch(setCompareData({ data: {} }));
     }
   }, [fakeDataParam]);
 
@@ -72,9 +73,14 @@ function ResultsView(props: ResultsViewProps) {
     const urlSearchParams = new URLSearchParams(location.search);
     const repos = urlSearchParams.get('repos')?.split(',');
     const revs = urlSearchParams.get('revs')?.split(',');
+    const framework = urlSearchParams.get('framework');
 
     if (revs && repos) {
-      void dispatchFetchCompareResults(repos as Repository['name'][], revs);
+      void dispatchFetchCompareResults(
+        repos as Repository['name'][],
+        revs,
+        framework as string,
+      );
 
       /*
       On component mount, use the repos and revs in hash to search for the base and new revisions. Store the results in state via the SelectedRevisionsSlice: see extra reducer, fetchRevisionsByID. Now can always display the selected revisions despite page refresh or copying and pasting url

--- a/src/components/Search/SearchView.tsx
+++ b/src/components/Search/SearchView.tsx
@@ -25,7 +25,9 @@ function SearchView(props: SearchViewProps) {
   const selectedRevisions = useAppSelector(
     (state: RootState) => state.selectedRevisions.revisions,
   );
-  const framework = useAppSelector((state: RootState) => state.framework);
+  const framework = useAppSelector(
+    (state: RootState) => state.framework as Framework,
+  );
 
   const styles = {
     container: style({

--- a/src/components/Search/SearchView.tsx
+++ b/src/components/Search/SearchView.tsx
@@ -11,6 +11,7 @@ import { useAppSelector } from '../../hooks/app';
 import { background } from '../../styles';
 import { skipLink } from '../../styles';
 import { RevisionsList, View } from '../../types/state';
+import { Framework } from '../../types/types';
 import SkipLink from '../Accessibility/SkipLink';
 import PerfCompareHeader from '../Shared/PerfCompareHeader';
 import SearchContainer from './SearchContainer';
@@ -24,18 +25,24 @@ function SearchView(props: SearchViewProps) {
   const selectedRevisions = useAppSelector(
     (state: RootState) => state.selectedRevisions.revisions,
   );
+  const framework = useAppSelector((state: RootState) => state.framework);
 
   const styles = {
     container: style({
       backgroundColor: background(themeMode),
     }),
   };
-  const goToCompareResultsPage = (selectedRevs: RevisionsList[]) => {
+  const goToCompareResultsPage = (
+    selectedRevs: RevisionsList[],
+    selectedFramework: Framework,
+  ) => {
     const revs = selectedRevs.map((rev) => rev.revision);
     const repos = selectedRevs.map((rev) => repoMap[rev.repository_id]);
     navigate({
       pathname: '/compare-results',
-      search: `?revs=${revs.join(',')}&repos=${repos.join(',')}`,
+      search: `?revs=${revs.join(',')}&repos=${repos.join(',')}&framework=${
+        selectedFramework.id
+      }`,
     });
   };
 
@@ -45,7 +52,7 @@ function SearchView(props: SearchViewProps) {
 
   useEffect(() => {
     if (selectedRevisions.length > 0) {
-      goToCompareResultsPage(selectedRevisions);
+      goToCompareResultsPage(selectedRevisions, framework);
     }
   }, [selectedRevisions]);
 

--- a/src/components/Search/SelectedRevisionItem.tsx
+++ b/src/components/Search/SelectedRevisionItem.tsx
@@ -56,6 +56,7 @@ function SelectedRevisionItem({
   const selectedRevisions = useAppSelector(
     (state) => state.selectedRevisions.revisions,
   );
+  const selectedFramework = useAppSelector((state) => state.framework);
   const navigate = useNavigate();
   const prevRevRef = React.useRef<RevisionsList[]>([]);
 
@@ -65,7 +66,9 @@ function SelectedRevisionItem({
 
     navigate({
       pathname: '/compare-results',
-      search: `?revs=${revs.join(',')}&repos=${repos.join(',')}`,
+      search: `?revs=${revs.join(',')}&repos=${repos.join(',')}&framework=${
+        selectedFramework.id
+      }`,
     });
   };
 

--- a/src/hooks/useFetchCompareResults.ts
+++ b/src/hooks/useFetchCompareResults.ts
@@ -8,6 +8,7 @@ function useFetchCompareResults() {
   const dispatchFetchCompareResults = async (
     repos: Repository['name'][] | null,
     revs: string[] | undefined,
+    framework: string,
   ) => {
     let baseRepo;
     let baseRev;
@@ -19,7 +20,13 @@ function useFetchCompareResults() {
         baseRepo = newRepo = repos[0];
         baseRev = newRev = revs[0];
         void dispatch(
-          fetchCompareResults({ baseRepo, baseRev, newRepo, newRev }),
+          fetchCompareResults({
+            baseRepo,
+            baseRev,
+            newRepo,
+            newRev,
+            framework,
+          }),
         );
       } else if (revs.length == 2) {
         baseRepo = repos[0];
@@ -27,10 +34,33 @@ function useFetchCompareResults() {
         newRepo = repos[1];
         newRev = revs[1];
         void dispatch(
-          fetchCompareResults({ baseRepo, baseRev, newRepo, newRev }),
+          fetchCompareResults({
+            baseRepo,
+            baseRev,
+            newRepo,
+            newRev,
+            framework,
+          }),
         );
+      } else if (revs.length > 2 && revs.length <= 4) {
+        baseRepo = repos[0];
+        baseRev = revs[0];
+        newRepo = repos[1];
+        newRev = revs[1];
+        for (let i = 1; i < revs.length; i++) {
+          newRepo = repos[i];
+          newRev = revs[i];
+          void dispatch(
+            fetchCompareResults({
+              baseRepo,
+              baseRev,
+              newRepo,
+              newRev,
+              framework,
+            }),
+          );
+        }
       }
-      // TODO: handle case for more than two selected revisions
     }
   };
   return { dispatchFetchCompareResults };

--- a/src/reducers/CompareResults.ts
+++ b/src/reducers/CompareResults.ts
@@ -1,9 +1,10 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import type { CompareResultsItem, CompareResultsState } from '../types/state';
+import { fetchCompareResults } from '../thunks/compareResultsThunk';
+import type { CompareResultsState, ResultsHashmap } from '../types/state';
 
 const initialState: CompareResultsState = {
-  data: [],
+  data: {},
   loading: false,
   error: undefined,
 };
@@ -15,11 +16,27 @@ const compareResults = createSlice({
     setCompareData(
       state,
       action: PayloadAction<{
-        data: CompareResultsItem[];
+        data: ResultsHashmap;
       }>,
     ) {
       state.data = action.payload.data;
     },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchCompareResults.fulfilled, (state, action) => {
+        const revisionHash = action.payload[0].new_rev;
+        state.data[revisionHash] = action.payload;
+        state.loading = initialState.loading;
+      })
+      .addCase(fetchCompareResults.pending, (state) => {
+        state.loading = true;
+        state.error = initialState.error;
+      })
+      .addCase(fetchCompareResults.rejected, (state, action) => {
+        state.error = action.payload;
+        state.loading = initialState.loading;
+      });
   },
 });
 

--- a/src/thunks/compareResultsThunk.ts
+++ b/src/thunks/compareResultsThunk.ts
@@ -10,7 +10,7 @@ export const fetchCompareResults = createAsyncThunk<
     baseRev: string;
     newRepo: Repository['name'];
     newRev: string;
-    framework: string;
+    framework: string; // expected values are the framework's ids (frameworks examples talos, awsy, mozperftest, browsertime, build_metrics)
   },
   { rejectValue: string }
 >(

--- a/src/thunks/compareResultsThunk.ts
+++ b/src/thunks/compareResultsThunk.ts
@@ -10,16 +10,29 @@ export const fetchCompareResults = createAsyncThunk<
     baseRev: string;
     newRepo: Repository['name'];
     newRev: string;
+    framework: string;
   },
   { rejectValue: string }
 >(
   'compareResults/fetchCompareResults',
-  async ({ baseRepo, baseRev, newRepo, newRev }, { rejectWithValue }) => {
+  async (
+    { baseRepo, baseRev, newRepo, newRev, framework },
+    { rejectWithValue },
+  ) => {
     let response;
     try {
       //Note: We can now select and add the framework in the url
+      const searchParams = new URLSearchParams({
+        base_repository: baseRepo,
+        base_revision: baseRev,
+        new_repository: newRepo,
+        new_revision: newRev,
+        framework,
+        interval: '86400',
+        no_subtests: 'true',
+      });
       response = await fetch(
-        `${treeherderBaseURL}/api/perfcompare/results/?base_repository=${baseRepo}&base_revision=${baseRev}&new_repository=${newRepo}&new_revision=${newRev}&framework=1&interval=86400&no_subtests=true`,
+        `${treeherderBaseURL}/api/perfcompare/results/?${searchParams.toString()}`,
       );
     } catch (err) {
       return rejectWithValue((err as Error).message);

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -113,8 +113,12 @@ export type SelectedRevisionsState = {
   new: RevisionsList[];
 };
 
+export interface ResultsHashmap {
+  [key: string]: CompareResultsItem[];
+}
+
 export type CompareResultsState = {
-  data: CompareResultsItem[];
+  data: ResultsHashmap;
   loading: boolean;
   error: string | undefined;
 };


### PR DESCRIPTION
Acceptance criteria:

- [x] keep the results in state from all the comparations between base revisions and all the new revision
- [x] add framework param to the URL
- [x] use the selected framework to make the call
- [x] by default the displayed data should be a combination of responses from all the calls to the backend