### PR TITLE
Fix: favicon not showing on deploy

### DIFF
--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -42,6 +42,7 @@ module.exports = {
   plugins: [
     new HtmlWebpackPlugin({
       template: path.resolve(__dirname, '..', './public/index.html'),
+      favicon: './public/favicon.svg',
     }),
   ],
 };


### PR DESCRIPTION
## This PR fixes the favicon not displaying on deploy issue
It is a solution for https://bugzilla.mozilla.org/show_bug.cgi?id=1856337

![Screenshot from 2023-10-02 16-22-28](https://github.com/mozilla/perfcompare/assets/60618877/070f3c9a-5c2a-40eb-b8c7-d8bb2f918d48)

- Specified the favicon in webpack config.