### PR TITLE
Results: Fix framework reverting to 'talos' on page render

### DIFF
--- a/src/components/CompareResults/beta/ResultsView.tsx
+++ b/src/components/CompareResults/beta/ResultsView.tsx
@@ -10,6 +10,7 @@ import { useSearchParams } from 'react-router-dom';
 import { style } from 'typestyle';
 
 import { compareView } from '../../../common/constants';
+import { frameworkMap } from '../../../common/constants';
 import { useAppDispatch, useAppSelector } from '../../../hooks/app';
 import useFetchCompareResults from '../../../hooks/useFetchCompareResults';
 import useHandleChangeSearch from '../../../hooks/useHandleChangeSearch';
@@ -17,10 +18,12 @@ import { comparisonResults as secondRevisionResults } from '../../../mockData/9d
 import { comparisonResults as thirdRevisionResults } from '../../../mockData/a998c42399a8';
 import { comparisonResults as firstRevisionResults } from '../../../mockData/bb6a5e451dac';
 import { setCompareData } from '../../../reducers/CompareResults';
+import { updateFramework } from '../../../reducers/FrameworkSlice';
 import { SearchContainerStyles } from '../../../styles';
 import { background } from '../../../styles';
 import { fetchRecentRevisions } from '../../../thunks/searchThunk';
 import { Repository, View, InputType } from '../../../types/state';
+import { Framework } from '../../../types/types';
 import CompareWithBase from '../../Search/CompareWithBase';
 import PerfCompareHeader from '../../Shared/PerfCompareHeader';
 import ResultsMain from './ResultsMain';
@@ -100,6 +103,16 @@ function ResultsView(props: ResultsViewProps) {
           'new',
         );
       });
+    }
+    if (framework) {
+      const frameworkId = parseInt(framework);
+      const frameworkName = frameworkMap[frameworkId as Framework['id']];
+      dispatch(
+        updateFramework({
+          id: frameworkId,
+          name: frameworkName,
+        }),
+      );
     }
   }, []);
 

--- a/src/components/CompareResults/beta/ResultsView.tsx
+++ b/src/components/CompareResults/beta/ResultsView.tsx
@@ -106,13 +106,15 @@ function ResultsView(props: ResultsViewProps) {
     }
     if (framework) {
       const frameworkId = parseInt(framework);
-      const frameworkName = frameworkMap[frameworkId as Framework['id']];
-      dispatch(
-        updateFramework({
-          id: frameworkId,
-          name: frameworkName,
-        }),
-      );
+      if (frameworkId in frameworkMap) {
+        const frameworkName = frameworkMap[frameworkId as Framework['id']];
+        dispatch(
+          updateFramework({
+            id: frameworkId,
+            name: frameworkName,
+          }),
+        );
+      }
     }
   }, []);
 


### PR DESCRIPTION
## This PR fixes the framework reverting to 'talos' on results view render.
It is related to https://bugzilla.mozilla.org/show_bug.cgi?id=1851048.

- On the initial results view render the store is populated using the data from the URL. These changes ensure that the store is populated with the framework included in the URL.    

- It is achieved with an `updateFramework` action, that is dispatched with the framework param from the URL in `results view`.


