### PR TITLE
PCF-288 Add selectProcessedResults with memoization

### DIFF
--- a/src/components/CompareResults/beta/ResultsTable.tsx
+++ b/src/components/CompareResults/beta/ResultsTable.tsx
@@ -6,13 +6,9 @@ import TableContainer from '@mui/material/TableContainer';
 import { style } from 'typestyle';
 
 import { useAppSelector } from '../../../hooks/app';
-import { Strings } from '../../../resources/Strings';
+import { selectProcessedResults } from '../../../reducers/ComparisonSlice';
 import { Colors, Spacing } from '../../../styles';
-import type {
-  CompareResultsItem,
-  RevisionsHeader,
-  ThemeMode,
-} from '../../../types/state';
+import type { ThemeMode } from '../../../types/state';
 import NoResultsFound from './NoResultsFound';
 import TableContent from './TableContent';
 import TableHeader from './TableHeader';
@@ -21,71 +17,12 @@ const customStyles = {
   boxShadow: 'none',
 };
 
-type Results = {
-  key: string;
-  value: CompareResultsItem[];
-  revisionHeader: RevisionsHeader;
-};
-
-function processResults(results: CompareResultsItem[]) {
-  const processedResults: Map<string, CompareResultsItem[]> = new Map<
-    string,
-    CompareResultsItem[]
-  >();
-  results.forEach((result) => {
-    const { new_rev: newRevision, header_name: header } = result;
-    const rowIdentifier = header.concat(' ', newRevision);
-    if (processedResults.has(rowIdentifier)) {
-      (processedResults.get(rowIdentifier) as CompareResultsItem[]).push(
-        result,
-      );
-    } else {
-      processedResults.set(rowIdentifier, [result]);
-    }
-  });
-  const restructuredResults: Results[] = Array.from(
-    processedResults,
-    function (entry) {
-      return {
-        key: entry[0],
-        value: entry[1],
-        revisionHeader: {
-          suite: entry[1][0].suite,
-          framework_id: entry[1][0].framework_id,
-          test: entry[1][0].test,
-          option_name: entry[1][0].option_name,
-          extra_options: entry[1][0].extra_options,
-          new_rev: entry[1][0].new_rev,
-          new_repo: entry[1][0].new_repository_name,
-        },
-      };
-    },
-  );
-
-  return restructuredResults;
-}
-
 function ResultsTable(props: ResultsTableProps) {
   const { themeMode } = props;
-  const allRevisionsOption =
-    Strings.components.comparisonRevisionDropdown.allRevisions;
 
   const loading = useAppSelector((state) => state.compareResults.loading);
 
-  const processedResults = useAppSelector((state) => {
-    const { data } = state.compareResults;
-    const { activeComparison } = state.comparison;
-
-    if (activeComparison === allRevisionsOption) {
-      const allResults = ([] as CompareResultsItem[]).concat(
-        ...Object.values(data),
-      );
-      return processResults(allResults);
-    } else {
-      const results = data[activeComparison];
-      return processResults(results);
-    }
-  });
+  const processedResults = useAppSelector(selectProcessedResults);
 
   const themeColor100 =
     themeMode === 'light' ? Colors.Background100 : Colors.Background100Dark;

--- a/src/reducers/ComparisonSlice.ts
+++ b/src/reducers/ComparisonSlice.ts
@@ -1,11 +1,21 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
+import { RootState } from '../common/store';
+import { Strings } from '../resources/Strings';
+import { CompareResultsItem, RevisionsHeader } from '../types/state';
+
 interface InitialState {
   activeComparison: string;
 }
 
 const initialState: InitialState = {
   activeComparison: 'All revisions',
+};
+
+type Results = {
+  key: string;
+  value: CompareResultsItem[];
+  revisionHeader: RevisionsHeader;
 };
 
 const comparison = createSlice({
@@ -22,6 +32,62 @@ const comparison = createSlice({
     },
   },
 });
+
+function processResults(results: CompareResultsItem[]) {
+  const processedResults: Map<string, CompareResultsItem[]> = new Map<
+    string,
+    CompareResultsItem[]
+  >();
+  results.forEach((result) => {
+    const { new_rev: newRevision, header_name: header } = result;
+    const rowIdentifier = header.concat(' ', newRevision);
+    if (processedResults.has(rowIdentifier)) {
+      (processedResults.get(rowIdentifier) as CompareResultsItem[]).push(
+        result,
+      );
+    } else {
+      processedResults.set(rowIdentifier, [result]);
+    }
+  });
+  const restructuredResults: Results[] = Array.from(
+    processedResults,
+    function (entry) {
+      return {
+        key: entry[0],
+        value: entry[1],
+        revisionHeader: {
+          suite: entry[1][0].suite,
+          framework_id: entry[1][0].framework_id,
+          test: entry[1][0].test,
+          option_name: entry[1][0].option_name,
+          extra_options: entry[1][0].extra_options,
+          new_rev: entry[1][0].new_rev,
+          new_repo: entry[1][0].new_repository_name,
+        },
+      };
+    },
+  );
+
+  return restructuredResults;
+}
+
+const allRevisionsOption =
+  Strings.components.comparisonRevisionDropdown.allRevisions;
+
+export const selectProcessedResults = (state: RootState) => {
+  const { data } = state.compareResults;
+  const { activeComparison } = state.comparison;
+
+  if (activeComparison === allRevisionsOption) {
+    const allResults = ([] as CompareResultsItem[]).concat(
+      ...Object.values(data),
+    );
+    return processResults(allResults);
+  } else {
+    const results = data[activeComparison];
+    return processResults(results);
+  }
+};
 
 export const { updateComparison } = comparison.actions;
 

--- a/src/reducers/ComparisonSlice.ts
+++ b/src/reducers/ComparisonSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createSelector, createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import { RootState } from '../common/store';
 import { Strings } from '../resources/Strings';
@@ -74,20 +74,21 @@ function processResults(results: CompareResultsItem[]) {
 const allRevisionsOption =
   Strings.components.comparisonRevisionDropdown.allRevisions;
 
-export const selectProcessedResults = (state: RootState) => {
-  const { data } = state.compareResults;
-  const { activeComparison } = state.comparison;
-
-  if (activeComparison === allRevisionsOption) {
-    const allResults = ([] as CompareResultsItem[]).concat(
-      ...Object.values(data),
-    );
-    return processResults(allResults);
-  } else {
-    const results = data[activeComparison];
-    return processResults(results);
-  }
-};
+export const selectProcessedResults = createSelector(
+  (state: RootState) => state.compareResults.data,
+  (state: RootState) => state.comparison.activeComparison,
+  (data, activeComparison) => {
+    if (activeComparison === allRevisionsOption) {
+      const allResults = ([] as CompareResultsItem[]).concat(
+        ...Object.values(data),
+      );
+      return processResults(allResults);
+    } else {
+      const results = data[activeComparison];
+      return processResults(results);
+    }
+  },
+);
 
 export const { updateComparison } = comparison.actions;
 

--- a/src/reducers/ComparisonSlice.ts
+++ b/src/reducers/ComparisonSlice.ts
@@ -51,18 +51,18 @@ function processResults(results: CompareResultsItem[]) {
   });
   const restructuredResults: Results[] = Array.from(
     processedResults,
-    function (entry) {
+    function ([rowIdentifier, result]) {
       return {
-        key: entry[0],
-        value: entry[1],
+        key: rowIdentifier,
+        value: result,
         revisionHeader: {
-          suite: entry[1][0].suite,
-          framework_id: entry[1][0].framework_id,
-          test: entry[1][0].test,
-          option_name: entry[1][0].option_name,
-          extra_options: entry[1][0].extra_options,
-          new_rev: entry[1][0].new_rev,
-          new_repo: entry[1][0].new_repository_name,
+          suite: result[0].suite,
+          framework_id: result[0].framework_id,
+          test: result[0].test,
+          option_name: result[0].option_name,
+          extra_options: result[0].extra_options,
+          new_rev: result[0].new_rev,
+          new_repo: result[0].new_repository_name,
         },
       };
     },


### PR DESCRIPTION
This PR is a follow up for PR #507  and addresses [the comment about memoized selector](https://github.com/mozilla/perfcompare/pull/507#discussion_r1296149027) for processing results in Compare Results view.

[Jira Ticket PCF-288](https://mozilla-hub.atlassian.net/browse/PCF-288)