### PR TITLE
Update react-router-dom to its latest version and use the new API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^8.0.2",
-        "react-router-dom": "^6.3.0",
+        "react-router-dom": "^6.18.0",
         "redux": "^4.2.0",
         "run": "^1.4.0",
         "ts-node": "^10.9.1",
@@ -3651,6 +3651,14 @@
         "react-redux": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.11.0.tgz",
+      "integrity": "sha512-BHdhcWgeiudl91HvVa2wxqZjSHbheSgIiDvxrF1VjFzBzpTtuDPkOdOi3Iqvc08kXtFkLjhbS+ML9aM8mJS+wQ==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rushstack/eslint-patch": {
@@ -8709,6 +8717,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
       "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.7.6"
       }
@@ -16314,23 +16323,29 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
-      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.18.0.tgz",
+      "integrity": "sha512-vk2y7Dsy8wI02eRRaRmOs9g2o+aE72YCx5q9VasT1N9v+lrdB79tIqrjMfByHiY5+6aYkH2rUa5X839nwWGPDg==",
       "dependencies": {
-        "history": "^5.2.0"
+        "@remix-run/router": "1.11.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
         "react": ">=16.8"
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
-      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.18.0.tgz",
+      "integrity": "sha512-Ubrue4+Ercc/BoDkFQfc6og5zRQ4A8YxSO3Knsne+eRbZ+IepAsK249XBH/XaFuOYOYr3L3r13CXTLvYt5JDjw==",
       "dependencies": {
-        "history": "^5.2.0",
-        "react-router": "6.3.0"
+        "@remix-run/router": "1.11.0",
+        "react-router": "6.18.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -21568,6 +21583,11 @@
         "reselect": "^4.1.5"
       }
     },
+    "@remix-run/router": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.11.0.tgz",
+      "integrity": "sha512-BHdhcWgeiudl91HvVa2wxqZjSHbheSgIiDvxrF1VjFzBzpTtuDPkOdOi3Iqvc08kXtFkLjhbS+ML9aM8mJS+wQ=="
+    },
     "@rushstack/eslint-patch": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.4.tgz",
@@ -25417,6 +25437,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
       "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.7.6"
       }
@@ -30707,20 +30728,20 @@
       "dev": true
     },
     "react-router": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
-      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.18.0.tgz",
+      "integrity": "sha512-vk2y7Dsy8wI02eRRaRmOs9g2o+aE72YCx5q9VasT1N9v+lrdB79tIqrjMfByHiY5+6aYkH2rUa5X839nwWGPDg==",
       "requires": {
-        "history": "^5.2.0"
+        "@remix-run/router": "1.11.0"
       }
     },
     "react-router-dom": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
-      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.18.0.tgz",
+      "integrity": "sha512-Ubrue4+Ercc/BoDkFQfc6og5zRQ4A8YxSO3Knsne+eRbZ+IepAsK249XBH/XaFuOYOYr3L3r13CXTLvYt5JDjw==",
       "requires": {
-        "history": "^5.2.0",
-        "react-router": "6.3.0"
+        "@remix-run/router": "1.11.0",
+        "react-router": "6.18.0"
       }
     },
     "react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.2",
-    "react-router-dom": "^6.3.0",
+    "react-router-dom": "^6.18.0",
     "redux": "^4.2.0",
     "run": "^1.4.0",
     "ts-node": "^10.9.1",

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5,7 +5,12 @@ import CssBaseline from '@mui/material/CssBaseline';
 import Link from '@mui/material/Link';
 import { ThemeProvider } from '@mui/material/styles';
 import { SnackbarProvider } from 'notistack';
-import { HashRouter as Router, Route, Routes } from 'react-router-dom';
+import {
+  createHashRouter,
+  RouterProvider,
+  createRoutesFromElements,
+  Route,
+} from 'react-router-dom';
 
 import { Strings } from '../resources/Strings';
 import { Banner } from '../styles/Banner';
@@ -42,6 +47,7 @@ function App() {
     null,
   );
   const { protocolTheme, toggleColorMode } = useProtocolTheme();
+
   return (
     <ThemeProvider theme={protocolTheme}>
       <AlertContainer ref={setAlertContainer} />
@@ -64,31 +70,35 @@ function App() {
             </div>
           </Alert>
 
-          <Router>
-            <Routes>
-              <Route
-                path='/'
-                element={
-                  <SearchView
-                    toggleColorMode={toggleColorMode}
-                    protocolTheme={protocolTheme}
-                    title={Strings.metaData.pageTitle.search}
+          <RouterProvider
+            router={createHashRouter(
+              createRoutesFromElements(
+                <>
+                  <Route
+                    path='/'
+                    element={
+                      <SearchView
+                        toggleColorMode={toggleColorMode}
+                        protocolTheme={protocolTheme}
+                        title={Strings.metaData.pageTitle.search}
+                      />
+                    }
                   />
-                }
-              />
 
-              <Route
-                path='/compare-results'
-                element={
-                  <ResultsView
-                    toggleColorMode={toggleColorMode}
-                    protocolTheme={protocolTheme}
-                    title={Strings.metaData.pageTitle.results}
+                  <Route
+                    path='/compare-results'
+                    element={
+                      <ResultsView
+                        toggleColorMode={toggleColorMode}
+                        protocolTheme={protocolTheme}
+                        title={Strings.metaData.pageTitle.results}
+                      />
+                    }
                   />
-                }
-              />
-            </Routes>
-          </Router>
+                </>,
+              ),
+            )}
+          />
         </SnackbarProvider>
       ) : null}
     </ThemeProvider>


### PR DESCRIPTION
This has 2 commits:
* commit 1: simply update react-router-dom to the latest version
* commit 2: switch to the new API with the `RouterProvider`. This changes nothing to the current behavior but is a prerequisite to the rest of the work.