### PR TITLE
Add 'title' prop in tests

### DIFF
--- a/src/__tests__/CompareResults/beta/ResultsView.test.tsx
+++ b/src/__tests__/CompareResults/beta/ResultsView.test.tsx
@@ -3,6 +3,7 @@ import { Bubble, ChartProps } from 'react-chartjs-2';
 
 import ResultsView from '../../../components/CompareResults/beta/ResultsView';
 import { setSelectedRevisions } from '../../../reducers/SelectedRevisionsSlice';
+import { Strings } from '../../../resources/Strings';
 import useProtocolTheme from '../../../theme/protocolTheme';
 import getTestData from '../../utils/fixtures';
 import { renderWithRouter, store } from '../../utils/setupTests';
@@ -24,6 +25,7 @@ describe('Results View', () => {
       <ResultsView
         protocolTheme={protocolTheme}
         toggleColorMode={toggleColorMode}
+        title={Strings.metaData.pageTitle.results}
       />,
     );
     expect(
@@ -37,6 +39,7 @@ describe('Results View', () => {
       <ResultsView
         protocolTheme={protocolTheme}
         toggleColorMode={toggleColorMode}
+        title={Strings.metaData.pageTitle.results}
       />,
     );
 
@@ -58,6 +61,7 @@ describe('Results View', () => {
       <ResultsView
         protocolTheme={protocolTheme}
         toggleColorMode={toggleColorMode}
+        title={Strings.metaData.pageTitle.results}
       />,
     );
 
@@ -99,6 +103,7 @@ describe('Results View', () => {
       <ResultsView
         protocolTheme={protocolTheme}
         toggleColorMode={toggleColorMode}
+        title={Strings.metaData.pageTitle.results}
       />,
     );
 
@@ -138,6 +143,7 @@ describe('Results View', () => {
       <ResultsView
         protocolTheme={protocolTheme}
         toggleColorMode={toggleColorMode}
+        title={Strings.metaData.pageTitle.results}
       />,
     );
 
@@ -168,6 +174,7 @@ describe('Results View', () => {
       <ResultsView
         protocolTheme={protocolTheme}
         toggleColorMode={toggleColorMode}
+        title={Strings.metaData.pageTitle.results}
       />,
     );
 
@@ -203,6 +210,7 @@ describe('Results View', () => {
       <ResultsView
         protocolTheme={protocolTheme}
         toggleColorMode={toggleColorMode}
+        title={Strings.metaData.pageTitle.results}
       />,
     );
 

--- a/src/__tests__/CompareResults/beta/SearchInput.test.tsx
+++ b/src/__tests__/CompareResults/beta/SearchInput.test.tsx
@@ -1,4 +1,5 @@
 import ResultsView from '../../../components/CompareResults/beta/ResultsView';
+import { Strings } from '../../../resources/Strings';
 import useProtocolTheme from '../../../theme/protocolTheme';
 import { renderWithRouter } from '../../utils/setupTests';
 import { renderHook, screen } from '../../utils/test-utils';
@@ -14,6 +15,7 @@ describe('Search by title/test name', () => {
       <ResultsView
         protocolTheme={protocolTheme}
         toggleColorMode={toggleColorMode}
+        title={Strings.metaData.pageTitle.results}
       />,
     );
 

--- a/src/__tests__/Search/CompareWithBase.test.tsx
+++ b/src/__tests__/Search/CompareWithBase.test.tsx
@@ -112,6 +112,7 @@ describe('Compare With Base', () => {
       <SearchView
         toggleColorMode={toggleColorMode}
         protocolTheme={protocolTheme}
+        title={Strings.metaData.pageTitle.search}
       />,
     );
     act(() => {
@@ -146,6 +147,7 @@ describe('Compare With Base', () => {
       <ResultsView
         toggleColorMode={toggleColorMode}
         protocolTheme={protocolTheme}
+        title={Strings.metaData.pageTitle.results}
       />,
     );
 

--- a/src/__tests__/Search/SearchResultsList.test.tsx
+++ b/src/__tests__/Search/SearchResultsList.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { act } from 'react-dom/test-utils';
 
 import SearchView from '../../components/Search/SearchView';
+import { Strings } from '../../resources/Strings';
 import useProtocolTheme from '../../theme/protocolTheme';
 import { InputType } from '../../types/state';
 import getTestData from '../utils/fixtures';
@@ -20,6 +21,7 @@ function renderComponent() {
     <SearchView
       toggleColorMode={toggleColorMode}
       protocolTheme={protocolTheme}
+      title={Strings.metaData.pageTitle.search}
     />,
   );
 }

--- a/src/__tests__/Search/SearchView.test.tsx
+++ b/src/__tests__/Search/SearchView.test.tsx
@@ -24,6 +24,7 @@ function renderComponent() {
     <SearchView
       toggleColorMode={toggleColorMode}
       protocolTheme={protocolTheme}
+      title={Strings.metaData.pageTitle.search}
     />,
   );
 }
@@ -298,6 +299,7 @@ describe('Base Search', () => {
       <SearchView
         toggleColorMode={toggleColorMode}
         protocolTheme={protocolTheme}
+        title={Strings.metaData.pageTitle.search}
       />,
     );
     expect(history.location.pathname).toEqual('/');

--- a/src/__tests__/Search/SelectedRevision.test.tsx
+++ b/src/__tests__/Search/SelectedRevision.test.tsx
@@ -4,6 +4,7 @@ import { act } from 'react-dom/test-utils';
 
 import SearchView from '../../components/Search/SearchView';
 import { updateCheckedRevisions } from '../../reducers/SearchSlice';
+import { Strings } from '../../resources/Strings';
 import useProtocolTheme from '../../theme/protocolTheme';
 import { InputType } from '../../types/state';
 import getTestData from '../utils/fixtures';
@@ -21,6 +22,7 @@ function renderComponent() {
     <SearchView
       toggleColorMode={toggleColorMode}
       protocolTheme={protocolTheme}
+      title={Strings.metaData.pageTitle.search}
     />,
   );
 }

--- a/src/__tests__/Search/fetchRecentRevisions.test.tsx
+++ b/src/__tests__/Search/fetchRecentRevisions.test.tsx
@@ -39,6 +39,7 @@ describe('SearchView/fetchRecentRevisions', () => {
       <SearchView
         toggleColorMode={toggleColorMode}
         protocolTheme={protocolTheme}
+        title={Strings.metaData.pageTitle.search}
       />,
     );
 
@@ -101,6 +102,7 @@ describe('SearchView/fetchRecentRevisions', () => {
       <SearchView
         toggleColorMode={toggleColorMode}
         protocolTheme={protocolTheme}
+        title={Strings.metaData.pageTitle.search}
       />,
     );
     renderWithRouter(<SearchComponent {...SearchPropsBase} />);
@@ -135,6 +137,7 @@ describe('SearchView/fetchRecentRevisions', () => {
       <SearchView
         toggleColorMode={toggleColorMode}
         protocolTheme={protocolTheme}
+        title={Strings.metaData.pageTitle.search}
       />,
     );
     renderWithRouter(<SearchComponent {...SearchPropsBase} />);

--- a/src/__tests__/Search/fetchRevisionByID.test.tsx
+++ b/src/__tests__/Search/fetchRevisionByID.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { act } from 'react-dom/test-utils';
 
 import SearchView from '../../components/Search/SearchView';
+import { Strings } from '../../resources/Strings';
 import useProtocolTheme from '../../theme/protocolTheme';
 import { InputType } from '../../types/state';
 import getTestData from '../utils/fixtures';
@@ -33,6 +34,7 @@ describe('SearchView/fetchRevisionByID', () => {
       <SearchView
         toggleColorMode={toggleColorMode}
         protocolTheme={protocolTheme}
+        title={Strings.metaData.pageTitle.search}
       />,
     );
 
@@ -75,6 +77,7 @@ describe('SearchView/fetchRevisionByID', () => {
       <SearchView
         toggleColorMode={toggleColorMode}
         protocolTheme={protocolTheme}
+        title={Strings.metaData.pageTitle.search}
       />,
     );
 
@@ -115,6 +118,7 @@ describe('SearchView/fetchRevisionByID', () => {
         <SearchView
           toggleColorMode={toggleColorMode}
           protocolTheme={protocolTheme}
+          title={Strings.metaData.pageTitle.search}
         />
       </>,
     );
@@ -146,6 +150,7 @@ describe('SearchView/fetchRevisionByID', () => {
       <SearchView
         toggleColorMode={toggleColorMode}
         protocolTheme={protocolTheme}
+        title={Strings.metaData.pageTitle.search}
       />,
     );
 

--- a/src/__tests__/Search/fetchRevisionsByAuthor.test.tsx
+++ b/src/__tests__/Search/fetchRevisionsByAuthor.test.tsx
@@ -37,6 +37,7 @@ describe('SearchView/fetchRevisionsByAuthor', () => {
       <SearchView
         toggleColorMode={toggleColorMode}
         protocolTheme={protocolTheme}
+        title={Strings.metaData.pageTitle.search}
       />,
     );
 
@@ -75,6 +76,7 @@ describe('SearchView/fetchRevisionsByAuthor', () => {
         <SearchView
           toggleColorMode={toggleColorMode}
           protocolTheme={protocolTheme}
+          title={Strings.metaData.pageTitle.search}
         />,
       );
     });
@@ -111,6 +113,7 @@ describe('SearchView/fetchRevisionsByAuthor', () => {
         <SearchView
           toggleColorMode={toggleColorMode}
           protocolTheme={protocolTheme}
+          title={Strings.metaData.pageTitle.search}
         />,
       );
     });
@@ -149,6 +152,7 @@ describe('SearchView/fetchRevisionsByAuthor', () => {
       <SearchView
         toggleColorMode={toggleColorMode}
         protocolTheme={protocolTheme}
+        title={Strings.metaData.pageTitle.search}
       />,
     );
 

--- a/src/__tests__/Snackbar.test.tsx
+++ b/src/__tests__/Snackbar.test.tsx
@@ -6,6 +6,7 @@ import { act } from 'react-dom/test-utils';
 import { maxRevisionsError } from '../common/constants';
 import App from '../components/App';
 import SearchView from '../components/Search/SearchView';
+import { Strings } from '../resources/Strings';
 import useProtocolTheme from '../theme/protocolTheme';
 import getTestData from './utils/fixtures';
 import { renderWithRouter, render } from './utils/setupTests';
@@ -88,6 +89,7 @@ describe('Snackbar', () => {
       <SearchView
         toggleColorMode={toggleColorMode}
         protocolTheme={protocolTheme}
+        title={Strings.metaData.pageTitle.search}
       />,
     );
 


### PR DESCRIPTION
## This PR is a follow-up to: [Change page title based on route](https://github.com/mozilla/perfcompare/pull/512).

In this PR `title` prop is added to the instances of `<ResultsView/>` and `<SearchView/>` in tests.

_These changes address typeScript errors due to missing `'title'` prop for `ResultsView` and `SearchView` in unit tests, a detail that was missed in the [preceding PR](https://github.com/mozilla/perfcompare/pull/512) resulting in TypeScript errors encountered on running **npm run tsc** in terminal_. 