### PR TITLE
Configure several jobs in CircleCI and remove the nightly job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,54 +1,57 @@
 version: 2.1
 orbs:
-  node: circleci/node@5.0.1
+  node: circleci/node@5.1.0
   codecov: codecov/codecov@3.2.2
+
 jobs:
-  test:
-    executor:
-      name: node/default
-      tag: '16.13'
+  tests:
+    executor: node/default
     steps:
       - checkout
-      - restore_cache: # special step to restore the dependency cache
-          # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
-          key: dependency-cache-{{ checksum "package.json" }}
-      - run:
-          name: install
-          command: npm install
-      - save_cache: # special step to save the dependency cache
-          key: dependency-cache-{{ checksum "package.json" }}
-          paths:
-            - ./node_modules
-      - run:
-          # Why only production? See: https://overreacted.io/npm-audit-broken-by-design/#what-next
-          name: audit
-          command: npm audit --omit=dev
-      - run:
-          name: lint
-          command: npm run lint
+      - node/install-packages
       - run:
           name: accessibility
           command: npm run test:a11y || true
       - run:
-          name: test
-          command: npm run test:coverage
+          name: tests
+          # We use workerIdleMemoryLimit to work around a memory issue with node.
+          # See https://github.com/facebook/jest/issues/11956
+          command: npm run test:coverage -- -w=4 --workerIdleMemoryLimit=1.5G
+      - codecov/upload
+
+  lint:
+    executor: node/default
+    steps:
+      - checkout
+      - node/install-packages
+      - run:
+          name: lint
+          command: npm run lint
       - run:
           name: prettier
           command: npm run format:check
-      - codecov/upload
+
+  typescript:
+    executor: node/default
+    steps:
+      - checkout
+      - node/install-packages
+      - run: npm run tsc
+
+  other:
+    executor: node/default
+    steps:
+      - checkout
+      - node/install-packages
+      - run:
+          # Why only production? See: https://overreacted.io/npm-audit-broken-by-design/#what-next
+          name: audit
+          command: npm audit --omit=dev
 
 workflows:
-  test:
+  main:
     jobs:
-      - test
-  nightly:
-    triggers:
-      - schedule:
-          cron: '0 0 * * *'
-          filters:
-            branches:
-              only:
-                - master
-                - staging
-    jobs:
-      - test
+      - tests
+      - lint
+      - typescript
+      - other


### PR DESCRIPTION
The goal is to split the big job into separate ones, so that they can run in parallel. I did it especially so that adding the typescript check wouldn't make the overall CI run too long.