### PR TITLE
Change a bit how the recent revisions dropdown handling works

### DIFF
--- a/src/components/Search/SearchComponent.tsx
+++ b/src/components/Search/SearchComponent.tsx
@@ -92,7 +92,7 @@ function SearchComponent({
 
   const searchState = useAppSelector((state) => state.search[searchType]);
   const { searchResults } = searchState;
-  const [focused, setFocused] = useState(false);
+  const [displayDropdown, setDisplayDropdown] = useState(false);
   const [formIsDisplayed, setFormIsDisplayed] = useState(!isEditable);
 
   const location = useLocation();
@@ -111,7 +111,7 @@ function SearchComponent({
 
   const handleDocumentMousedown = useCallback(
     (e: MouseEvent) => {
-      if (!focused) {
+      if (!displayDropdown) {
         return;
       }
 
@@ -120,15 +120,15 @@ function SearchComponent({
       if (target.closest(`.${searchType}-search-input`) === null) {
         // Close the dropdown only if the click is outside the search input or one
         // of it's descendants.
-        setFocused(false);
+        setDisplayDropdown(false);
       }
     },
-    [focused],
+    [displayDropdown],
   );
 
   const handleEscKeypress = (e: KeyboardEvent) => {
     if (e.key === 'Escape') {
-      setFocused(false);
+      setDisplayDropdown(false);
     }
   };
 
@@ -206,12 +206,12 @@ function SearchComponent({
         >
           <SearchInput
             mode={mode}
-            onFocus={() => setFocused(true)}
+            onFocus={() => setDisplayDropdown(true)}
             view={view}
             inputPlaceholder={inputPlaceholder}
             searchType={searchType}
           />
-          {searchResults.length > 0 && focused && (
+          {searchResults.length > 0 && displayDropdown && (
             <SearchResultsList
               mode={mode}
               view={view}

--- a/src/components/Search/SearchComponent.tsx
+++ b/src/components/Search/SearchComponent.tsx
@@ -1,4 +1,10 @@
-import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import {
+  Dispatch,
+  SetStateAction,
+  useEffect,
+  useState,
+  useCallback,
+} from 'react';
 
 import InfoIcon from '@mui/icons-material/InfoOutlined';
 import Grid from '@mui/material/Grid';
@@ -103,23 +109,22 @@ function SearchComponent({
     setFormIsDisplayed(false);
   };
 
-  const handleFocus = (e: MouseEvent) => {
-    if (
-      (e.target as HTMLElement).matches(`#${searchType}-search-container, 
-      #${searchType}-search-container *`) &&
-      // do not open search results when dropdown or cancel button is clicked
-      !(e.target as HTMLElement).matches(
-        `#${searchType}_search-dropdown,
-        #${searchType}_search-dropdown *,
-        #cancel-save_btns, 
-        #cancel-save_btns *`,
-      )
-    ) {
-      setFocused(true);
-      return;
-    }
-    setFocused(false);
-  };
+  const handleDocumentMousedown = useCallback(
+    (e: MouseEvent) => {
+      if (!focused) {
+        return;
+      }
+
+      const target = e.target as HTMLElement;
+
+      if (target.closest(`.${searchType}-search-input`) === null) {
+        // Close the dropdown only if the click is outside the search input or one
+        // of it's descendants.
+        setFocused(false);
+      }
+    },
+    [focused],
+  );
 
   const handleEscKeypress = (e: KeyboardEvent) => {
     if (e.key === 'Escape') {
@@ -128,11 +133,11 @@ function SearchComponent({
   };
 
   useEffect(() => {
-    document.addEventListener('mousedown', handleFocus);
+    document.addEventListener('mousedown', handleDocumentMousedown);
     return () => {
-      document.removeEventListener('mousedown', handleFocus);
+      document.removeEventListener('mousedown', handleDocumentMousedown);
     };
-  }, []);
+  }, [handleDocumentMousedown]);
 
   useEffect(() => {
     document.addEventListener('keydown', handleEscKeypress);
@@ -201,7 +206,7 @@ function SearchComponent({
         >
           <SearchInput
             mode={mode}
-            setFocused={setFocused}
+            onFocus={() => setFocused(true)}
             view={view}
             inputPlaceholder={inputPlaceholder}
             searchType={searchType}

--- a/src/components/Search/SearchInput.tsx
+++ b/src/components/Search/SearchInput.tsx
@@ -1,5 +1,3 @@
-import { Dispatch, SetStateAction } from 'react';
-
 import SearchIcon from '@mui/icons-material/Search';
 import FormControl from '@mui/material/FormControl';
 import InputAdornment from '@mui/material/InputAdornment';
@@ -12,7 +10,7 @@ import { InputStylesRaw } from '../../styles';
 import { InputType, ThemeMode, View } from '../../types/state';
 
 interface SearchInputProps {
-  setFocused: Dispatch<SetStateAction<boolean>>;
+  onFocus: () => unknown;
   inputPlaceholder: string;
   view: View;
   mode: ThemeMode;
@@ -20,7 +18,7 @@ interface SearchInputProps {
 }
 
 function SearchInput({
-  setFocused,
+  onFocus,
   view,
   mode,
   inputPlaceholder,
@@ -56,7 +54,7 @@ function SearchInput({
         helperText={inputError && inputHelperText}
         placeholder={inputPlaceholder}
         id={`search-${searchType}-input`}
-        onFocus={() => setFocused(true)}
+        onFocus={onFocus}
         onChange={(e) => handleChangeSearch({ e, searchType, repository })}
         size={size}
         name={`${searchType}Search`}


### PR DESCRIPTION
This contains 2 commits that can be looked at independently:

Commit 1:
* This changes the `mousedown` event handler that controls the hiding of the recent revisions dropdown when clicking elsewhere. Previously it also contained some code to display it, but that wasn't used... It also simplifies the check that the user clicks elsewhere.
* This simplifies the way that the search input notifies its parent about the focus event: instead of passing the `setFocused` function coming from `useState`, we just pass a callback that will be called when focus happens.

Commit 2: changes the state name about the fact that the dropdown is displayed or not, to better reflect that. For example we could have the input focused, press Escape, and then the dropdown would be hidden... but the focus would still be there. So the state was lying before.

There should be no behavior change again. So tell me what you think :-)