### PR TITLE
fix for close buttons in edit mode

### DIFF
--- a/src/__tests__/CompareResults/ResultsView.test.tsx
+++ b/src/__tests__/CompareResults/ResultsView.test.tsx
@@ -300,18 +300,18 @@ describe('Results View', () => {
       />,
     );
 
-    const removeButton = document.querySelectorAll(
+    const closeButton = document.querySelectorAll(
       '[aria-label="close-button"]',
     );
 
-    const removeIcon = screen.getAllByTestId('close-icon')[0];
-    expect(removeIcon).toBeInTheDocument();
+    const closeIcon = screen.getAllByTestId('close-icon')[0];
+    expect(closeIcon).toBeInTheDocument();
     expect(screen.getAllByTestId('selected-rev-item')[1]).toBeInTheDocument();
 
-    await user.click(removeButton[0]);
+    await user.click(closeButton[0]);
 
     act(() => {
-      expect(store.getState().selectedRevisions.new).toEqual([]);
+      expect(store.getState().selectedRevisions.base).toEqual([]);
     });
 
     expect(screen.queryAllByTestId('selected-rev-item')[1]).toBeUndefined();

--- a/src/__tests__/CompareResults/ResultsView.test.tsx
+++ b/src/__tests__/CompareResults/ResultsView.test.tsx
@@ -271,7 +271,7 @@ describe('Results View', () => {
     expect(link).toBeInTheDocument();
   });
 
-  it('should remove the selected revision once X button is clicked', async () => {
+  it('should remove the selected base revision once X button is clicked', async () => {
     const { testData } = getTestData();
     global.fetch = jest.fn(() =>
       Promise.resolve({
@@ -312,6 +312,52 @@ describe('Results View', () => {
 
     act(() => {
       expect(store.getState().selectedRevisions.base).toEqual([]);
+    });
+
+    expect(screen.queryAllByTestId('selected-rev-item')[1]).toBeUndefined();
+  });
+
+  it('should remove the selected new revision once X button is clicked', async () => {
+    const { testData } = getTestData();
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () => ({
+          results: testData,
+        }),
+      }),
+    ) as jest.Mock;
+    jest.spyOn(global, 'fetch');
+
+    // set delay to null to prevent test time-out due to useFakeTimers
+    const user = userEvent.setup({ delay: null });
+
+    const selectedRevisions = testData.slice(0, 2);
+    await act(async () => {
+      store.dispatch(
+        setSelectedRevisions({ selectedRevisions: selectedRevisions }),
+      );
+    });
+
+    renderWithRoute(
+      <ResultsView
+        protocolTheme={protocolTheme}
+        toggleColorMode={toggleColorMode}
+        title={Strings.metaData.pageTitle.results}
+      />,
+    );
+
+    const closeButton = document.querySelectorAll(
+      '[aria-label="close-button"]',
+    );
+
+    const closeIcon = screen.getAllByTestId('close-icon')[1];
+    expect(closeIcon).toBeInTheDocument();
+    expect(screen.getAllByTestId('selected-rev-item')[1]).toBeInTheDocument();
+
+    await user.click(closeButton[1]);
+
+    act(() => {
+      expect(store.getState().selectedRevisions.new).toEqual([]);
     });
 
     expect(screen.queryAllByTestId('selected-rev-item')[1]).toBeUndefined();

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -207,7 +207,7 @@ exports[`Results View RESULTS: clicking the cancel button hides input and dropdo
                         class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
                       >
                         <div
-                          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedStart css-1vjgbo6-MuiInputBase-root-MuiOutlinedInput-root"
+                          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1vjgbo6-MuiInputBase-root-MuiOutlinedInput-root"
                         >
                           <div
                             class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-yzzuft-MuiInputAdornment-root"
@@ -225,8 +225,7 @@ exports[`Results View RESULTS: clicking the cancel button hides input and dropdo
                             </svg>
                           </div>
                           <input
-                            aria-describedby="search-base-input-helper-text"
-                            aria-invalid="true"
+                            aria-invalid="false"
                             class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1rgu65m-MuiInputBase-input-MuiOutlinedInput-input"
                             id="search-base-input"
                             name="baseSearch"
@@ -249,12 +248,6 @@ exports[`Results View RESULTS: clicking the cancel button hides input and dropdo
                             </legend>
                           </fieldset>
                         </div>
-                        <p
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-contained css-1ut8mn8-MuiFormHelperText-root"
-                          id="search-base-input-helper-text"
-                        >
-                          An error has occurred
-                        </p>
                       </div>
                     </div>
                   </div>
@@ -514,7 +507,7 @@ exports[`Results View RESULTS: clicking the cancel button hides input and dropdo
                         class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
                       >
                         <div
-                          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedStart css-1vjgbo6-MuiInputBase-root-MuiOutlinedInput-root"
+                          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1vjgbo6-MuiInputBase-root-MuiOutlinedInput-root"
                         >
                           <div
                             class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-yzzuft-MuiInputAdornment-root"
@@ -532,8 +525,7 @@ exports[`Results View RESULTS: clicking the cancel button hides input and dropdo
                             </svg>
                           </div>
                           <input
-                            aria-describedby="search-new-input-helper-text"
-                            aria-invalid="true"
+                            aria-invalid="false"
                             class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1rgu65m-MuiInputBase-input-MuiOutlinedInput-input"
                             id="search-new-input"
                             name="newSearch"
@@ -556,12 +548,6 @@ exports[`Results View RESULTS: clicking the cancel button hides input and dropdo
                             </legend>
                           </fieldset>
                         </div>
-                        <p
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-contained css-1ut8mn8-MuiFormHelperText-root"
-                          id="search-new-input-helper-text"
-                        >
-                          An error has occurred
-                        </p>
                       </div>
                     </div>
                   </div>
@@ -1395,7 +1381,7 @@ exports[`Results View RESULTS: clicking the save button hides input and dropdown
                         class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
                       >
                         <div
-                          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedStart css-1vjgbo6-MuiInputBase-root-MuiOutlinedInput-root"
+                          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1vjgbo6-MuiInputBase-root-MuiOutlinedInput-root"
                         >
                           <div
                             class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-yzzuft-MuiInputAdornment-root"
@@ -1413,8 +1399,7 @@ exports[`Results View RESULTS: clicking the save button hides input and dropdown
                             </svg>
                           </div>
                           <input
-                            aria-describedby="search-base-input-helper-text"
-                            aria-invalid="true"
+                            aria-invalid="false"
                             class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1rgu65m-MuiInputBase-input-MuiOutlinedInput-input"
                             id="search-base-input"
                             name="baseSearch"
@@ -1437,12 +1422,6 @@ exports[`Results View RESULTS: clicking the save button hides input and dropdown
                             </legend>
                           </fieldset>
                         </div>
-                        <p
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-contained css-1ut8mn8-MuiFormHelperText-root"
-                          id="search-base-input-helper-text"
-                        >
-                          An error has occurred
-                        </p>
                       </div>
                     </div>
                   </div>
@@ -1702,7 +1681,7 @@ exports[`Results View RESULTS: clicking the save button hides input and dropdown
                         class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
                       >
                         <div
-                          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedStart css-1vjgbo6-MuiInputBase-root-MuiOutlinedInput-root"
+                          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1vjgbo6-MuiInputBase-root-MuiOutlinedInput-root"
                         >
                           <div
                             class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-yzzuft-MuiInputAdornment-root"
@@ -1720,8 +1699,7 @@ exports[`Results View RESULTS: clicking the save button hides input and dropdown
                             </svg>
                           </div>
                           <input
-                            aria-describedby="search-new-input-helper-text"
-                            aria-invalid="true"
+                            aria-invalid="false"
                             class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1rgu65m-MuiInputBase-input-MuiOutlinedInput-input"
                             id="search-new-input"
                             name="newSearch"
@@ -1744,12 +1722,6 @@ exports[`Results View RESULTS: clicking the save button hides input and dropdown
                             </legend>
                           </fieldset>
                         </div>
-                        <p
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-contained css-1ut8mn8-MuiFormHelperText-root"
-                          id="search-new-input-helper-text"
-                        >
-                          An error has occurred
-                        </p>
                       </div>
                     </div>
                   </div>
@@ -2583,7 +2555,7 @@ exports[`Results View RESULTS: shows dropdown and input when edit button in clic
                         class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
                       >
                         <div
-                          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedStart css-1vjgbo6-MuiInputBase-root-MuiOutlinedInput-root"
+                          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1vjgbo6-MuiInputBase-root-MuiOutlinedInput-root"
                         >
                           <div
                             class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-yzzuft-MuiInputAdornment-root"
@@ -2601,8 +2573,7 @@ exports[`Results View RESULTS: shows dropdown and input when edit button in clic
                             </svg>
                           </div>
                           <input
-                            aria-describedby="search-base-input-helper-text"
-                            aria-invalid="true"
+                            aria-invalid="false"
                             class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1rgu65m-MuiInputBase-input-MuiOutlinedInput-input"
                             id="search-base-input"
                             name="baseSearch"
@@ -2625,12 +2596,6 @@ exports[`Results View RESULTS: shows dropdown and input when edit button in clic
                             </legend>
                           </fieldset>
                         </div>
-                        <p
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-contained css-1ut8mn8-MuiFormHelperText-root"
-                          id="search-base-input-helper-text"
-                        >
-                          An error has occurred
-                        </p>
                       </div>
                     </div>
                   </div>
@@ -2890,7 +2855,7 @@ exports[`Results View RESULTS: shows dropdown and input when edit button in clic
                         class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
                       >
                         <div
-                          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-formControl MuiInputBase-adornedStart css-1vjgbo6-MuiInputBase-root-MuiOutlinedInput-root"
+                          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1vjgbo6-MuiInputBase-root-MuiOutlinedInput-root"
                         >
                           <div
                             class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-yzzuft-MuiInputAdornment-root"
@@ -2908,8 +2873,7 @@ exports[`Results View RESULTS: shows dropdown and input when edit button in clic
                             </svg>
                           </div>
                           <input
-                            aria-describedby="search-new-input-helper-text"
-                            aria-invalid="true"
+                            aria-invalid="false"
                             class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1rgu65m-MuiInputBase-input-MuiOutlinedInput-input"
                             id="search-new-input"
                             name="newSearch"
@@ -2932,12 +2896,6 @@ exports[`Results View RESULTS: shows dropdown and input when edit button in clic
                             </legend>
                           </fieldset>
                         </div>
-                        <p
-                          class="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-contained css-1ut8mn8-MuiFormHelperText-root"
-                          id="search-new-input-helper-text"
-                        >
-                          An error has occurred
-                        </p>
                       </div>
                     </div>
                   </div>

--- a/src/components/CompareResults/ResultsView.tsx
+++ b/src/components/CompareResults/ResultsView.tsx
@@ -15,8 +15,7 @@ import useHandleChangeSearch from '../../hooks/useHandleChangeSearch';
 import { updateFramework } from '../../reducers/FrameworkSlice';
 import { SearchContainerStyles } from '../../styles';
 import { background } from '../../styles';
-import { fetchRecentRevisions } from '../../thunks/searchThunk';
-import { Repository, View, InputType } from '../../types/state';
+import { Repository, View } from '../../types/state';
 import { Framework } from '../../types/types';
 import CompareWithBase from '../Search/CompareWithBase';
 import PerfCompareHeader from '../Shared/PerfCompareHeader';
@@ -55,10 +54,7 @@ function ResultsView(props: ResultsViewProps) {
     baseRepos: selectedBaseRepositories as Repository['name'][],
     newRepos: selectedNewRepositories as Repository['name'][],
   };
-  const repositoryBase = useAppSelector(
-    (state) => state.search.base.repository,
-  );
-  const repositoryNew = useAppSelector((state) => state.search.new.repository);
+
   const { dispatchFetchCompareResults, dispatchFakeCompareResults } =
     useFetchCompareResults();
   const { searchByRevisionOrEmail } = useHandleChangeSearch();
@@ -132,29 +128,6 @@ function ResultsView(props: ResultsViewProps) {
       }
     }
   }, [framework]);
-
-  /* editing the revisions requires fetching the
-   * recent revisions in results view
-   */
-  useEffect(() => {
-    const repository = repositoryBase;
-    void dispatch(
-      fetchRecentRevisions({
-        repository,
-        searchType: 'base' as InputType,
-      }),
-    );
-  }, [repositoryBase]);
-
-  useEffect(() => {
-    const repository = repositoryNew;
-    void dispatch(
-      fetchRecentRevisions({
-        repository,
-        searchType: 'new' as InputType,
-      }),
-    );
-  }, [repositoryNew]);
 
   return (
     <div

--- a/src/components/Search/SelectedRevisionItem.tsx
+++ b/src/components/Search/SelectedRevisionItem.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import { CloseOutlined } from '@mui/icons-material';
 import AccessTimeOutlinedIcon from '@mui/icons-material/AccessTimeOutlined';
@@ -65,6 +65,7 @@ function SelectedRevisionItem({
   const handleClose = () => {
     if (isEditable) {
       deleteSelectedRevisions(item);
+      removeCheckedRevision(item);
     } else {
       removeCheckedRevision(item);
     }

--- a/src/hooks/useSelectedRevisions.ts
+++ b/src/hooks/useSelectedRevisions.ts
@@ -18,10 +18,13 @@ const useSelectRevision = () => {
     (state) => state.search.new.checkedRevisions,
   );
 
+  const selectedRevisionsState = useAppSelector(
+    (state) => state.selectedRevisions,
+  );
+
   const selectedRevisions = useAppSelector(
     (state) => state.selectedRevisions.revisions,
   );
-
   const addSelectedRevisions = () => {
     const newSelected = [...selectedRevisions];
     newSelected.push(...baseCheckedRevisions, ...newCheckedRevisions);
@@ -35,10 +38,11 @@ const useSelectRevision = () => {
     let revisionsForEdit = selectedRevisions;
     switch (searchType) {
       case 'base':
-        revisionsForEdit = [revisionsForEdit[0]];
+        revisionsForEdit = selectedRevisionsState.base;
+
         break;
       case 'new':
-        revisionsForEdit = revisionsForEdit.slice(1);
+        revisionsForEdit = selectedRevisionsState.new;
         break;
       default:
         throw new Error('Invalid search type');
@@ -72,8 +76,20 @@ const useSelectRevision = () => {
 
   const deleteSelectedRevisions = (revision: RevisionsList) => {
     const newSelected = [...selectedRevisions];
+    if (newSelected[0].id === revision.id) {
+      //this is a base revision deletion
+      dispatch(
+        deleteRevision({
+          selectedRevisions: newSelected,
+          isBaseDeletion: true,
+        }),
+      );
+      return;
+    }
     newSelected.splice(selectedRevisions.indexOf(revision), 1);
-    dispatch(deleteRevision({ selectedRevisions: newSelected }));
+    dispatch(
+      deleteRevision({ selectedRevisions: newSelected, isBaseDeletion: false }),
+    );
   };
 
   return {

--- a/src/hooks/useSelectedRevisions.ts
+++ b/src/hooks/useSelectedRevisions.ts
@@ -76,16 +76,17 @@ const useSelectRevision = () => {
 
   const deleteSelectedRevisions = (revision: RevisionsList) => {
     const newSelected = [...selectedRevisions];
-    if (newSelected[0].id === revision.id) {
+    if (selectedRevisions[0].id === revision.id) {
       //this is a base revision deletion
       dispatch(
         deleteRevision({
-          selectedRevisions: newSelected,
+          selectedRevisions: selectedRevisions.slice(1),
           isBaseDeletion: true,
         }),
       );
       return;
     }
+
     newSelected.splice(selectedRevisions.indexOf(revision), 1);
     dispatch(
       deleteRevision({ selectedRevisions: newSelected, isBaseDeletion: false }),

--- a/src/reducers/SelectedRevisionsSlice.ts
+++ b/src/reducers/SelectedRevisionsSlice.ts
@@ -28,8 +28,16 @@ const selectedRevisions = createSlice({
       state,
       action: PayloadAction<{
         selectedRevisions: RevisionsList[];
+        isBaseDeletion: boolean;
       }>,
     ) {
+      if (action.payload.isBaseDeletion) {
+        return {
+          ...state,
+          revisions: action.payload.selectedRevisions.slice(1),
+          base: [],
+        };
+      }
       return {
         ...state,
         revisions: action.payload.selectedRevisions,

--- a/src/reducers/SelectedRevisionsSlice.ts
+++ b/src/reducers/SelectedRevisionsSlice.ts
@@ -34,7 +34,7 @@ const selectedRevisions = createSlice({
       if (action.payload.isBaseDeletion) {
         return {
           ...state,
-          revisions: action.payload.selectedRevisions.slice(1),
+          revisions: action.payload.selectedRevisions,
           base: [],
         };
       }


### PR DESCRIPTION
This  PR fulfills [Results: In edit mode, close buttons for selected revisions are broken](https://mozilla-hub.atlassian.net/browse/PCF-344). 

Note that the save and cancel bugs in edit mode will be taken care of in a separate PR. 

Also, I removed some fetch code in the Results View because I initially placed it in a separate, now deleted file but that will be taken care of in Julien's patch. I'll be glad to return it though. 
