### PR TITLE
Sort frameworks in framework dropdown list

### DIFF
--- a/src/__tests__/Search/CompareWithBase.test.tsx
+++ b/src/__tests__/Search/CompareWithBase.test.tsx
@@ -63,6 +63,7 @@ describe('Compare With Base', () => {
     });
 
     await user.click(frameworkDropdown);
+    expect(screen.getByRole('listbox')).toMatchSnapshot();
     const buildMetricsItem = screen.getByRole('option', {
       name: 'build_metrics',
     });

--- a/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
@@ -381,3 +381,133 @@ exports[`Compare With Base renders correctly when there are no results 1`] = `
   </div>
 </body>
 `;
+
+exports[`Compare With Base selects and displays new framework when clicked 1`] = `
+<ul
+  aria-labelledby="select-framework-label"
+  class="MuiList-root MuiList-padding MuiMenu-list css-6hp17o-MuiList-root-MuiMenu-list"
+  role="listbox"
+  tabindex="-1"
+>
+  <li
+    aria-selected="false"
+    class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters framework-dropdown-item css-shx448-MuiButtonBase-root-MuiMenuItem-root"
+    data-value="4"
+    role="option"
+    tabindex="-1"
+  >
+    awsy
+    <span
+      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+    />
+  </li>
+  <li
+    aria-selected="false"
+    class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters framework-dropdown-item css-shx448-MuiButtonBase-root-MuiMenuItem-root"
+    data-value="13"
+    role="option"
+    tabindex="-1"
+  >
+    browsertime
+    <span
+      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+    />
+  </li>
+  <li
+    aria-selected="false"
+    class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters framework-dropdown-item css-shx448-MuiButtonBase-root-MuiMenuItem-root"
+    data-value="2"
+    role="option"
+    tabindex="-1"
+  >
+    build_metrics
+    <span
+      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+    />
+  </li>
+  <li
+    aria-selected="false"
+    class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters framework-dropdown-item css-shx448-MuiButtonBase-root-MuiMenuItem-root"
+    data-value="12"
+    role="option"
+    tabindex="-1"
+  >
+    devtools
+    <span
+      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+    />
+  </li>
+  <li
+    aria-selected="false"
+    class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters framework-dropdown-item css-shx448-MuiButtonBase-root-MuiMenuItem-root"
+    data-value="16"
+    role="option"
+    tabindex="-1"
+  >
+    fxrecord
+    <span
+      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+    />
+  </li>
+  <li
+    aria-selected="false"
+    class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters framework-dropdown-item css-shx448-MuiButtonBase-root-MuiMenuItem-root"
+    data-value="11"
+    role="option"
+    tabindex="-1"
+  >
+    js-bench
+    <span
+      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+    />
+  </li>
+  <li
+    aria-selected="false"
+    class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters framework-dropdown-item css-shx448-MuiButtonBase-root-MuiMenuItem-root"
+    data-value="15"
+    role="option"
+    tabindex="-1"
+  >
+    mozperftest
+    <span
+      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+    />
+  </li>
+  <li
+    aria-selected="false"
+    class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters framework-dropdown-item css-shx448-MuiButtonBase-root-MuiMenuItem-root"
+    data-value="6"
+    role="option"
+    tabindex="-1"
+  >
+    platform_microbench
+    <span
+      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+    />
+  </li>
+  <li
+    aria-selected="false"
+    class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters framework-dropdown-item css-shx448-MuiButtonBase-root-MuiMenuItem-root"
+    data-value="10"
+    role="option"
+    tabindex="-1"
+  >
+    raptor
+    <span
+      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+    />
+  </li>
+  <li
+    aria-selected="true"
+    class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-selected MuiMenuItem-root MuiMenuItem-gutters Mui-selected framework-dropdown-item css-shx448-MuiButtonBase-root-MuiMenuItem-root"
+    data-value="1"
+    role="option"
+    tabindex="0"
+  >
+    talos
+    <span
+      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+    />
+  </li>
+</ul>
+`;

--- a/src/components/Search/FrameworkDropdown.tsx
+++ b/src/components/Search/FrameworkDropdown.tsx
@@ -22,13 +22,26 @@ import {
 } from '../../styles';
 import type { ThemeMode } from '../../types/state';
 import type { Framework } from '../../types/types';
-import { sortFrameworks } from '../../utils/helpers';
 
 interface FrameworkDropdownProps {
   mode: ThemeMode;
 }
 
 const strings = Strings.components.searchDefault.sharedCollasped.framkework;
+
+const sortFrameworks = (
+  frameworks: Record<Framework['id'], Framework['name']>,
+) => {
+  const unsortedArray = Object.entries(frameworks);
+
+  // Sort the array based on values
+
+  const sortedArray = unsortedArray.sort((a, b) => {
+    return a[1].localeCompare(b[1]);
+  });
+
+  return sortedArray;
+};
 
 const sortedFrameworks = sortFrameworks(frameworkMap);
 

