### PR TITLE
Results: Enable "Download JSON" button (Follow up)

### DIFF
--- a/src/__tests__/CompareResults/ResultsView.test.tsx
+++ b/src/__tests__/CompareResults/ResultsView.test.tsx
@@ -302,4 +302,36 @@ describe('Results View', () => {
     const labelResult = labelFunction({ raw: { x: 5, y: 0, r: 10 } });
     expect(labelResult).toBe('5 ms');
   });
+
+  it('should make blobUrl available when "Download JSON" button is clicked', async () => {
+    const user = userEvent.setup({ delay: null });
+
+    const createObjectURLMock = jest.fn().mockReturnValue('blob:');
+    global.URL.createObjectURL = createObjectURLMock;
+    const revokeObjectURLMock = jest.fn();
+    global.URL.revokeObjectURL = revokeObjectURLMock;
+    // Render the component
+
+    const { testData } = getTestData();
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () => ({
+          results: testData,
+        }),
+      }),
+    ) as jest.Mock;
+    jest.spyOn(global, 'fetch');
+
+    renderWithRouter(
+      <ResultsView
+        protocolTheme={protocolTheme}
+        toggleColorMode={toggleColorMode}
+        title={Strings.metaData.pageTitle.results}
+      />,
+    );
+    const button = await screen.findByText('Download JSON');
+    await user.click(button);
+
+    expect(createObjectURLMock).toHaveBeenCalled();
+  });
 });

--- a/src/__tests__/CompareResults/ResultsView.test.tsx
+++ b/src/__tests__/CompareResults/ResultsView.test.tsx
@@ -333,5 +333,6 @@ describe('Results View', () => {
     await user.click(button);
 
     expect(createObjectURLMock).toHaveBeenCalled();
+    expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:');
   });
 });

--- a/src/__tests__/CompareResults/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SearchInput.test.tsx.snap
@@ -473,17 +473,16 @@ exports[`Search by title/test name Should match snapshot 1`] = `
                 <div
                   class="fnyxjzg"
                 >
-                  <a
+                  <button
                     class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-t42cd1-MuiButtonBase-root-MuiButton-root"
-                    download="perf-compare-all-revisions.json"
-                    href="data:text/json;charset=utf-8,%5B%5D"
                     tabindex="0"
+                    type="button"
                   >
                     Download JSON
                     <span
                       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                     />
-                  </a>
+                  </button>
                 </div>
               </div>
             </header>

--- a/src/__tests__/CompareResults/__snapshots__/fetchCompareResults.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/fetchCompareResults.test.tsx.snap
@@ -473,17 +473,16 @@ exports[`Results View/fetchCompareResults Should fetch and display recent result
                 <div
                   class="fnyxjzg"
                 >
-                  <a
+                  <button
                     class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-t42cd1-MuiButtonBase-root-MuiButton-root"
-                    download="perf-compare-all-revisions.json"
-                    href="data:text/json;charset=utf-8,%5B%5D"
                     tabindex="0"
+                    type="button"
                   >
                     Download JSON
                     <span
                       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                     />
-                  </a>
+                  </button>
                 </div>
               </div>
             </header>
