### PR TITLE
PCF-289 Remove data-testid for TableRow in RevisionHeader

### DIFF
--- a/src/__tests__/CompareResults/beta/RevisionSelect.test.tsx
+++ b/src/__tests__/CompareResults/beta/RevisionSelect.test.tsx
@@ -96,6 +96,8 @@ describe('Revision select', () => {
     fireEvent.mouseDown(selectButton);
 
     // check to display results only for revision bb6a5e451dac
+    // findByRole doesn't work anymore because the root element
+    // has aria-hidden but we don't know why yet
     firstRevisionHeaders = await screen.findAllByText(/bb6a5e451dac/, {
       selector: 'a',
     });
@@ -159,6 +161,8 @@ describe('Revision select', () => {
     fireEvent.mouseDown(selectButton);
 
     // check to display results only for revision 9d5066525489
+    // findByRole doesn't work anymore because the root element
+    // has aria-hidden but we don't know why yet
     const secondRevisionHeaders = await screen.findAllByText(/9d5066525489/, {
       selector: 'a',
     });
@@ -222,6 +226,8 @@ describe('Revision select', () => {
     fireEvent.mouseDown(selectButton);
 
     // check to display results only for revision a998c42399a8
+    // findByRole doesn't work anymore because the root element
+    // has aria-hidden but we don't know why yet
     const thirdRevisionHeaders = await screen.findAllByText(/a998c42399a8/, {
       selector: 'a',
     });

--- a/src/__tests__/CompareResults/beta/RevisionSelect.test.tsx
+++ b/src/__tests__/CompareResults/beta/RevisionSelect.test.tsx
@@ -61,12 +61,24 @@ describe('Revision select', () => {
       />,
     );
 
-    let comparisonHeaders = await screen.findAllByTestId(/revision-header/);
-    expect(comparisonHeaders[0].textContent).toContain('bb6a5e451dac');
+    // check to display results for all revisions
+    let firstRevisionHeaders = await screen.findAllByText(/bb6a5e451dac/);
+    firstRevisionHeaders = firstRevisionHeaders.filter((header) =>
+      header.hasAttribute('href'),
+    );
+    expect(firstRevisionHeaders.length).toBe(8);
 
-    // there are 8 results for revision bb6a5e451dac
-    // next result tabel should be for revision 9d5066525489
-    expect(comparisonHeaders[8].textContent).toContain('9d5066525489');
+    let secondRevisionHeaders = await screen.findAllByText(/9d5066525489/);
+    secondRevisionHeaders = secondRevisionHeaders.filter((header) =>
+      header.hasAttribute('href'),
+    );
+    expect(secondRevisionHeaders.length).toBe(7);
+
+    let thirdRevisionHeaders = await screen.findAllByText(/a998c42399a8/);
+    thirdRevisionHeaders = thirdRevisionHeaders.filter((header) =>
+      header.hasAttribute('href'),
+    );
+    expect(thirdRevisionHeaders.length).toBe(7);
 
     // change comparison to revision bb6a5e451dac
     const selectRevisionDropdown = within(
@@ -86,12 +98,24 @@ describe('Revision select', () => {
 
     fireEvent.mouseDown(selectButton);
 
-    // check every revision header to be for revision bb6a5e451dac
-    comparisonHeaders = await screen.findAllByTestId(/revision-header/);
-
-    comparisonHeaders.forEach((resultHeader) =>
-      expect(resultHeader.textContent).toContain('bb6a5e451dac'),
+    // check to display results only for revision bb6a5e451dac
+    firstRevisionHeaders = await screen.findAllByText(/bb6a5e451dac/);
+    firstRevisionHeaders = firstRevisionHeaders.filter((header) =>
+      header.hasAttribute('href'),
     );
+    expect(firstRevisionHeaders.length).toBe(8);
+
+    secondRevisionHeaders = await screen.findAllByText(/9d5066525489/);
+    secondRevisionHeaders = secondRevisionHeaders.filter((header) =>
+      header.hasAttribute('href'),
+    );
+    expect(secondRevisionHeaders.length).toBe(0);
+
+    thirdRevisionHeaders = await screen.findAllByText(/a998c42399a8/);
+    thirdRevisionHeaders = thirdRevisionHeaders.filter((header) =>
+      header.hasAttribute('href'),
+    );
+    expect(thirdRevisionHeaders.length).toBe(0);
   });
 
   it('Should render results for 9d5066525489', async () => {
@@ -116,8 +140,11 @@ describe('Revision select', () => {
     );
 
     // check comparison to be for revision bb6a5e451dac
-    let firstRevisionHeader = await screen.findAllByTestId(/revision-header/);
-    expect(firstRevisionHeader[0].textContent).toContain('bb6a5e451dac');
+    let firstRevisionHeaders = await screen.findAllByText(/bb6a5e451dac/);
+    firstRevisionHeaders = firstRevisionHeaders.filter((header) =>
+      header.hasAttribute('href'),
+    );
+    expect(firstRevisionHeaders.length).toBe(8);
 
     // change comparison to revision 9d5066525489
     const selectRevisionDropdown = within(
@@ -136,10 +163,24 @@ describe('Revision select', () => {
 
     fireEvent.mouseDown(selectButton);
 
-    // check if first revision header has changed to 9d5066525489
-    firstRevisionHeader = await screen.findAllByTestId(/revision-header/);
+    // check to display results only for revision 9d5066525489
+    firstRevisionHeaders = await screen.findAllByText(/bb6a5e451dac/);
+    firstRevisionHeaders = firstRevisionHeaders.filter((header) =>
+      header.hasAttribute('href'),
+    );
+    expect(firstRevisionHeaders.length).toBe(0);
 
-    expect(firstRevisionHeader[0].textContent).toContain('9d5066525489');
+    let secondRevisionHeaders = await screen.findAllByText(/9d5066525489/);
+    secondRevisionHeaders = secondRevisionHeaders.filter((header) =>
+      header.hasAttribute('href'),
+    );
+    expect(secondRevisionHeaders.length).toBe(7);
+
+    let thirdRevisionHeaders = await screen.findAllByText(/a998c42399a8/);
+    thirdRevisionHeaders = thirdRevisionHeaders.filter((header) =>
+      header.hasAttribute('href'),
+    );
+    expect(thirdRevisionHeaders.length).toBe(0);
   });
 
   it('Should render results for a998c42399a8', async () => {
@@ -164,8 +205,11 @@ describe('Revision select', () => {
     );
 
     // check comparison to be for revision bb6a5e451dac
-    let firstRevisionHeader = await screen.findAllByTestId(/revision-header/);
-    expect(firstRevisionHeader[0].textContent).toContain('bb6a5e451dac');
+    let firstRevisionHeaders = await screen.findAllByText(/bb6a5e451dac/);
+    firstRevisionHeaders = firstRevisionHeaders.filter((header) =>
+      header.hasAttribute('href'),
+    );
+    expect(firstRevisionHeaders.length).toBe(8);
 
     // change comparison to revision a998c42399a8
     const selectRevisionDropdown = within(
@@ -184,8 +228,23 @@ describe('Revision select', () => {
 
     fireEvent.mouseDown(selectButton);
 
-    // check if first revision header has changed to a998c42399a8
-    firstRevisionHeader = await screen.findAllByTestId(/revision-header/);
-    expect(firstRevisionHeader[0].textContent).toContain('a998c42399a8');
+    // check to display results only for revision a998c42399a8
+    firstRevisionHeaders = await screen.findAllByText(/bb6a5e451dac/);
+    firstRevisionHeaders = firstRevisionHeaders.filter((header) =>
+      header.hasAttribute('href'),
+    );
+    expect(firstRevisionHeaders.length).toBe(0);
+
+    let secondRevisionHeaders = await screen.findAllByText(/9d5066525489/);
+    secondRevisionHeaders = secondRevisionHeaders.filter((header) =>
+      header.hasAttribute('href'),
+    );
+    expect(secondRevisionHeaders.length).toBe(0);
+
+    let thirdRevisionHeaders = await screen.findAllByText(/a998c42399a8/);
+    thirdRevisionHeaders = thirdRevisionHeaders.filter((header) =>
+      header.hasAttribute('href'),
+    );
+    expect(thirdRevisionHeaders.length).toBe(7);
   });
 });

--- a/src/__tests__/CompareResults/beta/RevisionSelect.test.tsx
+++ b/src/__tests__/CompareResults/beta/RevisionSelect.test.tsx
@@ -62,22 +62,19 @@ describe('Revision select', () => {
     );
 
     // check to display results for all revisions
-    let firstRevisionHeaders = await screen.findAllByText(/bb6a5e451dac/);
-    firstRevisionHeaders = firstRevisionHeaders.filter((header) =>
-      header.hasAttribute('href'),
-    );
+    let firstRevisionHeaders = await screen.findAllByRole('link', {
+      name: /bb6a5e451dac/,
+    });
     expect(firstRevisionHeaders.length).toBe(8);
 
-    let secondRevisionHeaders = await screen.findAllByText(/9d5066525489/);
-    secondRevisionHeaders = secondRevisionHeaders.filter((header) =>
-      header.hasAttribute('href'),
-    );
+    let secondRevisionHeaders = await screen.findAllByRole('link', {
+      name: /9d5066525489/,
+    });
     expect(secondRevisionHeaders.length).toBe(7);
 
-    let thirdRevisionHeaders = await screen.findAllByText(/a998c42399a8/);
-    thirdRevisionHeaders = thirdRevisionHeaders.filter((header) =>
-      header.hasAttribute('href'),
-    );
+    let thirdRevisionHeaders = await screen.findAllByRole('link', {
+      name: /a998c42399a8/,
+    });
     expect(thirdRevisionHeaders.length).toBe(7);
 
     // change comparison to revision bb6a5e451dac
@@ -99,22 +96,19 @@ describe('Revision select', () => {
     fireEvent.mouseDown(selectButton);
 
     // check to display results only for revision bb6a5e451dac
-    firstRevisionHeaders = await screen.findAllByText(/bb6a5e451dac/);
-    firstRevisionHeaders = firstRevisionHeaders.filter((header) =>
-      header.hasAttribute('href'),
-    );
+    firstRevisionHeaders = await screen.findAllByRole('link', {
+      name: /bb6a5e451dac/,
+    });
     expect(firstRevisionHeaders.length).toBe(8);
 
-    secondRevisionHeaders = await screen.findAllByText(/9d5066525489/);
-    secondRevisionHeaders = secondRevisionHeaders.filter((header) =>
-      header.hasAttribute('href'),
-    );
+    secondRevisionHeaders = await screen.findAllByRole('link', {
+      name: /9d5066525489/,
+    });
     expect(secondRevisionHeaders.length).toBe(0);
 
-    thirdRevisionHeaders = await screen.findAllByText(/a998c42399a8/);
-    thirdRevisionHeaders = thirdRevisionHeaders.filter((header) =>
-      header.hasAttribute('href'),
-    );
+    thirdRevisionHeaders = await screen.findAllByRole('link', {
+      name: /a998c42399a8/,
+    });
     expect(thirdRevisionHeaders.length).toBe(0);
   });
 
@@ -140,10 +134,9 @@ describe('Revision select', () => {
     );
 
     // check comparison to be for revision bb6a5e451dac
-    let firstRevisionHeaders = await screen.findAllByText(/bb6a5e451dac/);
-    firstRevisionHeaders = firstRevisionHeaders.filter((header) =>
-      header.hasAttribute('href'),
-    );
+    let firstRevisionHeaders = await screen.findAllByRole('link', {
+      name: /bb6a5e451dac/,
+    });
     expect(firstRevisionHeaders.length).toBe(8);
 
     // change comparison to revision 9d5066525489
@@ -164,22 +157,19 @@ describe('Revision select', () => {
     fireEvent.mouseDown(selectButton);
 
     // check to display results only for revision 9d5066525489
-    firstRevisionHeaders = await screen.findAllByText(/bb6a5e451dac/);
-    firstRevisionHeaders = firstRevisionHeaders.filter((header) =>
-      header.hasAttribute('href'),
-    );
+    firstRevisionHeaders = await screen.findAllByRole('link', {
+      name: /bb6a5e451dac/,
+    });
     expect(firstRevisionHeaders.length).toBe(0);
 
-    let secondRevisionHeaders = await screen.findAllByText(/9d5066525489/);
-    secondRevisionHeaders = secondRevisionHeaders.filter((header) =>
-      header.hasAttribute('href'),
-    );
+    const secondRevisionHeaders = await screen.findAllByRole('link', {
+      name: /9d5066525489/,
+    });
     expect(secondRevisionHeaders.length).toBe(7);
 
-    let thirdRevisionHeaders = await screen.findAllByText(/a998c42399a8/);
-    thirdRevisionHeaders = thirdRevisionHeaders.filter((header) =>
-      header.hasAttribute('href'),
-    );
+    const thirdRevisionHeaders = await screen.findAllByRole('link', {
+      name: /a998c42399a8/,
+    });
     expect(thirdRevisionHeaders.length).toBe(0);
   });
 
@@ -205,10 +195,9 @@ describe('Revision select', () => {
     );
 
     // check comparison to be for revision bb6a5e451dac
-    let firstRevisionHeaders = await screen.findAllByText(/bb6a5e451dac/);
-    firstRevisionHeaders = firstRevisionHeaders.filter((header) =>
-      header.hasAttribute('href'),
-    );
+    let firstRevisionHeaders = await screen.findAllByRole('link', {
+      name: /bb6a5e451dac/,
+    });
     expect(firstRevisionHeaders.length).toBe(8);
 
     // change comparison to revision a998c42399a8
@@ -229,22 +218,19 @@ describe('Revision select', () => {
     fireEvent.mouseDown(selectButton);
 
     // check to display results only for revision a998c42399a8
-    firstRevisionHeaders = await screen.findAllByText(/bb6a5e451dac/);
-    firstRevisionHeaders = firstRevisionHeaders.filter((header) =>
-      header.hasAttribute('href'),
-    );
+    firstRevisionHeaders = await screen.findAllByRole('link', {
+      name: /bb6a5e451dac/,
+    });
     expect(firstRevisionHeaders.length).toBe(0);
 
-    let secondRevisionHeaders = await screen.findAllByText(/9d5066525489/);
-    secondRevisionHeaders = secondRevisionHeaders.filter((header) =>
-      header.hasAttribute('href'),
-    );
+    const secondRevisionHeaders = await screen.findAllByRole('link', {
+      name: /9d5066525489/,
+    });
     expect(secondRevisionHeaders.length).toBe(0);
 
-    let thirdRevisionHeaders = await screen.findAllByText(/a998c42399a8/);
-    thirdRevisionHeaders = thirdRevisionHeaders.filter((header) =>
-      header.hasAttribute('href'),
-    );
+    const thirdRevisionHeaders = await screen.findAllByRole('link', {
+      name: /a998c42399a8/,
+    });
     expect(thirdRevisionHeaders.length).toBe(7);
   });
 });

--- a/src/__tests__/CompareResults/beta/RevisionSelect.test.tsx
+++ b/src/__tests__/CompareResults/beta/RevisionSelect.test.tsx
@@ -96,20 +96,20 @@ describe('Revision select', () => {
     fireEvent.mouseDown(selectButton);
 
     // check to display results only for revision bb6a5e451dac
-    firstRevisionHeaders = await screen.findAllByRole('link', {
-      name: /bb6a5e451dac/,
+    firstRevisionHeaders = await screen.findAllByText(/bb6a5e451dac/, {
+      selector: 'a',
     });
     expect(firstRevisionHeaders.length).toBe(8);
 
     expect(
-      screen.queryAllByRole('link', {
-        name: /9d5066525489/,
+      screen.queryAllByText(/9d5066525489/, {
+        selector: 'a',
       }),
     ).toStrictEqual([]);
 
     expect(
-      screen.queryAllByRole('link', {
-        name: /a998c42399a8/,
+      screen.queryAllByText(/a998c42399a8/, {
+        selector: 'a',
       }),
     ).toStrictEqual([]);
   });
@@ -159,20 +159,20 @@ describe('Revision select', () => {
     fireEvent.mouseDown(selectButton);
 
     // check to display results only for revision 9d5066525489
-    const secondRevisionHeaders = await screen.findAllByRole('link', {
-      name: /9d5066525489/,
+    const secondRevisionHeaders = await screen.findAllByText(/9d5066525489/, {
+      selector: 'a',
     });
     expect(secondRevisionHeaders.length).toBe(7);
 
     expect(
-      screen.queryAllByRole('link', {
-        name: /bb6a5e451dac/,
+      screen.queryAllByText(/bb6a5e451dac/, {
+        selector: 'a',
       }),
     ).toStrictEqual([]);
 
     expect(
-      screen.queryAllByRole('link', {
-        name: /a998c42399a8/,
+      screen.queryAllByText(/a998c42399a8/, {
+        selector: 'a',
       }),
     ).toStrictEqual([]);
   });
@@ -222,20 +222,20 @@ describe('Revision select', () => {
     fireEvent.mouseDown(selectButton);
 
     // check to display results only for revision a998c42399a8
-    const thirdRevisionHeaders = await screen.findAllByRole('link', {
-      name: /a998c42399a8/,
+    const thirdRevisionHeaders = await screen.findAllByText(/a998c42399a8/, {
+      selector: 'a',
     });
     expect(thirdRevisionHeaders.length).toBe(7);
 
     expect(
-      screen.queryAllByRole('link', {
-        name: /9d5066525489/,
+      screen.queryAllByText(/9d5066525489/, {
+        selector: 'a',
       }),
     ).toStrictEqual([]);
 
     expect(
-      screen.queryAllByRole('link', {
-        name: /bb6a5e451dac/,
+      screen.queryAllByText(/bb6a5e451dac/, {
+        selector: 'a',
       }),
     ).toStrictEqual([]);
   });

--- a/src/__tests__/CompareResults/beta/RevisionSelect.test.tsx
+++ b/src/__tests__/CompareResults/beta/RevisionSelect.test.tsx
@@ -67,12 +67,12 @@ describe('Revision select', () => {
     });
     expect(firstRevisionHeaders.length).toBe(8);
 
-    let secondRevisionHeaders = await screen.findAllByRole('link', {
+    const secondRevisionHeaders = await screen.findAllByRole('link', {
       name: /9d5066525489/,
     });
     expect(secondRevisionHeaders.length).toBe(7);
 
-    let thirdRevisionHeaders = await screen.findAllByRole('link', {
+    const thirdRevisionHeaders = await screen.findAllByRole('link', {
       name: /a998c42399a8/,
     });
     expect(thirdRevisionHeaders.length).toBe(7);
@@ -101,15 +101,17 @@ describe('Revision select', () => {
     });
     expect(firstRevisionHeaders.length).toBe(8);
 
-    secondRevisionHeaders = await screen.findAllByRole('link', {
-      name: /9d5066525489/,
-    });
-    expect(secondRevisionHeaders.length).toBe(0);
+    expect(
+      screen.queryAllByRole('link', {
+        name: /9d5066525489/,
+      }),
+    ).toStrictEqual([]);
 
-    thirdRevisionHeaders = await screen.findAllByRole('link', {
-      name: /a998c42399a8/,
-    });
-    expect(thirdRevisionHeaders.length).toBe(0);
+    expect(
+      screen.queryAllByRole('link', {
+        name: /a998c42399a8/,
+      }),
+    ).toStrictEqual([]);
   });
 
   it('Should render results for 9d5066525489', async () => {
@@ -134,7 +136,7 @@ describe('Revision select', () => {
     );
 
     // check comparison to be for revision bb6a5e451dac
-    let firstRevisionHeaders = await screen.findAllByRole('link', {
+    const firstRevisionHeaders = await screen.findAllByRole('link', {
       name: /bb6a5e451dac/,
     });
     expect(firstRevisionHeaders.length).toBe(8);
@@ -157,20 +159,22 @@ describe('Revision select', () => {
     fireEvent.mouseDown(selectButton);
 
     // check to display results only for revision 9d5066525489
-    firstRevisionHeaders = await screen.findAllByRole('link', {
-      name: /bb6a5e451dac/,
-    });
-    expect(firstRevisionHeaders.length).toBe(0);
-
     const secondRevisionHeaders = await screen.findAllByRole('link', {
       name: /9d5066525489/,
     });
     expect(secondRevisionHeaders.length).toBe(7);
 
-    const thirdRevisionHeaders = await screen.findAllByRole('link', {
-      name: /a998c42399a8/,
-    });
-    expect(thirdRevisionHeaders.length).toBe(0);
+    expect(
+      screen.queryAllByRole('link', {
+        name: /bb6a5e451dac/,
+      }),
+    ).toStrictEqual([]);
+
+    expect(
+      screen.queryAllByRole('link', {
+        name: /a998c42399a8/,
+      }),
+    ).toStrictEqual([]);
   });
 
   it('Should render results for a998c42399a8', async () => {
@@ -195,7 +199,7 @@ describe('Revision select', () => {
     );
 
     // check comparison to be for revision bb6a5e451dac
-    let firstRevisionHeaders = await screen.findAllByRole('link', {
+    const firstRevisionHeaders = await screen.findAllByRole('link', {
       name: /bb6a5e451dac/,
     });
     expect(firstRevisionHeaders.length).toBe(8);
@@ -218,19 +222,21 @@ describe('Revision select', () => {
     fireEvent.mouseDown(selectButton);
 
     // check to display results only for revision a998c42399a8
-    firstRevisionHeaders = await screen.findAllByRole('link', {
-      name: /bb6a5e451dac/,
-    });
-    expect(firstRevisionHeaders.length).toBe(0);
-
-    const secondRevisionHeaders = await screen.findAllByRole('link', {
-      name: /9d5066525489/,
-    });
-    expect(secondRevisionHeaders.length).toBe(0);
-
     const thirdRevisionHeaders = await screen.findAllByRole('link', {
       name: /a998c42399a8/,
     });
     expect(thirdRevisionHeaders.length).toBe(7);
+
+    expect(
+      screen.queryAllByRole('link', {
+        name: /9d5066525489/,
+      }),
+    ).toStrictEqual([]);
+
+    expect(
+      screen.queryAllByRole('link', {
+        name: /bb6a5e451dac/,
+      }),
+    ).toStrictEqual([]);
   });
 });

--- a/src/__tests__/CompareResults/beta/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/beta/__snapshots__/ResultsView.test.tsx.snap
@@ -679,7 +679,6 @@ exports[`Results View Should match snapshot 1`] = `
                 >
                   <tr
                     class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
-                    data-testid="revision-header-bb6a5e451dac"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
@@ -1656,7 +1655,6 @@ exports[`Results View Should match snapshot 1`] = `
                 >
                   <tr
                     class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
-                    data-testid="revision-header-bb6a5e451dac"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
@@ -2959,7 +2957,6 @@ exports[`Results View Should match snapshot 1`] = `
                 >
                   <tr
                     class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
-                    data-testid="revision-header-bb6a5e451dac"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
@@ -3337,7 +3334,6 @@ exports[`Results View Should match snapshot 1`] = `
                 >
                   <tr
                     class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
-                    data-testid="revision-header-bb6a5e451dac"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
@@ -4640,7 +4636,6 @@ exports[`Results View Should match snapshot 1`] = `
                 >
                   <tr
                     class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
-                    data-testid="revision-header-bb6a5e451dac"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
@@ -5617,7 +5612,6 @@ exports[`Results View Should match snapshot 1`] = `
                 >
                   <tr
                     class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
-                    data-testid="revision-header-bb6a5e451dac"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
@@ -5988,7 +5982,6 @@ exports[`Results View Should match snapshot 1`] = `
                 >
                   <tr
                     class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
-                    data-testid="revision-header-bb6a5e451dac"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
@@ -6972,7 +6965,6 @@ exports[`Results View Should match snapshot 1`] = `
                 >
                   <tr
                     class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
-                    data-testid="revision-header-bb6a5e451dac"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
@@ -7352,7 +7344,6 @@ exports[`Results View Should match snapshot 1`] = `
                 >
                   <tr
                     class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
-                    data-testid="revision-header-9d5066525489"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
@@ -8443,7 +8434,6 @@ exports[`Results View Should match snapshot 1`] = `
                 >
                   <tr
                     class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
-                    data-testid="revision-header-9d5066525489"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
@@ -10446,7 +10436,6 @@ exports[`Results View Should match snapshot 1`] = `
                 >
                   <tr
                     class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
-                    data-testid="revision-header-9d5066525489"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
@@ -12981,7 +12970,6 @@ exports[`Results View Should match snapshot 1`] = `
                 >
                   <tr
                     class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
-                    data-testid="revision-header-9d5066525489"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
@@ -13353,7 +13341,6 @@ exports[`Results View Should match snapshot 1`] = `
                 >
                   <tr
                     class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
-                    data-testid="revision-header-9d5066525489"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
@@ -14330,7 +14317,6 @@ exports[`Results View Should match snapshot 1`] = `
                 >
                   <tr
                     class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
-                    data-testid="revision-header-9d5066525489"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
@@ -15633,7 +15619,6 @@ exports[`Results View Should match snapshot 1`] = `
                 >
                   <tr
                     class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
-                    data-testid="revision-header-9d5066525489"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
@@ -16731,7 +16716,6 @@ exports[`Results View Should match snapshot 1`] = `
                 >
                   <tr
                     class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
-                    data-testid="revision-header-a998c42399a8"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
@@ -17708,7 +17692,6 @@ exports[`Results View Should match snapshot 1`] = `
                 >
                   <tr
                     class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
-                    data-testid="revision-header-a998c42399a8"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
@@ -18685,7 +18668,6 @@ exports[`Results View Should match snapshot 1`] = `
                 >
                   <tr
                     class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
-                    data-testid="revision-header-a998c42399a8"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
@@ -19669,7 +19651,6 @@ exports[`Results View Should match snapshot 1`] = `
                 >
                   <tr
                     class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
-                    data-testid="revision-header-a998c42399a8"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
@@ -20972,7 +20953,6 @@ exports[`Results View Should match snapshot 1`] = `
                 >
                   <tr
                     class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
-                    data-testid="revision-header-a998c42399a8"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
@@ -21956,7 +21936,6 @@ exports[`Results View Should match snapshot 1`] = `
                 >
                   <tr
                     class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
-                    data-testid="revision-header-a998c42399a8"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"
@@ -22933,7 +22912,6 @@ exports[`Results View Should match snapshot 1`] = `
                 >
                   <tr
                     class="MuiTableRow-root revision-header css-1yt2i5z-MuiTableRow-root"
-                    data-testid="revision-header-a998c42399a8"
                   >
                     <td
                       class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-15mfgc5-MuiTableCell-root"

--- a/src/components/CompareResults/beta/RevisionHeader.tsx
+++ b/src/components/CompareResults/beta/RevisionHeader.tsx
@@ -80,10 +80,7 @@ function RevisionHeader(props: RevisionHeaderProps) {
   const extraOptions = getExtraOptions(header.extra_options);
   const shortHash = truncateHash(header.new_rev);
   return (
-    <TableRow
-      className='revision-header'
-      data-testid={`revision-header-${shortHash}`}
-    >
+    <TableRow className='revision-header'>
       <TableCell colSpan={6}>
         <strong>{createTitle(header, docsURL, isLinkSupported)}</strong>{' '}
         <Link href={getTreeherderURL(header.new_rev, header.new_repo)}>


### PR DESCRIPTION
This PR is a follow up for #507 to address the [comment](https://github.com/mozilla/perfcompare/pull/507#discussion_r1290110332) about removing the data-testid

[Jira ticket](https://mozilla-hub.atlassian.net/browse/PCF-289)