--- a/src/components/Search/FrameworkDropdown.tsx
+++ b/src/components/Search/FrameworkDropdown.tsx
@@ -1,5 +1,3 @@
-import { useMemo } from 'react';
-
 import InfoIcon from '@mui/icons-material/InfoOutlined';
 import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
@@ -31,6 +29,8 @@ interface FrameworkDropdownProps {
 }
 
 const strings = Strings.components.searchDefault.sharedCollasped.framkework;
+
+const sortedFrameworks = sortFrameworks(frameworkMap);
 
 function FrameworkDropdown({ mode }: FrameworkDropdownProps) {
   cssRule('.MuiTooltip-popper', {
@@ -83,7 +83,6 @@ function FrameworkDropdown({ mode }: FrameworkDropdownProps) {
 
   const dispatch = useAppDispatch();
   const frameworkId = useAppSelector((state) => state.framework.id);
-  const sortedFrameworks = useMemo(() => sortFrameworks(frameworkMap), []);
 
   const handleFrameworkSelect = async (event: SelectChangeEvent) => {
     const id = +event.target.value as Framework['id'];

--- a/src/components/Search/FrameworkDropdown.tsx
+++ b/src/components/Search/FrameworkDropdown.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import InfoIcon from '@mui/icons-material/InfoOutlined';
 import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
@@ -81,6 +83,7 @@ function FrameworkDropdown({ mode }: FrameworkDropdownProps) {
 
   const dispatch = useAppDispatch();
   const frameworkId = useAppSelector((state) => state.framework.id);
+  const sortedFrameworks = useMemo(() => sortFrameworks(frameworkMap), []);
 
   const handleFrameworkSelect = async (event: SelectChangeEvent) => {
     const id = +event.target.value as Framework['id'];
@@ -116,7 +119,7 @@ function FrameworkDropdown({ mode }: FrameworkDropdownProps) {
           onChange={(e) => void handleFrameworkSelect(e)}
           name='Framework'
         >
-          {sortFrameworks(frameworkMap).map(([id, name]) => (
+          {sortedFrameworks.map(([id, name]) => (
             <MenuItem value={id} key={name} className='framework-dropdown-item'>
               {name}
             </MenuItem>

--- a/src/components/Search/FrameworkDropdown.tsx
+++ b/src/components/Search/FrameworkDropdown.tsx
@@ -22,6 +22,7 @@ import {
 } from '../../styles';
 import type { ThemeMode } from '../../types/state';
 import type { Framework } from '../../types/types';
+import { sortFrameworks } from '../../utils/helpers';
 
 interface FrameworkDropdownProps {
   mode: ThemeMode;
@@ -115,7 +116,7 @@ function FrameworkDropdown({ mode }: FrameworkDropdownProps) {
           onChange={(e) => void handleFrameworkSelect(e)}
           name='Framework'
         >
-          {Object.entries(frameworkMap).map(([id, name]) => (
+          {sortFrameworks(frameworkMap).map(([id, name]) => (
             <MenuItem value={id} key={name} className='framework-dropdown-item'>
               {name}
             </MenuItem>

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -14,20 +14,6 @@ import WindowsIcon from '../components/Shared/Icons/WindowsIcon';
 import type { Repository, RevisionsList } from '../types/state';
 import { Framework, SupportedPerfdocsFramework } from '../types/types';
 
-export const sortFrameworks = (
-  frameworks: Record<Framework['id'], Framework['name']>,
-) => {
-  const unsortedArray = Object.entries(frameworks);
-
-  // Sort the array based on values
-
-  const sortedArray = unsortedArray.sort((a, b) => {
-    return a[1].localeCompare(b[1]);
-  });
-
-  return sortedArray;
-};
-
 const truncateHash = (revision: RevisionsList['revision']) =>
   revision.slice(0, 12);
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -14,6 +14,20 @@ import WindowsIcon from '../components/Shared/Icons/WindowsIcon';
 import type { Repository, RevisionsList } from '../types/state';
 import { Framework, SupportedPerfdocsFramework } from '../types/types';
 
+export const sortFrameworks = (
+  frameworks: Record<Framework['id'], Framework['name']>,
+) => {
+  const unsortedArray = Object.entries(frameworks);
+
+  // Sort the array based on values
+
+  const sortedArray = unsortedArray.sort((a, b) => {
+    return a[1].localeCompare(b[1]);
+  });
+
+  return sortedArray;
+};
+
 const truncateHash = (revision: RevisionsList['revision']) =>
   revision.slice(0, 12);
 


### PR DESCRIPTION
## This PR adds a helper function to sort frameworks
It is a solution for https://bugzilla.mozilla.org/show_bug.cgi?id=1852292
![sortedFrameworks](https://github.com/mozilla/perfcompare/assets/60618877/da211ea3-34f9-4cf2-b546-493b94fe397d)

- `sortFrameworks()` function is implemented.
- Frameworks are sorted alphabetically

 