@@ -996,17 +995,16 @@ exports[`Results View/fetchCompareResults State does not contain data if fetch r
                 <div
                   class="fnyxjzg"
                 >
-                  <a
+                  <button
                     class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-t42cd1-MuiButtonBase-root-MuiButton-root"
-                    download="perf-compare-all-revisions.json"
-                    href="data:text/json;charset=utf-8,%5B%5D"
                     tabindex="0"
+                    type="button"
                   >
                     Download JSON
                     <span
                       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                     />
-                  </a>
+                  </button>
                 </div>
               </div>
             </header>

--- a/src/__tests__/Search/__snapshots__/SearchComponent.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchComponent.test.tsx.snap
@@ -855,17 +855,16 @@ exports[`Search View RESULTS: clicking the cancel button hides input and dropdow
                 <div
                   class="fnyxjzg"
                 >
-                  <a
+                  <button
                     class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-t42cd1-MuiButtonBase-root-MuiButton-root"
-                    download="perf-compare-all-revisions.json"
-                    href="data:text/json;charset=utf-8,%5B%5D"
                     tabindex="0"
+                    type="button"
                   >
                     Download JSON
                     <span
                       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                     />
-                  </a>
+                  </button>
                 </div>
               </div>
             </header>
@@ -1953,17 +1952,16 @@ exports[`Search View RESULTS: clicking the save button hides input and dropdown 
                 <div
                   class="fnyxjzg"
                 >
-                  <a
+                  <button
                     class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-t42cd1-MuiButtonBase-root-MuiButton-root"
-                    download="perf-compare-all-revisions.json"
-                    href="data:text/json;charset=utf-8,%5B%5D"
                     tabindex="0"
+                    type="button"
                   >
                     Download JSON
                     <span
                       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                     />
-                  </a>
+                  </button>
                 </div>
               </div>
             </header>
@@ -3051,17 +3049,16 @@ exports[`Search View RESULTS: shows dropdown and input when edit button in click
                 <div
                   class="fnyxjzg"
                 >
-                  <a
+                  <button
                     class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-t42cd1-MuiButtonBase-root-MuiButton-root"
-                    download="perf-compare-all-revisions.json"
-                    href="data:text/json;charset=utf-8,%5B%5D"
                     tabindex="0"
+                    type="button"
                   >
                     Download JSON
                     <span
                       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                     />
-                  </a>
+                  </button>
                 </div>
               </div>
             </header>

--- a/src/components/CompareResults/DownloadButton.tsx
+++ b/src/components/CompareResults/DownloadButton.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Button } from '@mui/material';
 import { style } from 'typestyle';
 
@@ -58,4 +56,4 @@ function DownloadButton() {
   );
 }
 
-export default React.memo(DownloadButton);
+export default DownloadButton;

--- a/src/components/CompareResults/DownloadButton.tsx
+++ b/src/components/CompareResults/DownloadButton.tsx
@@ -1,7 +1,11 @@
+import React from 'react';
+
 import { Button } from '@mui/material';
 import { style } from 'typestyle';
 
+import { RootState } from '../../common/store';
 import { useAppSelector } from '../../hooks/app';
+import { selectStringifiedJsonResults } from '../../reducers/ComparisonSlice';
 import { Strings } from '../../resources/Strings';
 import { ButtonsLightRaw } from '../../styles';
 import { truncateHash } from '../../utils/helpers';
@@ -16,78 +20,42 @@ const styles = {
   }),
 };
 
