### PR TITLE
PCF - 250 Results: Add implementation for switching between comparisons Part 2

### DIFF
--- a/src/components/CompareResults/beta/RevisionSelect.tsx
+++ b/src/components/CompareResults/beta/RevisionSelect.tsx
@@ -4,11 +4,13 @@ import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import SvgIcon from '@mui/material/SvgIcon';
 import { useDispatch } from 'react-redux';
+import { useSearchParams } from 'react-router-dom';
 import { style } from 'typestyle';
 
 import { useAppSelector } from '../../../hooks/app';
 import { updateComparison } from '../../../reducers/ComparisonSlice';
 import { Strings } from '../../../resources/Strings';
+import { truncateHash } from '../../../utils/helpers';
 
 const styles = {
   box: style({
@@ -23,7 +25,7 @@ const styles = {
 const allRevisionsOption =
   Strings.components.comparisonRevisionDropdown.allRevisions;
 
-const revisionsOptions = [
+const fakeRevisionsOptions = [
   allRevisionsOption,
   'bb6a5e451dac',
   '9d5066525489',
@@ -33,6 +35,19 @@ const revisionsOptions = [
 function RevisionSelect() {
   const dispatch = useDispatch();
   const { activeComparison } = useAppSelector((state) => state.comparison);
+
+  const newRevisions = useAppSelector((state) => {
+    return state.selectedRevisions.new.map((item) =>
+      truncateHash(item.revision),
+    );
+  });
+
+  const [searchParams] = useSearchParams();
+  const fakeDataParam: string | null = searchParams.get('fakedata');
+
+  const revisionsOptions = fakeDataParam
+    ? fakeRevisionsOptions
+    : [allRevisionsOption, ...newRevisions];
 
   const handlerChangeComparison = (option: string) => {
     dispatch(updateComparison({ activeComparison: option }));

--- a/src/components/CompareResults/beta/RevisionSelect.tsx
+++ b/src/components/CompareResults/beta/RevisionSelect.tsx
@@ -37,9 +37,7 @@ function RevisionSelect() {
   const { activeComparison } = useAppSelector((state) => state.comparison);
 
   const newRevisions = useAppSelector((state) => {
-    return state.selectedRevisions.new.map((item) =>
-      truncateHash(item.revision),
-    );
+    return state.selectedRevisions.new.map((item) => item.revision);
   });
 
   const [searchParams] = useSearchParams();
@@ -48,6 +46,9 @@ function RevisionSelect() {
   const revisionsOptions = fakeDataParam
     ? fakeRevisionsOptions
     : [allRevisionsOption, ...newRevisions];
+
+  const getShortHashOption = (value: string) =>
+    value === allRevisionsOption ? allRevisionsOption : truncateHash(value);
 
   const handlerChangeComparison = (option: string) => {
     dispatch(updateComparison({ activeComparison: option }));
@@ -66,7 +67,7 @@ function RevisionSelect() {
               <SvgIcon>
                 <SortIcon />
               </SvgIcon>
-              {value}
+              {getShortHashOption(value)}
             </Box>
           );
         }}
@@ -75,7 +76,7 @@ function RevisionSelect() {
       >
         {revisionsOptions.map((option) => (
           <MenuItem key={option} value={option}>
-            {option}
+            {getShortHashOption(option)}
           </MenuItem>
         ))}
       </Select>


### PR DESCRIPTION
This PR fulfills [Results: Add implementation for switching between comparisons](https://mozilla-hub.atlassian.net/browse/PCF-250)
subtask: [Populate all revisions dropdown with real data](https://mozilla-hub.atlassian.net/browse/PCF-282)

STR:

1. Go to http://localhost:3000/ or https://deploy-preview-516--mozilla-perfcompare.netlify.app/
2. Select some base and new revisions for comparison
3. Click `Compare` to be redirected to results page
4. Click on `All revisions` dropdown
5. The revisions that were selected on the home page should be in this dropdown

![Screenshot 2023-08-17 at 5 27 44 PM](https://github.com/mozilla/perfcompare/assets/63001299/9350c04a-e501-4288-8e2f-054eb3e6516d)
