### PR TITLE
Use the new react router api to manage the URL and fetching external data

### DIFF
--- a/src/__tests__/hooks/useHandleChangeSearch.test.ts
+++ b/src/__tests__/hooks/useHandleChangeSearch.test.ts
@@ -32,9 +32,12 @@ describe('Tests useHandleSearchHook', () => {
       searchType,
       repository: 'try' as Repository['name'],
     };
-    const { result } = renderHook(() => useHandleChangeSearch(), {
-      wrapper: StoreProvider,
-    });
+    const { result } = renderHook(
+      () => useHandleChangeSearch({ load: jest.fn() }),
+      {
+        wrapper: StoreProvider,
+      },
+    );
     await act(async () => {
       result.current.handleChangeSearch(searchState);
     });
@@ -53,9 +56,12 @@ describe('Tests useHandleSearchHook', () => {
       results: testData,
       searchType,
     };
-    const { result } = renderHook(() => useHandleChangeSearch(), {
-      wrapper: StoreProvider,
-    });
+    const { result } = renderHook(
+      () => useHandleChangeSearch({ load: jest.fn() }),
+      {
+        wrapper: StoreProvider,
+      },
+    );
 
     await act(async () => {
       store.dispatch(updateSearchResults(searchResults));
@@ -79,9 +85,12 @@ describe('Tests useHandleSearchHook', () => {
       repository: 'try' as Repository['name'],
     };
     const testError = 'test error';
-    const { result } = renderHook(() => useHandleChangeSearch(), {
-      wrapper: StoreProvider,
-    });
+    const { result } = renderHook(
+      () => useHandleChangeSearch({ load: jest.fn() }),
+      {
+        wrapper: StoreProvider,
+      },
+    );
 
     act(() => {
       store.dispatch(setInputError({ errorMessage: testError, searchType }));
@@ -103,9 +112,12 @@ describe('Tests useHandleSearchHook', () => {
       searchType,
       repository: 'try' as Repository['name'],
     };
-    const { result } = renderHook(() => useHandleChangeSearch(), {
-      wrapper: StoreProvider,
-    });
+    const { result } = renderHook(
+      () => useHandleChangeSearch({ load: jest.fn() }),
+      {
+        wrapper: StoreProvider,
+      },
+    );
     await act(async () => {
       result.current.handleChangeSearch(searchState);
     });
@@ -123,15 +135,16 @@ describe('Tests useHandleSearchHook', () => {
       searchType,
       repository: 'try' as Repository['name'],
     };
-    const { result } = renderHook(() => useHandleChangeSearch(), {
+    const fetcher = { load: jest.fn() };
+    const { result } = renderHook(() => useHandleChangeSearch(fetcher), {
       wrapper: StoreProvider,
     });
     await act(async () => {
       result.current.handleChangeSearch(searchState);
     });
     jest.runAllTimers();
-    expect(global.fetch).toHaveBeenCalledWith(
-      `https://treeherder.mozilla.org/api/project/${searchState.repository}/push/?hide_reviewbot_pushes=true`,
+    expect(fetcher.load).toHaveBeenCalledWith(
+      `/api/recent-revisions/${searchState.repository}`,
     );
   });
 
@@ -142,15 +155,16 @@ describe('Tests useHandleSearchHook', () => {
       searchType,
       repository: 'try' as Repository['name'],
     };
-    const { result } = renderHook(() => useHandleChangeSearch(), {
+    const fetcher = { load: jest.fn() };
+    const { result } = renderHook(() => useHandleChangeSearch(fetcher), {
       wrapper: StoreProvider,
     });
     await act(async () => {
       result.current.handleChangeSearch(searchState);
     });
     jest.runAllTimers();
-    expect(global.fetch).toHaveBeenCalledWith(
-      `https://treeherder.mozilla.org/api/project/${searchState.repository}/push/?author=some@email.com`,
+    expect(fetcher.load).toHaveBeenCalledWith(
+      `/api/recent-revisions/${searchState.repository}/by-author/some@email.com`,
     );
   });
 
@@ -166,23 +180,24 @@ describe('Tests useHandleSearchHook', () => {
       searchType,
       repository: 'mozilla-central' as Repository['name'],
     };
-    const { result } = renderHook(() => useHandleChangeSearch(), {
+    const fetcher = { load: jest.fn() };
+    const { result } = renderHook(() => useHandleChangeSearch(fetcher), {
       wrapper: StoreProvider,
     });
     await act(async () => {
       result.current.handleChangeSearch(searchState);
     });
     jest.runAllTimers();
-    expect(global.fetch).toHaveBeenCalledWith(
-      `https://treeherder.mozilla.org/api/project/${searchState.repository}/push/?revision=abcdef123456`,
+    expect(fetcher.load).toHaveBeenCalledWith(
+      `/api/recent-revisions/${searchState.repository}/by-hash/abcdef123456`,
     );
 
     await act(async () => {
       result.current.handleChangeSearch(searchState2);
     });
     jest.runAllTimers();
-    expect(global.fetch).toHaveBeenCalledWith(
-      `https://treeherder.mozilla.org/api/project/${searchState2.repository}/push/?revision=abcdef1234567890abcdef1234567890abcdef12`,
+    expect(fetcher.load).toHaveBeenCalledWith(
+      `/api/recent-revisions/${searchState.repository}/by-hash/abcdef1234567890abcdef1234567890abcdef12`,
     );
   });
 
@@ -193,7 +208,8 @@ describe('Tests useHandleSearchHook', () => {
       searchType,
       repository: 'autoland' as Repository['name'],
     };
-    const { result } = renderHook(() => useHandleChangeSearch(), {
+    const fetcher = { load: jest.fn() };
+    const { result } = renderHook(() => useHandleChangeSearch(fetcher), {
       wrapper: StoreProvider,
     });
     await act(async () => {
@@ -206,6 +222,6 @@ describe('Tests useHandleSearchHook', () => {
       result.current.handleChangeSearch(searchState);
     });
     jest.runAllTimers();
-    expect(global.fetch).toBeCalledTimes(1);
+    expect(fetcher.load).toBeCalledTimes(1);
   });
 });

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -17,6 +17,7 @@ import { Banner } from '../styles/Banner';
 import useProtocolTheme from '../theme/protocolTheme';
 import { loader as compareLoader } from './CompareResults/loader';
 import ResultsView from './CompareResults/ResultsView';
+import { loader as recentRevisionsLoader } from './Search/loader';
 import SearchView from './Search/SearchView';
 import SnackbarCloseButton from './Shared/SnackbarCloseButton';
 
@@ -97,6 +98,20 @@ function App() {
                       />
                     }
                   />
+
+                  <Route
+                    path='/api/recent-revisions/:repository'
+                    loader={recentRevisionsLoader}
+                  >
+                    <Route
+                      path='by-author/:author'
+                      loader={recentRevisionsLoader}
+                    />
+                    <Route
+                      path='by-hash/:hash'
+                      loader={recentRevisionsLoader}
+                    />
+                  </Route>
                 </>,
               ),
             )}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -15,6 +15,7 @@ import {
 import { Strings } from '../resources/Strings';
 import { Banner } from '../styles/Banner';
 import useProtocolTheme from '../theme/protocolTheme';
+import { loader as compareLoader } from './CompareResults/loader';
 import ResultsView from './CompareResults/ResultsView';
 import SearchView from './Search/SearchView';
 import SnackbarCloseButton from './Shared/SnackbarCloseButton';
@@ -87,6 +88,7 @@ function App() {
 
                   <Route
                     path='/compare-results'
+                    loader={compareLoader}
                     element={
                       <ResultsView
                         toggleColorMode={toggleColorMode}

--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -1,17 +1,72 @@
+import { useMemo } from 'react';
+
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import Paper from '@mui/material/Paper';
 import Table from '@mui/material/Table';
 import TableContainer from '@mui/material/TableContainer';
+import { useLoaderData } from 'react-router-dom';
 import { style } from 'typestyle';
 
 import { useAppSelector } from '../../hooks/app';
-import { selectProcessedResults } from '../../reducers/ComparisonSlice';
+import { Strings } from '../../resources/Strings';
 import { Colors, Spacing } from '../../styles';
-import type { ThemeMode } from '../../types/state';
+import type {
+  ThemeMode,
+  CompareResultsItem,
+  RevisionsHeader,
+} from '../../types/state';
+import type { LoaderReturnValue } from './loader';
 import NoResultsFound from './NoResultsFound';
 import TableContent from './TableContent';
 import TableHeader from './TableHeader';
+
+type Results = {
+  key: string;
+  value: CompareResultsItem[];
+  revisionHeader: RevisionsHeader;
+};
+
+function processResults(results: CompareResultsItem[]) {
+  const processedResults: Map<string, CompareResultsItem[]> = new Map<
+    string,
+    CompareResultsItem[]
+  >();
+  results.forEach((result) => {
+    const { new_rev: newRevision, header_name: header } = result;
+    const rowIdentifier = header.concat(' ', newRevision);
+    if (processedResults.has(rowIdentifier)) {
+      (processedResults.get(rowIdentifier) as CompareResultsItem[]).push(
+        result,
+      );
+    } else {
+      processedResults.set(rowIdentifier, [result]);
+    }
+  });
+  const restructuredResults: Results[] = Array.from(
+    processedResults,
+    function ([rowIdentifier, result]) {
+      return {
+        key: rowIdentifier,
+        value: result,
+        revisionHeader: {
+          suite: result[0].suite,
+          framework_id: result[0].framework_id,
+          test: result[0].test,
+          option_name: result[0].option_name,
+          extra_options: result[0].extra_options,
+          new_rev: result[0].new_rev,
+          new_repo: result[0].new_repository_name,
+        },
+      };
+    },
+  );
+
+  return restructuredResults;
+}
+
+const allRevisionsOption =
+  Strings.components.comparisonRevisionDropdown.allRevisions.key;
 
 const customStyles = {
   boxShadow: 'none',
@@ -20,9 +75,23 @@ const customStyles = {
 function ResultsTable(props: ResultsTableProps) {
   const { themeMode } = props;
 
-  const loading = useAppSelector((state) => state.compareResults.loading);
+  const { results } = useLoaderData() as LoaderReturnValue;
+  const activeComparison = useAppSelector(
+    (state) => state.comparison.activeComparison,
+  );
 
-  const processedResults = useAppSelector(selectProcessedResults);
+  const processedResults = useMemo(() => {
+    const resultsForCurrentComparison =
+      activeComparison === allRevisionsOption
+        ? results.flat()
+        : results.find((result) => result[0].new_rev === activeComparison) ??
+          [];
+    return processResults(resultsForCurrentComparison);
+  }, [results, activeComparison]);
+
+  // TODO support loading through the react-router defer mechanism
+  // const loading = useAppSelector((state) => state.compareResults.loading);
+  const loading = false;
 
   const themeColor100 =
     themeMode === 'light' ? Colors.Background100 : Colors.Background100Dark;

--- a/src/components/CompareResults/ResultsView.tsx
+++ b/src/components/CompareResults/ResultsView.tsx
@@ -11,7 +11,6 @@ import { style } from 'typestyle';
 import { compareView, frameworkMap, repoMap } from '../../common/constants';
 import { useAppDispatch, useAppSelector } from '../../hooks/app';
 import useFetchCompareResults from '../../hooks/useFetchCompareResults';
-import useHandleChangeSearch from '../../hooks/useHandleChangeSearch';
 import { updateFramework } from '../../reducers/FrameworkSlice';
 import { SearchContainerStyles } from '../../styles';
 import { background } from '../../styles';
@@ -46,7 +45,6 @@ function ResultsView(props: ResultsViewProps) {
 
   const { dispatchFetchCompareResults, dispatchFakeCompareResults } =
     useFetchCompareResults();
-  const { searchRecentRevisions } = useHandleChangeSearch();
 
   const { protocolTheme, toggleColorMode, title } = props;
   const themeMode = protocolTheme.palette.mode;
@@ -84,22 +82,6 @@ function ResultsView(props: ResultsViewProps) {
         revsArray,
         framework as string,
       );
-
-      /*
-       *On component mount, use the repos and revs in hash to search for the base and new *revisions. Store the results in state via the SelectedRevisionsSlice: see extra *reducer, fetchRevisionsByID. Now can always display the selected revisions despite *page refresh or copying and pasting url
-       */
-      revsArray.forEach((rev, index) => {
-        void searchRecentRevisions(
-          reposArray[index] as Repository['name'],
-          rev,
-          'base',
-        );
-        void searchRecentRevisions(
-          reposArray[index] as Repository['name'],
-          rev,
-          'new',
-        );
-      });
     }
   }, [repos, revs, framework]);
 

--- a/src/components/CompareResults/loader.ts
+++ b/src/components/CompareResults/loader.ts
@@ -1,0 +1,130 @@
+import { repoMap } from '../../common/constants';
+import {
+  fetchCompareResults,
+  fetchFakeCompareResults,
+} from '../../logic/treeherder';
+import { Repository } from '../../types/state';
+import { FakeCommitHash } from '../../types/types';
+
+async function checkValuesAndFetchCompareResultsOnTreeherder({
+  baseRev,
+  baseRepo,
+  newRevs,
+  newRepos,
+  framework,
+}: {
+  baseRev: string | null;
+  baseRepo: Repository['name'] | null;
+  newRevs: string[];
+  newRepos: Repository['name'][];
+  framework: string | null;
+}) {
+  if (baseRev === null) {
+    throw new Error('The parameter baseRev is missing.');
+  }
+
+  if (baseRepo === null) {
+    throw new Error('The parameter baseRepo is missing.');
+  }
+
+  const validRepoValues = Object.values(repoMap);
+  if (!validRepoValues.includes(baseRepo)) {
+    throw new Error(
+      `The parameter baseRepo "${baseRepo}" should be one of ${validRepoValues.join(
+        ', ',
+      )}.`,
+    );
+  }
+
+  if (framework === null) {
+    throw new Error('The parameter framework is missing.');
+  }
+
+  let promises;
+  if (newRevs.length) {
+    if (newRevs.length !== newRepos.length) {
+      throw new Error(
+        'There should be as many "newRepo" parameters as there are "newRev" parameters.',
+      );
+    }
+    if (!newRepos.every((newRepo) => validRepoValues.includes(newRepo))) {
+      throw new Error(
+        `Every parameter newRepo "${newRepos.join(
+          '", "',
+        )}" should be one of ${validRepoValues.join(', ')}.`,
+      );
+    }
+
+    promises = newRevs.map((newRev, i) =>
+      fetchCompareResults({
+        baseRev,
+        baseRepo,
+        newRev,
+        newRepo: newRepos[i],
+        framework,
+      }),
+    );
+    return Promise.all(promises);
+  }
+  return [
+    await fetchCompareResults({
+      baseRev,
+      baseRepo,
+      newRev: baseRev,
+      newRepo: baseRepo,
+      framework,
+    }),
+  ];
+}
+
+async function fetchAllFakeCompareResults() {
+  const fakeCommitHashes: FakeCommitHash[] = [
+    'bb6a5e451dace3b9c7be42d24c9272738d73e6db',
+    '9d50665254899d8431813bdc04178e6006ce6d59',
+    'a998c42399a8fcea623690bf65bef49de20535b4',
+  ];
+
+  const promises = fakeCommitHashes.map((hash) =>
+    fetchFakeCompareResults(hash),
+  );
+  return Promise.all(promises);
+}
+
+// This function is responsible for fetching the data from the URL. It's called
+// by React Router DOM when the compare-results path is requested.
+// It uses the parameters to
+export async function loader({ request }: { request: Request }) {
+  const url = new URL(request.url);
+  const useFakeData = url.searchParams.has('fakedata');
+  const baseRev = url.searchParams.get('baseRev');
+  const baseRepo = url.searchParams.get('baseRepo') as
+    | Repository['name']
+    | null;
+  const newRevs = url.searchParams.getAll('newRev');
+  const newRepos = url.searchParams.getAll('newRepo') as Repository['name'][];
+  const framework = url.searchParams.get('framework');
+
+  let resultsForAllRevs;
+  if (useFakeData) {
+    resultsForAllRevs = await fetchAllFakeCompareResults();
+  } else {
+    resultsForAllRevs = await checkValuesAndFetchCompareResultsOnTreeherder({
+      baseRev,
+      baseRepo,
+      newRevs,
+      newRepos,
+      framework,
+    });
+  }
+
+  return {
+    results: resultsForAllRevs,
+    baseRev: baseRev as string,
+    baseRepo: baseRepo as Repository['name'],
+    newRevs,
+    newRepos,
+    framework,
+  };
+}
+
+export type LoaderReturnValue = Awaited<ReturnType<typeof loader>>;

--- a/src/components/Search/CompareButton.tsx
+++ b/src/components/Search/CompareButton.tsx
@@ -1,7 +1,6 @@
 import Button from '@mui/material/Button';
 import { style } from 'typestyle';
 
-import useSelectRevision from '../../hooks/useSelectedRevisions';
 import { Strings } from '../../resources/Strings';
 import { ButtonStyles } from '../../styles';
 import type { ThemeMode } from '../../types/state';
@@ -13,16 +12,10 @@ interface CompareButtonProps {
 const strings = Strings.components.searchDefault.sharedCollasped;
 
 export default function CompareButton({ mode }: CompareButtonProps) {
-  const { addSelectedRevisions } = useSelectRevision();
-
   const btnStyles = ButtonStyles(mode);
 
   const styles = {
     button: style({ ...btnStyles.Primary }),
-  };
-
-  const handleAddSelectedRevisions = () => {
-    addSelectedRevisions();
   };
 
   return (
@@ -32,7 +25,7 @@ export default function CompareButton({ mode }: CompareButtonProps) {
       className={`compare-button ${styles.button}`}
       aria-label='compare revisions'
       sx={{ textTransform: 'none !important' }}
-      onClick={handleAddSelectedRevisions}
+      type='submit'
     >
       {strings.button}
     </Button>

--- a/src/components/Search/CompareWithBase.tsx
+++ b/src/components/Search/CompareWithBase.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import Divider from '@mui/material/Divider';
 import Grid from '@mui/material/Grid';
+import { Form } from 'react-router-dom';
 import { style } from 'typestyle';
 
 import { useAppSelector } from '../../hooks/app';
@@ -82,7 +83,7 @@ function CompareWithBase({
         } ${styles.container} `}
       >
         <Divider className='divider' />
-        <div className='form-wrapper'>
+        <Form action='/compare-results' className='form-wrapper'>
           <SearchComponent
             searchType='base'
             isEditable={isEditable}
@@ -109,7 +110,7 @@ function CompareWithBase({
             <FrameworkDropdown mode={mode} />
             <CompareButton mode={mode} />
           </Grid>
-        </div>
+        </Form>
       </div>
     </Grid>
   );

--- a/src/components/Search/FrameworkDropdown.tsx
+++ b/src/components/Search/FrameworkDropdown.tsx
@@ -129,7 +129,7 @@ function FrameworkDropdown({ mode }: FrameworkDropdownProps) {
           className='dropdown-select'
           variant='standard'
           onChange={(e) => void handleFrameworkSelect(e)}
-          name='Framework'
+          name='framework'
         >
           {sortedFrameworks.map(([id, name]) => (
             <MenuItem value={id} key={name} className='framework-dropdown-item'>

--- a/src/components/Search/SearchComponent.tsx
+++ b/src/components/Search/SearchComponent.tsx
@@ -10,12 +10,12 @@ import InfoIcon from '@mui/icons-material/InfoOutlined';
 import Grid from '@mui/material/Grid';
 import InputLabel from '@mui/material/InputLabel';
 import Tooltip from '@mui/material/Tooltip';
+import { useFetcher } from 'react-router-dom';
 import { useLocation } from 'react-router-dom';
 import { cssRule } from 'typestyle';
 
 import { compareView, searchView } from '../../common/constants';
 import { useAppDispatch } from '../../hooks/app';
-import { useAppSelector } from '../../hooks/app';
 import useSelectedRevisions from '../../hooks/useSelectedRevisions';
 import { clearCheckedRevisionforType } from '../../reducers/SearchSlice';
 import {
@@ -88,10 +88,9 @@ function SearchComponent({
   });
 
   const dispatch = useAppDispatch();
+  const fetcher = useFetcher<RevisionsList[]>();
   const { updateSelectedRevisions } = useSelectedRevisions();
 
-  const searchState = useAppSelector((state) => state.search[searchType]);
-  const { searchResults } = searchState;
   const [displayDropdown, setDisplayDropdown] = useState(false);
   const [formIsDisplayed, setFormIsDisplayed] = useState(!isEditable);
 
@@ -210,12 +209,14 @@ function SearchComponent({
             view={view}
             inputPlaceholder={inputPlaceholder}
             searchType={searchType}
+            fetcher={fetcher}
           />
-          {searchResults.length > 0 && displayDropdown && (
+          {fetcher.data && fetcher.data.length && displayDropdown && (
             <SearchResultsList
               mode={mode}
               view={view}
               searchType={searchType}
+              searchResults={fetcher.data}
             />
           )}
         </Grid>

--- a/src/components/Search/SearchInput.tsx
+++ b/src/components/Search/SearchInput.tsx
@@ -15,6 +15,7 @@ interface SearchInputProps {
   view: View;
   mode: ThemeMode;
   searchType: InputType;
+  fetcher: { load: (url: string) => void };
 }
 
 function SearchInput({
@@ -23,8 +24,10 @@ function SearchInput({
   mode,
   inputPlaceholder,
   searchType,
+  fetcher,
 }: SearchInputProps) {
-  const { handleChangeSearch } = useHandleChangeSearch();
+  const { handleChangeSearch, searchRecentRevisions } =
+    useHandleChangeSearch(fetcher);
   const searchState = useAppSelector((state) => state.search[searchType]);
   const { inputError, inputHelperText, repository } = searchState;
 
@@ -47,6 +50,14 @@ function SearchInput({
     }),
   };
 
+  async function onInputFocus(
+    e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) {
+    onFocus();
+    const searchTerm = e.currentTarget.value;
+    await searchRecentRevisions(repository, searchTerm, searchType);
+  }
+
   return (
     <FormControl className={styles.container} fullWidth>
       <TextField
@@ -54,7 +65,7 @@ function SearchInput({
         helperText={inputError && inputHelperText}
         placeholder={inputPlaceholder}
         id={`search-${searchType}-input`}
-        onFocus={onFocus}
+        onFocus={(e) => void onInputFocus(e)}
         onChange={(e) => handleChangeSearch({ e, searchType, repository })}
         size={size}
         className={`search-text-field ${searchType}`}

--- a/src/components/Search/SearchInput.tsx
+++ b/src/components/Search/SearchInput.tsx
@@ -57,7 +57,6 @@ function SearchInput({
         onFocus={onFocus}
         onChange={(e) => handleChangeSearch({ e, searchType, repository })}
         size={size}
-        name={`${searchType}Search`}
         className={`search-text-field ${searchType}`}
         InputProps={{
           startAdornment: (

--- a/src/components/Search/SearchResultsList.tsx
+++ b/src/components/Search/SearchResultsList.tsx
@@ -1,21 +1,19 @@
 import Box from '@mui/material/Box';
 import List from '@mui/material/List';
 
-import { useAppSelector } from '../../hooks/app';
 import { SelectListStyles } from '../../styles';
-import { InputType, ThemeMode, View } from '../../types/state';
+import { InputType, ThemeMode, View, RevisionsList } from '../../types/state';
 import SearchResultsListItem from './SearchResultsListItem';
 
 interface SearchResultsListProps {
   view: View;
   mode: ThemeMode;
   searchType: InputType;
+  searchResults: RevisionsList[];
 }
 
 function SearchResultsList(props: SearchResultsListProps) {
-  const { view, mode, searchType } = props;
-  const searchState = useAppSelector((state) => state.search[searchType]);
-  const { searchResults } = searchState;
+  const { view, mode, searchType, searchResults } = props;
   const styles = SelectListStyles(mode);
 
   return (

--- a/src/components/Search/SelectedRevisionItem.tsx
+++ b/src/components/Search/SelectedRevisionItem.tsx
@@ -76,6 +76,8 @@ function SelectedRevisionItem({
       className={`item-container item-${index} item-${searchType}`}
       data-testid='selected-rev-item'
     >
+      <input type='hidden' name={searchType + 'Rev'} value={item.revision} />
+      <input type='hidden' name={searchType + 'Repo'} value={repository} />
       <div className={styles.repo}>
         <div>{repository}</div>
         {isWarning && repository === 'try' && (

--- a/src/components/Search/loader.ts
+++ b/src/components/Search/loader.ts
@@ -1,0 +1,17 @@
+import type { Params } from 'react-router-dom';
+
+import { fetchRecentRevisions as fetchRecentRevisionsOnTreeherder } from '../../logic/treeherder';
+
+export async function loader({
+  params,
+}: {
+  params: Params<'repository' | 'author' | 'hash'>;
+}) {
+  const { repository } = params;
+  if (!repository) {
+    throw new Error("The repository param is missing, this shouldn't happen.");
+  }
+
+  // The spread operation tells TypeScript that we checked `repository` in this object.
+  return fetchRecentRevisionsOnTreeherder({ ...params, repository });
+}

--- a/src/logic/treeherder.ts
+++ b/src/logic/treeherder.ts
@@ -1,0 +1,55 @@
+import { CompareResultsItem, Repository } from '../types/state';
+
+// This file contains functions to request the Treeherder API
+
+export const treeherderBaseURL = 'https://treeherder.mozilla.org';
+
+type FetchProps = {
+  baseRepo: Repository['name'];
+  baseRev: string;
+  newRepo: Repository['name'];
+  newRev: string;
+  framework: string; // expected values are the framework's ids (frameworks examples talos, awsy, mozperftest, browsertime, build_metrics)
+};
+
+export async function fetchCompareResults({
+  baseRev,
+  baseRepo,
+  newRev,
+  newRepo,
+  framework,
+}: FetchProps) {
+  const searchParams = new URLSearchParams({
+    base_repository: baseRepo,
+    base_revision: baseRev,
+    new_repository: newRepo,
+    new_revision: newRev,
+    framework,
+    interval: '86400',
+    no_subtests: 'true',
+  });
+
+  const response = await fetch(
+    `${treeherderBaseURL}/api/perfcompare/results/?${searchParams.toString()}`,
+  );
+  if (!response.ok) {
+    if (response.status === 400) {
+      throw new Error(
+        `Error when requesting treeherder: ${await response.text()}`,
+      );
+    } else {
+      throw new Error(
+        `Error when requesting treeherder: (${response.status}) ${response.statusText}`,
+      );
+    }
+  }
+
+  return response.json() as Promise<CompareResultsItem[]>;
+}
+
+export async function fetchFakeCompareResults(commitHash: string) {
+  const module = (await import(`../mockData/${commitHash}`)) as {
+    comparisonResults: CompareResultsItem[];
+  };
+  return module.comparisonResults;
+}

--- a/src/logic/treeherder.ts
+++ b/src/logic/treeherder.ts
@@ -56,8 +56,8 @@ export async function fetchFakeCompareResults(commitHash: string) {
 
 export type RecentRevisionsParams = {
   repository: string;
-  hash: string | undefined;
-  author: string | undefined;
+  hash?: string | undefined;
+  author?: string | undefined;
 };
 
 function computeUrlFromSearchTermAndRepository({

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -128,6 +128,27 @@ const swapArrayElements = <T>(
   return array;
 };
 
+// This is a polyfill fo Object.groupBy. We can remove it once it's shipped more
+// broadly OR we configure core-js to provide this polyfill properly.
+// The typing comes from https://github.com/microsoft/TypeScript/issues/47171#issuecomment-1697373352
+function groupBy<Item, Key extends PropertyKey>(
+  items: Iterable<Item>,
+  keySelector: (item: Item, index: number) => Key,
+): Record<Key, Item[]> {
+  const result = Object.create(null) as Record<Key, Item[]>;
+  let i = 0;
+  for (const item of items) {
+    const key = keySelector(item, i);
+    let bucket = result[key];
+    if (bucket === undefined) {
+      bucket = result[key] = [];
+    }
+    bucket.push(item);
+    i++;
+  }
+  return result;
+}
+
 export {
   formatDate,
   getLatestCommitMessage,
@@ -137,4 +158,5 @@ export {
   swapArrayElements,
   truncateHash,
   getDocsURL,
+  groupBy,
 };


### PR DESCRIPTION
Not finished yet, but I put this up so that we can look at the deploy preview.
It should be better/easier to look at the commits one by one.
I'll probably extract some of the commits (the first ones) to separate PRs to make it easier to review.

Done:
* [X] The compare results page use the URL parameters.
* [X] The Search form feeds the URL parameters.
* [X] The results shown in the Search dropdown come from the router too
* [X] Typescript passes.
* [X] The Search form itself isn't itself primed with the URL parameters (in the compare results page).
 
Not done or known bugs:
* [ ] Edit mode for the search form in the compare results page doesn't work.
* [ ] No clean up has been done on the existing redux store that we won't use anymore.
* [ ] No test has been updated 
* [ ] Handle errors gracefully
* [ ] "Loading" indicator in the CompareResults page (probably in another PR)
* [ ] Better behavior when clicking first in the search input -- currently there's a delay due to the fact that the request is sent on focus, while before it was primed before focus. We'll probably want some "optimistic design" with grey boxes while it's loading. Or find a way to prime the data in a better way than we used to do.
* [ ] Move from a HashRouter to a BrowserRouter (probably in another PR)

