### PR TITLE
PCF-290 Create memoized selector for populating all revisions dropdown

### DIFF
--- a/src/components/CompareResults/beta/RevisionSelect.tsx
+++ b/src/components/CompareResults/beta/RevisionSelect.tsx
@@ -8,7 +8,10 @@ import { useSearchParams } from 'react-router-dom';
 import { style } from 'typestyle';
 
 import { useAppSelector } from '../../../hooks/app';
-import { updateComparison } from '../../../reducers/ComparisonSlice';
+import {
+  selectNewRevisions,
+  updateComparison,
+} from '../../../reducers/ComparisonSlice';
 import { Strings } from '../../../resources/Strings';
 import { truncateHash } from '../../../utils/helpers';
 
@@ -36,9 +39,7 @@ function RevisionSelect() {
   const dispatch = useDispatch();
   const { activeComparison } = useAppSelector((state) => state.comparison);
 
-  const newRevisions = useAppSelector((state) => {
-    return state.selectedRevisions.new.map((item) => item.revision);
-  });
+  const newRevisions = useAppSelector(selectNewRevisions);
 
   const [searchParams] = useSearchParams();
   const fakeDataParam: string | null = searchParams.get('fakedata');

--- a/src/reducers/ComparisonSlice.ts
+++ b/src/reducers/ComparisonSlice.ts
@@ -91,9 +91,9 @@ export const selectProcessedResults = createSelector(
 );
 
 export const selectNewRevisions = createSelector(
-  (state: RootState) => state.selectedRevisions,
-  (selectedRevisions) => {
-    return selectedRevisions.new.map((item) => item.revision);
+  (state: RootState) => state.selectedRevisions.new,
+  (newSelectedRevisions) => {
+    return newSelectedRevisions.map((item) => item.revision);
   },
 );
 

--- a/src/reducers/ComparisonSlice.ts
+++ b/src/reducers/ComparisonSlice.ts
@@ -90,6 +90,13 @@ export const selectProcessedResults = createSelector(
   },
 );
 
+export const selectNewRevisions = createSelector(
+  (state: RootState) => state.selectedRevisions,
+  (selectedRevisions) => {
+    return selectedRevisions.new.map((item) => item.revision);
+  },
+);
+
 export const { updateComparison } = comparison.actions;
 
 export default comparison.reducer;


### PR DESCRIPTION
This PR is a follow up for #516 to address the [comment](https://github.com/mozilla/perfcompare/pull/516#discussion_r1297358956) about adding memoized select for newRevisions in all revisions dropdown

[Jira ticket](https://mozilla-hub.atlassian.net/browse/PCF-290)