-interface GroupedResults {
-  [key: string]: ResultObject[];
-}
-
-interface ResultObject {
-  header_name: string;
-  new_rev: string;
-}
-
 function DownloadButton() {
-  let fileName = 'perf-compare-all-revisions.json';
-  const results = useAppSelector((state) => {
+  const results = useAppSelector(selectStringifiedJsonResults);
+
+  const fileName = useAppSelector((state: RootState) => {
     if (
       state.comparison.activeComparison ===
       Strings.components.comparisonRevisionDropdown.allRevisions.key
     ) {
-      return state.compareResults.data;
+      return 'perf-compare-all-revisions.json';
     } else {
-      fileName = `perf-compare-${truncateHash(
+      return `perf-compare-${truncateHash(
         state.comparison.activeComparison,
       )}.json`;
-      return {
-        [state.comparison.activeComparison]:
-          state.compareResults.data[state.comparison.activeComparison],
-      };
     }
   });
 
-  const formatDownloadData = (
-    data: Record<string, ResultObject[]>,
-  ): object[] => {
-    const groupNames = Object.keys(data);
-    const transformedGroups: object[] = [];
+  const handleDownloadClick = () => {
+    if (results) {
+      const blob = new Blob([results], { type: 'application/json' });
+      const blobUrl = URL.createObjectURL(blob);
 
-    groupNames.forEach((groupName) => {
-      const groupedResults = data[groupName].reduce(
-        (grouped: GroupedResults, result: ResultObject) => {
-          if (!grouped[result.header_name]) {
-            grouped[result.header_name] = [];
-          }
-          grouped[result.header_name].push(result);
-          return grouped;
-        },
-        {},
-      );
+      // Trigger the download programmatically
+      const downloadLink = document.createElement('a');
+      downloadLink.href = blobUrl;
+      downloadLink.download = fileName;
+      downloadLink.click();
 
-      const transformedGroupEntries = Object.keys(groupedResults).map(
-        (header_name) => ({
-          [`${header_name} ${truncateHash(
-            groupedResults[header_name][0].new_rev,
-          )}`]: groupedResults[header_name],
-        }),
-      );
-
-      transformedGroups.push(...transformedGroupEntries);
-    });
-    return transformedGroups;
+      // Clean up the URL object
+      URL.revokeObjectURL(blobUrl);
+    }
   };
-
   return (
     <div className={styles.downloadButton}>
-      <Button
-        disabled={!results}
-        href={`data:text/json;charset=utf-8,${encodeURIComponent(
-          JSON.stringify(formatDownloadData(results)),
-        )}`}
-        download={fileName}
-      >
-        Download JSON
-      </Button>
+      <Button onClick={handleDownloadClick}>Download JSON</Button>
     </div>
   );
 }
 
-export default DownloadButton;
+export default React.memo(DownloadButton);

--- a/src/reducers/ComparisonSlice.ts
+++ b/src/reducers/ComparisonSlice.ts
@@ -3,6 +3,7 @@ import { createSelector, createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { RootState } from '../common/store';
 import { Strings } from '../resources/Strings';
 import { CompareResultsItem, RevisionsHeader } from '../types/state';
+import { truncateHash } from '../utils/helpers';
 
 interface InitialState {
   activeComparison: string;
@@ -19,6 +20,13 @@ type Results = {
   revisionHeader: RevisionsHeader;
 };
 
+type ResultsGroupedByKey = Record<string, ResultObject[]>;
+
+interface ResultObject {
+  header_name: string;
+  new_rev: string;
+}
+
 const comparison = createSlice({
   name: 'comparison',
   initialState,
@@ -33,6 +41,73 @@ const comparison = createSlice({
     },
   },
 });
+
+/*This function transforms results into an array of objects, where each object represents a array of objects 
+grouped by their header_name as key. The keys in the resulting objects are composed of header_name and a 
+truncated hash of new_rev.
+for example: [
+  {
+    "a11yr opt e10s fission stylo webrender 69d5beb77da0": [
+      {
+        "base_rev": "8f5a11c1eb0b7598d1415f6efa9c360191a423f8",
+        "new_rev": "69d5beb77da06f9eda78eff3c54463273d457e66",
+        "framework_id": 1,...}{}{}...]}{}{}...] */
+export const formatDownloadData = (
+  data: Record<string, ResultObject[]>,
+): Array<ResultsGroupedByKey> => {
+  const groupNames = Object.keys(data);
+  const transformedGroups: Array<ResultsGroupedByKey> = [];
+
+  groupNames.forEach((groupName) => {
+    const groupedResults = data[groupName].reduce(
+      (grouped: ResultsGroupedByKey, result: ResultObject) => {
+        if (!grouped[result.header_name]) {
+          grouped[result.header_name] = [];
+        }
+        grouped[result.header_name].push(result);
+        return grouped;
+      },
+      {},
+    );
+
+    const transformedGroupEntries = Object.keys(groupedResults).map(
+      (header_name) => {
+        const key = `${header_name} ${truncateHash(
+          groupedResults[header_name][0].new_rev,
+        )}`;
+        const value = groupedResults[header_name];
+
+        return {
+          [key]: value,
+        };
+      },
+    );
+
+    transformedGroups.push(...transformedGroupEntries);
+  });
+  return transformedGroups;
+};
+
+export const selectStringifiedJsonResults = createSelector(
+  (state: RootState) => state.comparison.activeComparison,
+  (state: RootState) => state.compareResults.data,
+  (activeComparison, data) => {
+    if (
+      activeComparison ===
+      Strings.components.comparisonRevisionDropdown.allRevisions.key
+    ) {
+      return JSON.stringify(formatDownloadData(data), null, 2);
+    } else {
+      return JSON.stringify(
+        formatDownloadData({
+          [activeComparison]: data[activeComparison],
+        }),
+        null,
+        2,
+      );
+    }
+  },
+);
 
 function processResults(results: CompareResultsItem[]) {
   const processedResults: Map<string, CompareResultsItem[]> = new Map<


### PR DESCRIPTION
## This PR is a follow-up of  [#520](https://github.com/mozilla/perfcompare/pull/520) 
It is a solution for https://bugzilla.mozilla.org/show_bug.cgi?id=1845985.   

- Implemented a `fileName` selector.
- Used `createSelector()` and `React.memo()` to ensure the state is only recalculated when changed.
- Used `blob` instead of putting all the data inside the URL.
- Blob is generated programatically when the user clicks the "Download JSON" button.
