### PR TITLE
Simplify how the render functions are defined and used in test files

### DIFF
--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -2,8 +2,7 @@ import userEvent from '@testing-library/user-event';
 import { act } from 'react-dom/test-utils';
 
 import App from '../components/App';
-import { render } from './utils/setupTests';
-import { screen, FetchMockSandbox } from './utils/test-utils';
+import { render, screen, FetchMockSandbox } from './utils/test-utils';
 
 describe('App', () => {
   beforeEach(() => {

--- a/src/__tests__/CompareResults/ResultsTable.test.tsx
+++ b/src/__tests__/CompareResults/ResultsTable.test.tsx
@@ -2,8 +2,7 @@ import type { ReactElement } from 'react';
 
 import ResultsTable from '../../components/CompareResults/ResultsTable';
 import useProtocolTheme from '../../theme/protocolTheme';
-import { renderWithRouter } from '../utils/setupTests';
-import { renderHook, screen } from '../utils/test-utils';
+import { renderWithRouter, renderHook, screen } from '../utils/test-utils';
 
 function renderWithRoute(component: ReactElement) {
   return renderWithRouter(component, {

--- a/src/__tests__/CompareResults/ResultsView.test.tsx
+++ b/src/__tests__/CompareResults/ResultsView.test.tsx
@@ -10,8 +10,8 @@ import { Strings } from '../../resources/Strings';
 import useProtocolTheme from '../../theme/protocolTheme';
 import { RevisionsHeader } from '../../types/state';
 import getTestData from '../utils/fixtures';
-import { renderWithRouter, store } from '../utils/setupTests';
-import { renderHook, screen, act } from '../utils/test-utils';
+import { store } from '../utils/setupTests';
+import { renderWithRouter, renderHook, screen, act } from '../utils/test-utils';
 
 function renderWithRoute(component: ReactElement) {
   return renderWithRouter(component, {

--- a/src/__tests__/CompareResults/RevisionRow.test.tsx
+++ b/src/__tests__/CompareResults/RevisionRow.test.tsx
@@ -1,9 +1,7 @@
-import { screen } from '@testing-library/react';
-
 import RevisionRow from '../../components/CompareResults/RevisionRow';
 import { Platform } from '../../types/types';
 import getTestData from '../utils/fixtures';
-import { render } from '../utils/setupTests';
+import { render, screen } from '../utils/test-utils';
 
 describe('<RevisionRow>', () => {
   it.each([

--- a/src/__tests__/CompareResults/RevisionSelect.test.tsx
+++ b/src/__tests__/CompareResults/RevisionSelect.test.tsx
@@ -4,8 +4,13 @@ import ResultsView from '../../components/CompareResults/ResultsView';
 import RevisionSelect from '../../components/CompareResults/RevisionSelect';
 import { Strings } from '../../resources/Strings';
 import useProtocolTheme from '../../theme/protocolTheme';
-import { renderWithRouter } from '../utils/setupTests';
-import { fireEvent, renderHook, screen, within } from '../utils/test-utils';
+import {
+  fireEvent,
+  renderWithRouter,
+  renderHook,
+  screen,
+  within,
+} from '../utils/test-utils';
 
 function renderWithRoute(component: ReactElement) {
   return renderWithRouter(component, {

--- a/src/__tests__/CompareResults/SearchInput.test.tsx
+++ b/src/__tests__/CompareResults/SearchInput.test.tsx
@@ -1,8 +1,7 @@
 import ResultsView from '../../components/CompareResults/ResultsView';
 import { Strings } from '../../resources/Strings';
 import useProtocolTheme from '../../theme/protocolTheme';
-import { renderWithRouter } from '../utils/setupTests';
-import { renderHook, screen } from '../utils/test-utils';
+import { renderHook, renderWithRouter, screen } from '../utils/test-utils';
 
 describe('Search by title/test name', () => {
   const protocolTheme = renderHook(() => useProtocolTheme()).result.current

--- a/src/__tests__/CompareResults/TableHeader.test.tsx
+++ b/src/__tests__/CompareResults/TableHeader.test.tsx
@@ -1,7 +1,6 @@
 import TableHeader from '../../components/CompareResults/TableHeader';
 import useProtocolTheme from '../../theme/protocolTheme';
-import { renderWithRouter } from '../utils/setupTests';
-import { renderHook, screen } from '../utils/test-utils';
+import { renderHook, renderWithRouter, screen } from '../utils/test-utils';
 
 describe('Table Header', () => {
   const protocolTheme = renderHook(() => useProtocolTheme()).result.current

--- a/src/__tests__/CompareResults/fetchCompareResults.test.tsx
+++ b/src/__tests__/CompareResults/fetchCompareResults.test.tsx
@@ -4,8 +4,12 @@ import ResultsView from '../../components/CompareResults/ResultsView';
 import { Strings } from '../../resources/Strings';
 import useProtocolTheme from '../../theme/protocolTheme';
 import getTestData from '../utils/fixtures';
-import { renderWithRouter } from '../utils/setupTests';
-import { screen, renderHook, FetchMockSandbox } from '../utils/test-utils';
+import {
+  screen,
+  renderWithRouter,
+  renderHook,
+  FetchMockSandbox,
+} from '../utils/test-utils';
 
 function renderWithRoute(component: ReactElement) {
   return renderWithRouter(component, {

--- a/src/__tests__/Search/CompareWithBase.test.tsx
+++ b/src/__tests__/Search/CompareWithBase.test.tsx
@@ -6,8 +6,14 @@ import SearchView from '../../components/Search/SearchView';
 import { Strings } from '../../resources/Strings';
 import useProtocolTheme from '../../theme/protocolTheme';
 import getTestData from '../utils/fixtures';
-import { renderWithRouter, store } from '../utils/setupTests';
-import { act, screen, renderHook, FetchMockSandbox } from '../utils/test-utils';
+import { store } from '../utils/setupTests';
+import {
+  act,
+  screen,
+  renderHook,
+  renderWithRouter,
+  FetchMockSandbox,
+} from '../utils/test-utils';
 
 const protocolTheme = renderHook(() => useProtocolTheme()).result.current
   .protocolTheme;

--- a/src/__tests__/Search/SearchContainer.test.tsx
+++ b/src/__tests__/Search/SearchContainer.test.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 
-import { renderHook } from '@testing-library/react';
-
 import SearchContainer from '../../components/Search/SearchContainer';
 import useProtocolTheme from '../../theme/protocolTheme';
-import { renderWithRouter } from '../utils/setupTests';
+import { renderWithRouter, renderHook } from '../utils/test-utils';
 
 const protocolTheme = renderHook(() => useProtocolTheme()).result.current
   .protocolTheme;

--- a/src/__tests__/Search/SearchResultsList.test.tsx
+++ b/src/__tests__/Search/SearchResultsList.test.tsx
@@ -4,11 +4,11 @@ import SearchView from '../../components/Search/SearchView';
 import { Strings } from '../../resources/Strings';
 import useProtocolTheme from '../../theme/protocolTheme';
 import getTestData from '../utils/fixtures';
-import { renderWithRouter } from '../utils/setupTests';
 import {
   screen,
   within,
   renderHook,
+  renderWithRouter,
   FetchMockSandbox,
 } from '../utils/test-utils';
 

--- a/src/__tests__/Search/SearchView.test.tsx
+++ b/src/__tests__/Search/SearchView.test.tsx
@@ -1,12 +1,16 @@
-import { renderHook } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import SearchView from '../../components/Search/SearchView';
 import { Strings } from '../../resources/Strings';
 import useProtocolTheme from '../../theme/protocolTheme';
 import getTestData from '../utils/fixtures';
-import { renderWithRouter } from '../utils/setupTests';
-import { screen, act, FetchMockSandbox } from '../utils/test-utils';
+import {
+  screen,
+  act,
+  renderWithRouter,
+  renderHook,
+  FetchMockSandbox,
+} from '../utils/test-utils';
 
 const protocolTheme = renderHook(() => useProtocolTheme()).result.current
   .protocolTheme;

--- a/src/__tests__/Search/SelectedRevision.test.tsx
+++ b/src/__tests__/Search/SelectedRevision.test.tsx
@@ -1,6 +1,4 @@
-import { renderHook } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { act } from 'react-dom/test-utils';
 
 import SearchView from '../../components/Search/SearchView';
 import { updateCheckedRevisions } from '../../reducers/SearchSlice';
@@ -8,8 +6,15 @@ import { Strings } from '../../resources/Strings';
 import useProtocolTheme from '../../theme/protocolTheme';
 import { InputType } from '../../types/state';
 import getTestData from '../utils/fixtures';
-import { renderWithRouter, store } from '../utils/setupTests';
-import { screen, within, FetchMockSandbox } from '../utils/test-utils';
+import { store } from '../utils/setupTests';
+import {
+  screen,
+  within,
+  renderHook,
+  renderWithRouter,
+  act,
+  FetchMockSandbox,
+} from '../utils/test-utils';
 
 const protocolTheme = renderHook(() => useProtocolTheme()).result.current
   .protocolTheme;

--- a/src/__tests__/Search/fetchRecentRevisions.test.tsx
+++ b/src/__tests__/Search/fetchRecentRevisions.test.tsx
@@ -4,8 +4,12 @@ import SearchView from '../../components/Search/SearchView';
 import { Strings } from '../../resources/Strings';
 import useProtocolTheme from '../../theme/protocolTheme';
 import getTestData from '../utils/fixtures';
-import { renderWithRouter } from '../utils/setupTests';
-import { screen, renderHook, FetchMockSandbox } from '../utils/test-utils';
+import {
+  screen,
+  renderHook,
+  renderWithRouter,
+  FetchMockSandbox,
+} from '../utils/test-utils';
 
 describe('Search View/fetchRecentRevisions', () => {
   const protocolTheme = renderHook(() => useProtocolTheme()).result.current

--- a/src/__tests__/Search/fetchRevisionByID.test.tsx
+++ b/src/__tests__/Search/fetchRevisionByID.test.tsx
@@ -4,8 +4,13 @@ import SearchView from '../../components/Search/SearchView';
 import { Strings } from '../../resources/Strings';
 import useProtocolTheme from '../../theme/protocolTheme';
 import getTestData from '../utils/fixtures';
-import { renderWithRouter } from '../utils/setupTests';
-import { screen, renderHook, act, FetchMockSandbox } from '../utils/test-utils';
+import {
+  screen,
+  renderHook,
+  renderWithRouter,
+  act,
+  FetchMockSandbox,
+} from '../utils/test-utils';
 
 describe('Search View/fetchRevisionByID', () => {
   const protocolTheme = renderHook(() => useProtocolTheme()).result.current

--- a/src/__tests__/Search/fetchRevisionsByAuthor.test.tsx
+++ b/src/__tests__/Search/fetchRevisionsByAuthor.test.tsx
@@ -4,8 +4,13 @@ import SearchView from '../../components/Search/SearchView';
 import { Strings } from '../../resources/Strings';
 import useProtocolTheme from '../../theme/protocolTheme';
 import getTestData from '../utils/fixtures';
-import { renderWithRouter } from '../utils/setupTests';
-import { screen, act, renderHook, FetchMockSandbox } from '../utils/test-utils';
+import {
+  screen,
+  act,
+  renderHook,
+  renderWithRouter,
+  FetchMockSandbox,
+} from '../utils/test-utils';
 
 describe('SearchView/fetchRevisionsByAuthor', () => {
   const protocolTheme = renderHook(() => useProtocolTheme()).result.current

--- a/src/__tests__/Snackbar.test.tsx
+++ b/src/__tests__/Snackbar.test.tsx
@@ -6,11 +6,12 @@ import SearchView from '../components/Search/SearchView';
 import { Strings } from '../resources/Strings';
 import useProtocolTheme from '../theme/protocolTheme';
 import getTestData from './utils/fixtures';
-import { renderWithRouter, render } from './utils/setupTests';
 import {
   screen,
   act,
   renderHook,
+  renderWithRouter,
+  render,
   waitForElementToBeRemoved,
   FetchMockSandbox,
 } from './utils/test-utils';

--- a/src/__tests__/hooks/useFetchCompareResults.test.tsx
+++ b/src/__tests__/hooks/useFetchCompareResults.test.tsx
@@ -1,6 +1,14 @@
+import { Provider } from 'react-redux';
+
 import useFetchCompareResults from '../../hooks/useFetchCompareResults';
-import { StoreProvider } from '../utils/setupTests';
+import { store } from '../utils/setupTests';
 import { renderHook, FetchMockSandbox } from '../utils/test-utils';
+
+function renderFetchCompareResultsHook() {
+  return renderHook(() => useFetchCompareResults(), {
+    wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+  });
+}
 
 describe('Tests useFetchCompareResults', () => {
   beforeEach(() => {
@@ -15,7 +23,7 @@ describe('Tests useFetchCompareResults', () => {
       result: {
         current: { dispatchFetchCompareResults },
       },
-    } = renderHook(() => useFetchCompareResults(), { wrapper: StoreProvider });
+    } = renderFetchCompareResultsHook();
     dispatchFetchCompareResults(['fenix'], ['testRev'], '1');
     const url = (global.fetch as FetchMockSandbox).lastUrl() ?? '';
     const searchParams = new URL(url).searchParams;
@@ -30,7 +38,7 @@ describe('Tests useFetchCompareResults', () => {
       result: {
         current: { dispatchFetchCompareResults },
       },
-    } = renderHook(() => useFetchCompareResults(), { wrapper: StoreProvider });
+    } = renderFetchCompareResultsHook();
     dispatchFetchCompareResults(
       ['fenix', 'try'],
       ['testRev1', 'testRev2'],
@@ -49,7 +57,7 @@ describe('Tests useFetchCompareResults', () => {
       result: {
         current: { dispatchFetchCompareResults },
       },
-    } = renderHook(() => useFetchCompareResults(), { wrapper: StoreProvider });
+    } = renderFetchCompareResultsHook();
     dispatchFetchCompareResults(
       ['fenix', 'try', 'mozilla-beta', 'autoland'],
       ['testRev1', 'testRev2', 'testRev3', 'testRev4'],
@@ -63,7 +71,7 @@ describe('Tests useFetchCompareResults', () => {
       result: {
         current: { dispatchFetchCompareResults },
       },
-    } = renderHook(() => useFetchCompareResults(), { wrapper: StoreProvider });
+    } = renderFetchCompareResultsHook();
     dispatchFetchCompareResults(
       ['fenix', 'try', 'mozilla-beta', 'autoland', 'mozilla-central'],
       ['testRev1', 'testRev2', 'testRev3', 'testRev4', 'testRev5'],

--- a/src/__tests__/hooks/useHandleChangeSearch.test.tsx
+++ b/src/__tests__/hooks/useHandleChangeSearch.test.tsx
@@ -1,13 +1,19 @@
 import { FormEvent } from 'react';
 
+import { Provider } from 'react-redux';
+
 import useHandleChangeSearch from '../../hooks/useHandleChangeSearch';
 import { setInputError, updateSearchResults } from '../../reducers/SearchSlice';
 import { InputType, Repository } from '../../types/state';
 import getTestData from '../utils/fixtures';
-import { store, StoreProvider } from '../utils/setupTests';
+import { store } from '../utils/setupTests';
 import { renderHook, FetchMockSandbox } from '../utils/test-utils';
 
-jest.useFakeTimers();
+function renderHandleChangeSearchHook() {
+  return renderHook(() => useHandleChangeSearch(), {
+    wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+  });
+}
 
 describe('Tests useHandleSearchHook', () => {
   const { testData } = getTestData();
@@ -30,9 +36,7 @@ describe('Tests useHandleSearchHook', () => {
       searchType,
       repository: 'try' as Repository['name'],
     };
-    const { result } = renderHook(() => useHandleChangeSearch(), {
-      wrapper: StoreProvider,
-    });
+    const { result } = renderHandleChangeSearchHook();
     result.current.handleChangeSearch(searchState);
     const { search: searchSlice } = store.getState();
     expect(searchSlice[searchType].searchValue).toBe('test input');
@@ -49,9 +53,7 @@ describe('Tests useHandleSearchHook', () => {
       results: testData,
       searchType,
     };
-    const { result } = renderHook(() => useHandleChangeSearch(), {
-      wrapper: StoreProvider,
-    });
+    const { result } = renderHandleChangeSearchHook();
 
     store.dispatch(updateSearchResults(searchResults));
 
@@ -71,9 +73,7 @@ describe('Tests useHandleSearchHook', () => {
       repository: 'try' as Repository['name'],
     };
     const testError = 'test error';
-    const { result } = renderHook(() => useHandleChangeSearch(), {
-      wrapper: StoreProvider,
-    });
+    const { result } = renderHandleChangeSearchHook();
 
     store.dispatch(setInputError({ errorMessage: testError, searchType }));
 
@@ -91,9 +91,7 @@ describe('Tests useHandleSearchHook', () => {
       searchType,
       repository: 'try' as Repository['name'],
     };
-    const { result } = renderHook(() => useHandleChangeSearch(), {
-      wrapper: StoreProvider,
-    });
+    const { result } = renderHandleChangeSearchHook();
     result.current.handleChangeSearch(searchState);
     jest.runAllTimers();
     const { search: updatedSearchSlice } = store.getState();
@@ -109,9 +107,7 @@ describe('Tests useHandleSearchHook', () => {
       searchType,
       repository: 'try' as Repository['name'],
     };
-    const { result } = renderHook(() => useHandleChangeSearch(), {
-      wrapper: StoreProvider,
-    });
+    const { result } = renderHandleChangeSearchHook();
     result.current.handleChangeSearch(searchState);
     jest.runAllTimers();
     expect(global.fetch).toHaveBeenCalledWith(
@@ -127,9 +123,7 @@ describe('Tests useHandleSearchHook', () => {
       searchType,
       repository: 'try' as Repository['name'],
     };
-    const { result } = renderHook(() => useHandleChangeSearch(), {
-      wrapper: StoreProvider,
-    });
+    const { result } = renderHandleChangeSearchHook();
     result.current.handleChangeSearch(searchState);
     jest.runAllTimers();
     expect(global.fetch).toHaveBeenCalledWith(
@@ -150,9 +144,7 @@ describe('Tests useHandleSearchHook', () => {
       searchType,
       repository: 'mozilla-central' as Repository['name'],
     };
-    const { result } = renderHook(() => useHandleChangeSearch(), {
-      wrapper: StoreProvider,
-    });
+    const { result } = renderHandleChangeSearchHook();
     result.current.handleChangeSearch(searchState);
     jest.runAllTimers();
     expect(global.fetch).toHaveBeenCalledWith(
@@ -175,9 +167,7 @@ describe('Tests useHandleSearchHook', () => {
       searchType,
       repository: 'autoland' as Repository['name'],
     };
-    const { result } = renderHook(() => useHandleChangeSearch(), {
-      wrapper: StoreProvider,
-    });
+    const { result } = renderHandleChangeSearchHook();
     result.current.handleChangeSearch(searchState);
     result.current.handleChangeSearch(searchState);
     result.current.handleChangeSearch(searchState);

--- a/src/__tests__/utils/setupTests.ts
+++ b/src/__tests__/utils/setupTests.ts
@@ -7,8 +7,6 @@ import 'regenerator-runtime/runtime';
 import '@testing-library/jest-dom';
 import { TextDecoder, TextEncoder } from 'util';
 
-import React from 'react';
-
 import { density1d } from 'fast-kde';
 // The import of fetchMock also installs jest matchers as a side effect.
 import fetchMock from 'fetch-mock-jest';
@@ -16,12 +14,6 @@ import { Bubble, Line } from 'react-chartjs-2';
 
 import { createStore } from '../../common/store';
 import type { Store } from '../../common/store';
-import {
-  createRender,
-  createRenderWithRouter,
-  createStoreProvider,
-} from './test-utils';
-import type { Render, RenderWithRouter } from './test-utils';
 
 // Register TextDecoder and TextEncoder with the global scope.
 // These are now available globally in nodejs, but not when running with jsdom
@@ -39,10 +31,7 @@ if ('TextDecoder' in global) {
 global.TextDecoder = TextDecoder;
 global.TextEncoder = TextEncoder;
 
-let render: Render;
-let renderWithRouter: RenderWithRouter;
 let store: Store;
-let StoreProvider: React.FC<{ children: JSX.Element }>;
 
 jest.mock('react-chartjs-2', () => ({
   Bubble: jest.fn(),
@@ -80,12 +69,6 @@ beforeEach(function () {
 beforeEach(() => {
   jest.useFakeTimers();
   store = createStore();
-  /* The plugin is confused by our naming. */
-  /* eslint-disable-next-line testing-library/no-render-in-lifecycle */
-  render = createRender(store);
-  /* eslint-disable-next-line testing-library/no-render-in-lifecycle */
-  renderWithRouter = createRenderWithRouter(store);
-  StoreProvider = createStoreProvider(store);
 });
 
 afterEach(() => {
@@ -99,4 +82,4 @@ afterEach(() => {
   fetchMock.mockReset();
 });
 
-export { store, render, renderWithRouter, StoreProvider };
+export { store };

--- a/src/__tests__/utils/setupTests.ts
+++ b/src/__tests__/utils/setupTests.ts
@@ -9,6 +9,8 @@ import { TextDecoder, TextEncoder } from 'util';
 
 import { density1d } from 'fast-kde';
 // The import of fetchMock also installs jest matchers as a side effect.
+// See https://www.wheresrhys.co.uk/fetch-mock/ for more information about how
+// to use this mock.
 import fetchMock from 'fetch-mock-jest';
 import { Bubble, Line } from 'react-chartjs-2';
 

--- a/src/__tests__/utils/test-utils.tsx
+++ b/src/__tests__/utils/test-utils.tsx
@@ -60,5 +60,7 @@ export * from '@testing-library/react';
 // want the type as used by `fetch-mock-jest`. Ideally `fetch-mock-jest` should
 // reexport it but it doesn't. Instead let's disable the eslint rule for this
 // specific import.
+// See https://www.wheresrhys.co.uk/fetch-mock/ for more information about how
+// to use this package.
 /* eslint-disable-next-line import/no-extraneous-dependencies */
 export { FetchMockSandbox } from 'fetch-mock';

--- a/src/__tests__/utils/test-utils.tsx
+++ b/src/__tests__/utils/test-utils.tsx
@@ -5,93 +5,55 @@ import { SnackbarProvider } from 'notistack';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
 
-import type { Store } from '../../common/store';
 import SnackbarCloseButton from '../../components/Shared/SnackbarCloseButton';
 import useProtocolTheme from '../../theme/protocolTheme';
+import { store } from './setupTests';
 
 type ChildrenProps = { children: React.ReactElement };
 
-const createStoreProvider = (store: Store) => {
-  return function StoreProvider({ children }: ChildrenProps) {
-    return <Provider store={store}>{children}</Provider>;
-  };
-};
-
 type ThemeConfig = Partial<Theme> | null;
-const createRender = (store: Store) => {
-  function render(ui: React.ReactElement, themeConfig?: ThemeConfig) {
-    function Wrapper({ children }: ChildrenProps) {
-      const { protocolTheme } = useProtocolTheme();
-      const theme = themeConfig ? createTheme(themeConfig) : protocolTheme;
-      return (
-        <ThemeProvider theme={theme}>
-          <SnackbarProvider
-            maxSnack={3}
-            autoHideDuration={6000}
-            action={(snackbarKey) => (
-              <SnackbarCloseButton snackbarKey={snackbarKey} />
-            )}
-          >
-            <Provider store={store}>{children}</Provider>
-          </SnackbarProvider>
-        </ThemeProvider>
-      );
-    }
-    return rtlRender(ui, { wrapper: Wrapper });
+export function render(ui: React.ReactElement, themeConfig?: ThemeConfig) {
+  function Wrapper({ children }: ChildrenProps) {
+    const { protocolTheme } = useProtocolTheme();
+    const theme = themeConfig ? createTheme(themeConfig) : protocolTheme;
+    return (
+      <ThemeProvider theme={theme}>
+        <SnackbarProvider
+          maxSnack={3}
+          autoHideDuration={6000}
+          action={(snackbarKey) => (
+            <SnackbarCloseButton snackbarKey={snackbarKey} />
+          )}
+        >
+          <Provider store={store}>{children}</Provider>
+        </SnackbarProvider>
+      </ThemeProvider>
+    );
   }
-  return render;
-};
+  return rtlRender(ui, { wrapper: Wrapper });
+}
 
-const createRenderWithRouter = (store: Store) => {
-  function renderWithRouter(
-    ui: React.ReactElement,
-    {
-      route = '/',
-      history = createMemoryHistory({ initialEntries: [route] }),
-    } = {},
-    theme: ThemeConfig = null,
-  ) {
-    /* Eslint is confused with our naming. */
-    /* eslint-disable-next-line testing-library/render-result-naming-convention */
-    const render = createRender(store);
-    return {
-      ...render(
-        <Router location={history.location} navigator={history}>
-          {ui}
-        </Router>,
-        theme,
-      ),
-      history,
-    };
-  }
-  return renderWithRouter;
-};
-
-const createRouterWrapper = (
-  route: string,
-  history = createMemoryHistory({ initialEntries: [route] }),
-) => {
+export function renderWithRouter(
+  ui: React.ReactElement,
+  {
+    route = '/',
+    history = createMemoryHistory({ initialEntries: [route] }),
+  } = {},
+  theme: ThemeConfig = null,
+) {
   return {
-    RouterWrapper: ({ children }: ChildrenProps) => (
+    ...render(
       <Router location={history.location} navigator={history}>
-        {children}
-      </Router>
+        {ui}
+      </Router>,
+      theme,
     ),
     history,
   };
-};
+}
 
 // re-export everything
 export * from '@testing-library/react';
-// override render method
-export type Render = ReturnType<typeof createRender>;
-export type RenderWithRouter = ReturnType<typeof createRenderWithRouter>;
-export {
-  createRender,
-  createRenderWithRouter,
-  createRouterWrapper,
-  createStoreProvider,
-};
 
 // This eslint rule wants that every requested package is specified in
 // package.json, which is usually a good thing. But in this case we actually


### PR DESCRIPTION
Before this patch, we have 2 different render functions: `render` and `renderWithRouter`. We also have a `StoreProvider` that's just `react-redux`'s `Provider` pre-configured, that we use in some hooks-related test files.

The 2 render functions are "created" in `beforeEach` and exposed by `setupTests`. Instead of "creating" them, in this patch they're now defined directly, and they can be imported directly from `test-utils` in the test files. The goal is that it's now easier to create new flavors for these functions, that I'd like to use in #582.

The `store` object is imported from `setupTests` instead of being passed as a parameter. I considered creating it in the  `render` functions (possibly as a default parameter, so that we could pass another store if needed) and returning it, but this would require changing all call sites, so I decided to keep it simple for now. We could always change it more later.

This is on top of #584 and #586 to minimize rebase conflicts, so take care to only look at the few un-labeled commits at the end of the commit list.