### PR TITLE
PCF-322 White table row corners in dark mode

### DIFF
--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -88,7 +88,9 @@ function RevisionRow(props: RevisionRowProps) {
 
   const styles = {
     revisionRow: style({
+      borderRadius: '4px 0px 0px 4px',
       display: 'grid',
+      margin: `${Spacing.Small}px 0px`,
       // Should be kept in sync with the gridTemplateColumns from TableHeader
       gridTemplateColumns: '2fr 1fr 0.2fr 1fr 1fr 1fr 1fr 1fr 2fr 0.2fr',
       $nest: {
@@ -116,6 +118,8 @@ function RevisionRow(props: RevisionRowProps) {
           backgroundColor: themeColor200,
         },
         '.platform': {
+          backgroundColor: themeColor200,
+          borderRadius: '4px 0 0 4px',
           paddingLeft: Spacing.xLarge,
           justifyContent: 'left',
         },
@@ -123,10 +127,10 @@ function RevisionRow(props: RevisionRowProps) {
           alignItems: 'flex-end',
           backgroundColor: themeColor200,
           display: 'flex',
-          borderRadius: '4px 0 0 4px',
         },
         '.retrigger-button': {
           backgroundColor: themeColor200,
+          borderRadius: '0px 4px 4px 0px',
           cursor: 'not-allowed',
         },
         '.status': {
@@ -138,6 +142,8 @@ function RevisionRow(props: RevisionRowProps) {
         },
 
         '.row-buttons': {
+          backgroundColor: themeColor200,
+          borderRadius: '0px 4px 4px 0px',
           display: 'flex',
           justifyContent: 'flex-end',
           $nest: {

--- a/src/components/CompareResults/TableContent.tsx
+++ b/src/components/CompareResults/TableContent.tsx
@@ -1,6 +1,6 @@
 import { style } from 'typestyle';
 
-import { Colors, Spacing } from '../../styles';
+import { Spacing } from '../../styles';
 import type {
   CompareResultsItem,
   RevisionsHeader,
@@ -15,12 +15,6 @@ function TableContent(props: TableContentProps) {
   const styles = {
     tableBody: style({
       marginTop: Spacing.Large,
-      $nest: {
-        '.revisionRow': {
-          backgroundColor: Colors.Background200,
-          margin: `${Spacing.Small}px 0px`,
-        },
-      },
     }),
   };
   return (


### PR DESCRIPTION
This PR addresses [PCF-322 White table row corners in dark mode](https://mozilla-hub.atlassian.net/browse/PCF-322). It removes the white corners.

<img width="141" alt="Screenshot 2023-12-21 at 3 45 30 PM" src="https://github.com/mozilla/perfcompare/assets/63001299/a937f780-b92e-4144-9bb6-164e65728372">
<img width="184" alt="Screenshot 2023-12-21 at 3 50 48 PM" src="https://github.com/mozilla/perfcompare/assets/63001299/41868e57-cf05-4bd9-9f6d-bb71bf46eb61">

Before and after

