### PR TITLE
Fix the setup of jest fake timers so that they don't run unexpectedly

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -44,7 +44,6 @@ const config: Config.InitialOptions = {
     'jest-watch-typeahead/filename',
     'jest-watch-typeahead/testname',
   ],
-  resetMocks: true,
   globalSetup: '<rootDir>/src/__tests__/utils/globalSetup.ts',
   testTimeout: 30000,
 };

--- a/src/__tests__/CompareResults/ResultsView.test.tsx
+++ b/src/__tests__/CompareResults/ResultsView.test.tsx
@@ -87,8 +87,6 @@ describe('Results View', () => {
     ) as HTMLElement;
 
     expect(hiddenEditButton).not.toBeInTheDocument();
-
-    await act(async () => void jest.runOnlyPendingTimers());
   });
 
   it('RESULTS: clicking the cancel button hides input and dropdown', async () => {
@@ -136,8 +134,6 @@ describe('Results View', () => {
       '.base-search-container',
     ) as HTMLElement;
     expect(container).not.toBeInTheDocument();
-
-    await act(async () => void jest.runOnlyPendingTimers());
   });
 
   it('RESULTS: clicking the save button hides input and dropdown', async () => {
@@ -207,7 +203,6 @@ describe('Results View', () => {
     });
 
     expect(container).not.toBeInTheDocument();
-    await act(async () => void jest.runOnlyPendingTimers());
   });
 
   it('Should render the selected revisions', async () => {

--- a/src/__tests__/Search/CompareWithBase.test.tsx
+++ b/src/__tests__/Search/CompareWithBase.test.tsx
@@ -42,7 +42,6 @@ describe('Compare With Base', () => {
     renderComponent(false);
 
     expect(document.body).toMatchSnapshot();
-    await act(async () => void jest.runOnlyPendingTimers());
   });
 
   it('toggles component open and closed on click', async () => {

--- a/src/__tests__/Search/SearchContainer.test.tsx
+++ b/src/__tests__/Search/SearchContainer.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { renderHook } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
 
 import SearchContainer from '../../components/Search/SearchContainer';
 import useProtocolTheme from '../../theme/protocolTheme';
@@ -24,6 +23,5 @@ describe('Search Containter', () => {
     renderComponent();
 
     expect(document.body).toMatchSnapshot();
-    await act(async () => void jest.runOnlyPendingTimers());
   });
 });

--- a/src/__tests__/Search/SearchView.test.tsx
+++ b/src/__tests__/Search/SearchView.test.tsx
@@ -93,8 +93,6 @@ describe('Base Search', () => {
 
     // No list items should appear
     expect(screen.queryByRole('listitem')).not.toBeInTheDocument();
-
-    await act(async () => void jest.runOnlyPendingTimers());
   });
 
   it('renders framework dropdown in closed condition', async () => {
@@ -103,8 +101,6 @@ describe('Base Search', () => {
     expect(screen.getByText(/talos/i)).toBeInTheDocument();
     expect(screen.queryByText(/build_metrics/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/awsy/i)).not.toBeInTheDocument();
-
-    await act(async () => void jest.runOnlyPendingTimers());
   });
 
   it('should hide search results when clicking outside of search input', async () => {

--- a/src/__tests__/utils/setupTests.ts
+++ b/src/__tests__/utils/setupTests.ts
@@ -92,7 +92,7 @@ afterEach(() => {
   jest.clearAllMocks();
   jest.resetAllMocks();
   jest.restoreAllMocks();
-  jest.runOnlyPendingTimers();
+  jest.clearAllTimers();
   jest.useRealTimers();
 
   // Also restore the fetch mock


### PR DESCRIPTION
This also removes the running of all timers at the end of some tests, that were working around the faulty setup.

I noticed this issue while working on another patch, and decided to extract it.