### PR TITLE
PCF-362 Fix dark mode on results table

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Results Table Should match snapshot 1`] = `
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-1qr77tn-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-13yod79-MuiPaper-root"
       data-testid="results-table"
       role="table"
     >

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Results Table Should match snapshot 1`] = `
 <body>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-16rtr54-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-1qr77tn-MuiPaper-root"
       data-testid="results-table"
       role="table"
     >

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -946,7 +946,7 @@ exports[`Results View RESULTS: clicking the cancel button hides input and dropdo
               </div>
             </header>
             <div
-              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-1qr77tn-MuiPaper-root"
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-13yod79-MuiPaper-root"
               data-testid="results-table"
               role="table"
             >
@@ -2103,7 +2103,7 @@ exports[`Results View RESULTS: clicking the save button hides input and dropdown
               </div>
             </header>
             <div
-              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-1qr77tn-MuiPaper-root"
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-13yod79-MuiPaper-root"
               data-testid="results-table"
               role="table"
             >
@@ -3260,7 +3260,7 @@ exports[`Results View RESULTS: shows dropdown and input when edit button in clic
               </div>
             </header>
             <div
-              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-1qr77tn-MuiPaper-root"
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-13yod79-MuiPaper-root"
               data-testid="results-table"
               role="table"
             >
@@ -3473,7 +3473,7 @@ exports[`Results View RESULTS: shows dropdown and input when edit button in clic
 
 exports[`Results View Should match snapshot 1`] = `
 <div
-  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-1qr77tn-MuiPaper-root"
+  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-13yod79-MuiPaper-root"
   data-testid="results-table"
   role="table"
 >

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -946,7 +946,7 @@ exports[`Results View RESULTS: clicking the cancel button hides input and dropdo
               </div>
             </header>
             <div
-              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-16rtr54-MuiPaper-root"
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-1qr77tn-MuiPaper-root"
               data-testid="results-table"
               role="table"
             >
@@ -2103,7 +2103,7 @@ exports[`Results View RESULTS: clicking the save button hides input and dropdown
               </div>
             </header>
             <div
-              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-16rtr54-MuiPaper-root"
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-1qr77tn-MuiPaper-root"
               data-testid="results-table"
               role="table"
             >
@@ -3260,7 +3260,7 @@ exports[`Results View RESULTS: shows dropdown and input when edit button in clic
               </div>
             </header>
             <div
-              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-16rtr54-MuiPaper-root"
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-1qr77tn-MuiPaper-root"
               data-testid="results-table"
               role="table"
             >
@@ -3473,7 +3473,7 @@ exports[`Results View RESULTS: shows dropdown and input when edit button in clic
 
 exports[`Results View Should match snapshot 1`] = `
 <div
-  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-16rtr54-MuiPaper-root"
+  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-1qr77tn-MuiPaper-root"
   data-testid="results-table"
   role="table"
 >

--- a/src/__tests__/CompareResults/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SearchInput.test.tsx.snap
@@ -695,7 +695,7 @@ exports[`Search by title/test name Should match snapshot 1`] = `
               </div>
             </header>
             <div
-              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-1qr77tn-MuiPaper-root"
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-13yod79-MuiPaper-root"
               data-testid="results-table"
               role="table"
             >

--- a/src/__tests__/CompareResults/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SearchInput.test.tsx.snap
@@ -695,7 +695,7 @@ exports[`Search by title/test name Should match snapshot 1`] = `
               </div>
             </header>
             <div
-              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-16rtr54-MuiPaper-root"
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-1qr77tn-MuiPaper-root"
               data-testid="results-table"
               role="table"
             >

--- a/src/__tests__/CompareResults/__snapshots__/fetchCompareResults.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/fetchCompareResults.test.tsx.snap
@@ -814,7 +814,7 @@ exports[`Results View/fetchCompareResults Should fetch and display recent result
               </div>
             </header>
             <div
-              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-16rtr54-MuiPaper-root"
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-1qr77tn-MuiPaper-root"
               data-testid="results-table"
               role="table"
             >
@@ -3122,7 +3122,7 @@ exports[`Results View/fetchCompareResults State does not contain data if fetch r
               </div>
             </header>
             <div
-              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-16rtr54-MuiPaper-root"
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-1qr77tn-MuiPaper-root"
               data-testid="results-table"
               role="table"
             >

--- a/src/__tests__/CompareResults/__snapshots__/fetchCompareResults.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/fetchCompareResults.test.tsx.snap
@@ -814,7 +814,7 @@ exports[`Results View/fetchCompareResults Should fetch and display recent result
               </div>
             </header>
             <div
-              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-1qr77tn-MuiPaper-root"
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-13yod79-MuiPaper-root"
               data-testid="results-table"
               role="table"
             >
@@ -3122,7 +3122,7 @@ exports[`Results View/fetchCompareResults State does not contain data if fetch r
               </div>
             </header>
             <div
-              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-1qr77tn-MuiPaper-root"
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 fv9cdwb css-13yod79-MuiPaper-root"
               data-testid="results-table"
               role="table"
             >

--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -12,6 +12,8 @@ import TableHeader from './TableHeader';
 
 const customStyles = {
   boxShadow: 'none',
+  backgroundImage: 'none',
+  backgroundColor: 'transparent',
 };
 
 function ResultsTable() {

--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -12,8 +12,7 @@ import TableHeader from './TableHeader';
 
 const customStyles = {
   boxShadow: 'none',
-  backgroundImage: 'none',
-  backgroundColor: 'transparent',
+  background: 'none',
 };
 
 function ResultsTable() {


### PR DESCRIPTION
This PR addresses [PCF-362 Fix dark mode on results table](https://mozilla-hub.atlassian.net/browse/PCF-362).

The table background is the same as the page background. Below there is a before and after.
<img width="392" alt="Screenshot 2024-01-22 at 5 25 57 PM" src="https://github.com/mozilla/perfcompare/assets/63001299/6f89ed24-c907-4c93-a897-dbdde28594c3">

<img width="420" alt="Screenshot 2024-01-22 at 5 25 02 PM" src="https://github.com/mozilla/perfcompare/assets/63001299/b7a44b34-737c-45ac-9091-7747d397c3fb">
