### PR TITLE
Add an Error Boundary for the results page, and add more tests around the react router behavior

### DIFF
--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -1,15 +1,20 @@
 import userEvent from '@testing-library/user-event';
 import { act } from 'react-dom/test-utils';
 
-import App from '../components/App';
+import App, { router } from '../components/App';
+import getTestData from './utils/fixtures';
 import { render, screen, FetchMockSandbox } from './utils/test-utils';
 
 describe('App', () => {
   beforeEach(() => {
-    (global.fetch as FetchMockSandbox).get(
-      'glob:https://treeherder.mozilla.org/api/project/*/push/*',
-      { results: [] },
-    );
+    const { testData } = getTestData();
+    (global.fetch as FetchMockSandbox)
+      .get('glob:https://treeherder.mozilla.org/api/project/*/push/*', {
+        results: [],
+      })
+      .get('begin:https://treeherder.mozilla.org/api/project/', {
+        results: [testData[0]],
+      });
   });
 
   test('Should render search view on default route', async () => {
@@ -36,5 +41,151 @@ describe('App', () => {
 
     await user.click(darkModeButton);
     expect(screen.queryByLabelText('Light mode')).not.toBeInTheDocument();
+  });
+
+  describe('CompareResults loader', () => {
+    it('Should render an error page when the treeherder request fails with an error 500', async () => {
+      // Silence console.error for a better console output. We'll check its result later.
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      (window.fetch as FetchMockSandbox).get(
+        'begin:https://treeherder.mozilla.org/api/perfcompare/results/',
+        500,
+      );
+
+      await router.navigate(
+        '/compare-results/?baseRev=spam&baseRepo=mozilla-central&framework=2',
+      );
+      render(<App />);
+
+      await screen.findByText(/Error/);
+      expect(console.error).toHaveBeenCalledWith(
+        new Error(
+          'Error when requesting treeherder: (500) Internal Server Error',
+        ),
+      );
+      expect(console.error).toHaveBeenCalledTimes(1);
+      expect(document.body).toMatchSnapshot();
+    });
+
+    it('Should render an error page when the treeherder request fails with an error 400', async () => {
+      // Silence console.error for a better console output. We'll check its result later.
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      (window.fetch as FetchMockSandbox).get(
+        'begin:https://treeherder.mozilla.org/api/perfcompare/results/',
+        {
+          status: 400,
+          body: 'Treeherder request error',
+        },
+      );
+
+      await router.navigate(
+        '/compare-results/?baseRev=spam&baseRepo=mozilla-central&framework=2',
+      );
+      render(<App />);
+
+      await screen.findByText(/Error/);
+      expect(console.error).toHaveBeenCalledWith(
+        new Error('Error when requesting treeherder: Treeherder request error'),
+      );
+      expect(console.error).toHaveBeenCalledTimes(1);
+      expect(document.body).toMatchSnapshot();
+    });
+
+    it('Should render an error page when the requested URL is invalid', async () => {
+      // Silence console.error for a better console output. We'll check its result later.
+      // If an expectation toHaveBeenCalledTimes fails, it might be easier to
+      // remove the mockImplementation part to debug.
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      // Error 1: no baseRev
+      await router.navigate('/compare-results/');
+      render(<App />);
+      expect(await screen.findByText(/baseRev/)).toMatchSnapshot();
+      expect(console.error).toHaveBeenCalledWith(
+        new Error('The parameter baseRev is missing.'),
+      );
+      expect(console.error).toHaveBeenCalledTimes(1);
+      (console.error as jest.Mock).mockClear();
+
+      // Error 2: no baseRepo
+      await act(() => router.navigate('/compare-results/?baseRev=spam'));
+      expect(await screen.findByText(/baseRepo/)).toMatchSnapshot();
+      expect(console.error).toHaveBeenCalledWith(
+        new Error('The parameter baseRepo is missing.'),
+      );
+      expect(console.error).toHaveBeenCalledTimes(1);
+      (console.error as jest.Mock).mockClear();
+
+      // Error 3: not the same amount of newRevs and newRepos
+      await act(() =>
+        router.navigate(
+          '/compare-results/?baseRev=spam&baseRepo=try&newRev=foo&newRepo=try&newRepo=mozilla-central',
+        ),
+      );
+      expect(await screen.findByText(/"newRepo"/)).toMatchSnapshot();
+      expect(console.error).toHaveBeenCalledWith(
+        new Error(
+          'There should be as many "newRepo" parameters as there are "newRev" parameters.',
+        ),
+      );
+      expect(console.error).toHaveBeenCalledTimes(1);
+      (console.error as jest.Mock).mockClear();
+
+      // Error 4: unknown baseRepo value
+      await act(() =>
+        router.navigate('/compare-results/?baseRev=spam&baseRepo=UNKNOWN'),
+      );
+      expect(await screen.findByText(/"UNKNOWN"/)).toMatchSnapshot();
+      expect(console.error).toHaveBeenCalledWith(
+        new Error(
+          'The parameter baseRepo "UNKNOWN" should be one of mozilla-central, try, mozilla-beta, mozilla-release, autoland, fenix.',
+        ),
+      );
+      expect(console.error).toHaveBeenCalledTimes(1);
+      (console.error as jest.Mock).mockClear();
+
+      // Error 5: unknown newRepo value
+      await act(() =>
+        router.navigate(
+          '/compare-results/?baseRev=spam&baseRepo=try&newRev=foo&newRepo=UNKNOWN',
+        ),
+      );
+      expect(await screen.findByText(/"UNKNOWN"/)).toMatchSnapshot();
+      expect(console.error).toHaveBeenCalledWith(
+        new Error(
+          'Every parameter newRepo "UNKNOWN" should be one of mozilla-central, try, mozilla-beta, mozilla-release, autoland, fenix.',
+        ),
+      );
+      expect(console.error).toHaveBeenCalledTimes(1);
+      (console.error as jest.Mock).mockClear();
+
+      // Error 6: invalid framework value
+      await act(() =>
+        router.navigate(
+          '/compare-results/?baseRev=spam&baseRepo=try&framework=FOO',
+        ),
+      );
+      expect(await screen.findByText(/"FOO"/)).toMatchSnapshot();
+      expect(console.error).toHaveBeenCalledWith(
+        new Error(
+          'The parameter framework should be a number, but it is "FOO".',
+        ),
+      );
+      expect(console.error).toHaveBeenCalledTimes(1);
+      (console.error as jest.Mock).mockClear();
+
+      // Error 7: unknown framework value
+      await act(() =>
+        router.navigate(
+          '/compare-results/?baseRev=spam&baseRepo=try&framework=25',
+        ),
+      );
+      expect(await screen.findByText(/"25"/)).toMatchSnapshot();
+      expect(console.error).toHaveBeenCalledWith(
+        new Error(`The parameter framework isn't a valid value: "25".`),
+      );
+      expect(console.error).toHaveBeenCalledTimes(1);
+      (console.error as jest.Mock).mockClear();
+    });
   });
 });

--- a/src/__tests__/__snapshots__/App.test.tsx.snap
+++ b/src/__tests__/__snapshots__/App.test.tsx.snap
@@ -1,0 +1,334 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`App CompareResults loader Should render an error page when the requested URL is invalid 1`] = `
+<p>
+  Error: 
+  The parameter baseRev is missing.
+</p>
+`;
+
+exports[`App CompareResults loader Should render an error page when the requested URL is invalid 2`] = `
+<p>
+  Error: 
+  The parameter baseRepo is missing.
+</p>
+`;
+
+exports[`App CompareResults loader Should render an error page when the requested URL is invalid 3`] = `
+<p>
+  Error: 
+  There should be as many "newRepo" parameters as there are "newRev" parameters.
+</p>
+`;
+
+exports[`App CompareResults loader Should render an error page when the requested URL is invalid 4`] = `
+<p>
+  Error: 
+  The parameter baseRepo "UNKNOWN" should be one of mozilla-central, try, mozilla-beta, mozilla-release, autoland, fenix.
+</p>
+`;
+
+exports[`App CompareResults loader Should render an error page when the requested URL is invalid 5`] = `
+<p>
+  Error: 
+  Every parameter newRepo "UNKNOWN" should be one of mozilla-central, try, mozilla-beta, mozilla-release, autoland, fenix.
+</p>
+`;
+
+exports[`App CompareResults loader Should render an error page when the requested URL is invalid 6`] = `
+<p>
+  Error: 
+  The parameter framework should be a number, but it is "FOO".
+</p>
+`;
+
+exports[`App CompareResults loader Should render an error page when the requested URL is invalid 7`] = `
+<p>
+  Error: 
+  The parameter framework isn't a valid value: "25".
+</p>
+`;
+
+exports[`App CompareResults loader Should render an error page when the treeherder request fails with an error 400 1`] = `
+<body>
+  <div>
+    <div
+      aria-live="assertive"
+      class="alert-container"
+      role="alert"
+    />
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-standardWarning MuiAlert-standard fld8l4l css-1qrenvf-MuiPaper-root-MuiAlert-root"
+      role="alert"
+    >
+      <div
+        class="MuiAlert-icon css-1ytlwq5-MuiAlert-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+          data-testid="ReportProblemOutlinedIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiAlert-message css-1pxa9xg-MuiAlert-message"
+      >
+        <div
+          class="banner-text"
+        >
+          This is an unstable pre-release version. Some features may not yet be supported.
+           
+          <a
+            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
+            href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Testing&component=PerfCompare&status_whiteboard=[pcf]"
+            target="_blank"
+          >
+            File a bug on Bugzilla.
+          </a>
+        </div>
+      </div>
+    </div>
+    <div
+      class="fcndgf6"
+    >
+      <div
+        class="MuiGrid-root header-container container_flkg2b4 css-plh9qo-MuiGrid-root"
+      >
+        <div
+          class="toggle-dark-mode f4zotac MuiBox-root css-0"
+        >
+          <div
+            class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
+          >
+            <label
+              class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementStart toggle-text css-z8chs3-MuiFormControlLabel-root"
+            >
+              <span
+                class="MuiSwitch-root MuiSwitch-sizeMedium toggle-switch toggle-dark-mode css-julti5-MuiSwitch-root"
+              >
+                <span
+                  class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-1yg1ubd-MuiButtonBase-root-MuiSwitch-switchBase"
+                >
+                  <input
+                    aria-label="Dark mode switch"
+                    class="PrivateSwitchBase-input MuiSwitch-input css-1m9pwf3"
+                    id="Dark mode"
+                    name="toggle-dark-mode"
+                    type="checkbox"
+                  />
+                  <span
+                    class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
+                  />
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </span>
+                <span
+                  class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
+                />
+              </span>
+              <span
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1giq4eh-MuiTypography-root"
+              >
+                Dark mode
+              </span>
+            </label>
+          </div>
+        </div>
+        <div
+          class="header-text MuiBox-root css-0"
+        >
+          <div
+            class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-160ox9e-MuiTypography-root"
+          >
+            PerfCompare
+          </div>
+        </div>
+      </div>
+      <section
+        class="container_fs3wa1q"
+      >
+        <a
+          aria-label="link to home"
+          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
+          href="/"
+        >
+          <div
+            class="css-1d9cypr-MuiStack-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-1mecf1h-MuiSvgIcon-root"
+              data-testid="ChevronLeftIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+              />
+            </svg>
+            <p>
+              Home
+            </p>
+          </div>
+        </a>
+        <p>
+          Error: 
+          Error when requesting treeherder: Treeherder request error
+        </p>
+        <p>
+          More information about this error has been written to the Web Console.
+        </p>
+      </section>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`App CompareResults loader Should render an error page when the treeherder request fails with an error 500 1`] = `
+<body>
+  <div>
+    <div
+      aria-live="assertive"
+      class="alert-container"
+      role="alert"
+    />
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-standardWarning MuiAlert-standard fld8l4l css-1qrenvf-MuiPaper-root-MuiAlert-root"
+      role="alert"
+    >
+      <div
+        class="MuiAlert-icon css-1ytlwq5-MuiAlert-icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+          data-testid="ReportProblemOutlinedIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiAlert-message css-1pxa9xg-MuiAlert-message"
+      >
+        <div
+          class="banner-text"
+        >
+          This is an unstable pre-release version. Some features may not yet be supported.
+           
+          <a
+            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
+            href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Testing&component=PerfCompare&status_whiteboard=[pcf]"
+            target="_blank"
+          >
+            File a bug on Bugzilla.
+          </a>
+        </div>
+      </div>
+    </div>
+    <div
+      class="fcndgf6"
+    >
+      <div
+        class="MuiGrid-root header-container container_flkg2b4 css-plh9qo-MuiGrid-root"
+      >
+        <div
+          class="toggle-dark-mode f4zotac MuiBox-root css-0"
+        >
+          <div
+            class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
+          >
+            <label
+              class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementStart toggle-text css-z8chs3-MuiFormControlLabel-root"
+            >
+              <span
+                class="MuiSwitch-root MuiSwitch-sizeMedium toggle-switch toggle-dark-mode css-julti5-MuiSwitch-root"
+              >
+                <span
+                  class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-1yg1ubd-MuiButtonBase-root-MuiSwitch-switchBase"
+                >
+                  <input
+                    aria-label="Dark mode switch"
+                    class="PrivateSwitchBase-input MuiSwitch-input css-1m9pwf3"
+                    id="Dark mode"
+                    name="toggle-dark-mode"
+                    type="checkbox"
+                  />
+                  <span
+                    class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
+                  />
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </span>
+                <span
+                  class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
+                />
+              </span>
+              <span
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1giq4eh-MuiTypography-root"
+              >
+                Dark mode
+              </span>
+            </label>
+          </div>
+        </div>
+        <div
+          class="header-text MuiBox-root css-0"
+        >
+          <div
+            class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-160ox9e-MuiTypography-root"
+          >
+            PerfCompare
+          </div>
+        </div>
+      </div>
+      <section
+        class="container_fs3wa1q"
+      >
+        <a
+          aria-label="link to home"
+          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
+          href="/"
+        >
+          <div
+            class="css-1d9cypr-MuiStack-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-1mecf1h-MuiSvgIcon-root"
+              data-testid="ChevronLeftIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+              />
+            </svg>
+            <p>
+              Home
+            </p>
+          </div>
+        </a>
+        <p>
+          Error: 
+          Error when requesting treeherder: (500) Internal Server Error
+        </p>
+        <p>
+          More information about this error has been written to the Web Console.
+        </p>
+      </section>
+    </div>
+  </div>
+</body>
+`;

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -47,7 +47,9 @@ AlertContainer.displayName = 'AlertContainer';
 
 // The router should be statically defined outside of the React tree.
 // See https://reactrouter.com/en/main/routers/router-provider for more information.
-const router = createBrowserRouter(
+// It's exported so that we can control it in tests. Do not use it directly in
+// application code!
+export const router = createBrowserRouter(
   createRoutesFromElements(
     <>
       <Route

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -19,6 +19,7 @@ import getProtocolTheme from '../theme/protocolTheme';
 import { loader as compareLoader } from './CompareResults/loader';
 import ResultsView from './CompareResults/ResultsView';
 import SearchView from './Search/SearchView';
+import { PageError } from './Shared/PageError';
 import SnackbarCloseButton from './Shared/SnackbarCloseButton';
 
 const strings: BannerStrings = {
@@ -58,6 +59,7 @@ const router = createBrowserRouter(
         path='/compare-results'
         loader={compareLoader}
         element={<ResultsView title={Strings.metaData.pageTitle.results} />}
+        errorElement={<PageError title={Strings.metaData.pageTitle.results} />}
       />
     </>,
   ),

--- a/src/components/CompareResults/ResultsView.tsx
+++ b/src/components/CompareResults/ResultsView.tsx
@@ -7,11 +7,9 @@ import Stack from '@mui/material/Stack';
 import { useLoaderData } from 'react-router-dom';
 import { style } from 'typestyle';
 
-import { compareView } from '../../common/constants';
 import { useAppDispatch, useAppSelector } from '../../hooks/app';
 import { updateFramework } from '../../reducers/FrameworkSlice';
 import { SearchContainerStyles, background } from '../../styles';
-import { View } from '../../types/state';
 import CompareWithBase from '../Search/CompareWithBase';
 import SearchViewInit from '../Search/SearchViewInit';
 import PerfCompareHeader from '../Shared/PerfCompareHeader';
@@ -48,7 +46,7 @@ function ResultsView(props: ResultsViewProps) {
     }),
   };
 
-  const sectionStyles = SearchContainerStyles(themeMode, compareView);
+  const sectionStyles = SearchContainerStyles(themeMode, /* isHome */ false);
 
   useEffect(() => {
     document.title = title;
@@ -70,7 +68,7 @@ function ResultsView(props: ResultsViewProps) {
       className={styles.container}
       data-testid='beta-version-compare-results'
     >
-      <PerfCompareHeader view={compareView as View} />
+      <PerfCompareHeader />
       <section className={sectionStyles.container}>
         <Link href='/' aria-label='link to home'>
           <Stack direction='row' alignItems='center'>

--- a/src/components/CompareResults/ResultsView.tsx
+++ b/src/components/CompareResults/ResultsView.tsx
@@ -1,9 +1,6 @@
 import { useEffect, useMemo } from 'react';
 
-import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import Grid from '@mui/material/Grid';
-import Link from '@mui/material/Link';
-import Stack from '@mui/material/Stack';
 import { useLoaderData } from 'react-router-dom';
 import { style } from 'typestyle';
 
@@ -12,6 +9,7 @@ import { updateFramework } from '../../reducers/FrameworkSlice';
 import { SearchContainerStyles, background } from '../../styles';
 import CompareWithBase from '../Search/CompareWithBase';
 import SearchViewInit from '../Search/SearchViewInit';
+import { LinkToHome } from '../Shared/LinkToHome';
 import PerfCompareHeader from '../Shared/PerfCompareHeader';
 import type { LoaderReturnValue } from './loader';
 import ResultsMain from './ResultsMain';
@@ -70,12 +68,7 @@ function ResultsView(props: ResultsViewProps) {
     >
       <PerfCompareHeader />
       <section className={sectionStyles.container}>
-        <Link href='/' aria-label='link to home'>
-          <Stack direction='row' alignItems='center'>
-            <ChevronLeftIcon fontSize='small' />
-            <p>Home</p>
-          </Stack>
-        </Link>
+        <LinkToHome />
         <SearchViewInit />
 
         <CompareWithBase

--- a/src/components/Search/SearchContainer.tsx
+++ b/src/components/Search/SearchContainer.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Typography from '@mui/material/Typography';
 
-import { repoMap, searchView } from '../../common/constants';
+import { repoMap } from '../../common/constants';
 import { useAppSelector } from '../../hooks/app';
 import { Strings } from '../../resources/Strings';
 import { SearchContainerStyles } from '../../styles';
@@ -13,7 +13,7 @@ const strings = Strings.components.searchDefault;
 
 function SearchContainer(props: SearchViewProps) {
   const themeMode = useAppSelector((state) => state.theme.mode);
-  const styles = SearchContainerStyles(themeMode, searchView);
+  const styles = SearchContainerStyles(themeMode, /* isHome */ true);
   const checkedRevisionsListNew = useAppSelector(
     (state) => state.search.new.checkedRevisions,
   );

--- a/src/components/Search/SearchView.tsx
+++ b/src/components/Search/SearchView.tsx
@@ -2,11 +2,9 @@ import { useRef, useEffect } from 'react';
 
 import { style } from 'typestyle';
 
-import { searchView } from '../../common/constants';
 import { useAppSelector } from '../../hooks/app';
 import { background } from '../../styles';
 import { skipLink } from '../../styles';
-import { View } from '../../types/state';
 import SkipLink from '../Accessibility/SkipLink';
 import PerfCompareHeader from '../Shared/PerfCompareHeader';
 import SearchContainer from './SearchContainer';
@@ -34,7 +32,7 @@ function SearchView(props: SearchViewProps) {
           Skip to search
         </button>
       </SkipLink>
-      <PerfCompareHeader view={searchView as View} />
+      <PerfCompareHeader isHome />
       <SearchViewInit />
       <SearchContainer containerRef={containerRef} />
     </div>

--- a/src/components/Shared/LinkToHome.tsx
+++ b/src/components/Shared/LinkToHome.tsx
@@ -1,0 +1,14 @@
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import Link from '@mui/material/Link';
+import Stack from '@mui/material/Stack';
+
+export function LinkToHome() {
+  return (
+    <Link href='/' aria-label='link to home'>
+      <Stack direction='row' alignItems='center'>
+        <ChevronLeftIcon fontSize='small' />
+        <p>Home</p>
+      </Stack>
+    </Link>
+  );
+}

--- a/src/components/Shared/PageError.tsx
+++ b/src/components/Shared/PageError.tsx
@@ -1,0 +1,44 @@
+import { useEffect } from 'react';
+
+import { useRouteError } from 'react-router-dom';
+import { style } from 'typestyle';
+
+import { useAppSelector } from '../../hooks/app';
+import { SearchContainerStyles, background } from '../../styles';
+import { LinkToHome } from './LinkToHome';
+import PerfCompareHeader from './PerfCompareHeader';
+
+interface PageErrorProps {
+  title: string;
+}
+
+export function PageError({ title }: PageErrorProps) {
+  const themeMode = useAppSelector((state) => state.theme.mode);
+  useEffect(() => {
+    document.title = title;
+  }, [title]);
+
+  const styles = {
+    container: style({
+      backgroundColor: background(themeMode),
+    }),
+  };
+
+  const sectionStyles = SearchContainerStyles(themeMode, /* isHome */ false);
+
+  const error = useRouteError() as Error;
+  console.error(error);
+
+  return (
+    <div className={styles.container}>
+      <PerfCompareHeader />
+      <section className={sectionStyles.container}>
+        <LinkToHome />
+        <p>Error: {error.message}</p>
+        <p>
+          More information about this error has been written to the Web Console.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/src/components/Shared/PerfCompareHeader.tsx
+++ b/src/components/Shared/PerfCompareHeader.tsx
@@ -9,14 +9,14 @@ import { HeaderStyles } from '../../styles';
 import ToggleDarkMode from './ToggleDarkModeButton';
 
 interface PerfCompareHeaderProps {
-  view: 'search' | 'compare-results';
+  isHome?: boolean;
 }
 
 const strings = Strings.components.header;
 
-function PerfCompareHeader({ view }: PerfCompareHeaderProps) {
+function PerfCompareHeader({ isHome }: PerfCompareHeaderProps) {
   const themeMode = useAppSelector((state) => state.theme.mode);
-  const styles = HeaderStyles(themeMode, view);
+  const styles = HeaderStyles(themeMode, isHome ?? false);
 
   return (
     <Grid className={`header-container ${styles.container}`}>
@@ -31,7 +31,7 @@ function PerfCompareHeader({ view }: PerfCompareHeaderProps) {
         >
           {strings.title}
         </Typography>
-        {view === 'search' && (
+        {isHome ? (
           <>
             <Typography
               component='div'
@@ -43,7 +43,7 @@ function PerfCompareHeader({ view }: PerfCompareHeaderProps) {
             </Typography>
             <Button className='learn-more-btn'>{strings.learnMore}</Button>
           </>
-        )}
+        ) : null}
       </Box>
     </Grid>
   );

--- a/src/styles/Header.ts
+++ b/src/styles/Header.ts
@@ -7,22 +7,18 @@ import { Spacing } from './Spacing';
 
 const strings = Strings.components.header;
 
-export const HeaderStyles = (
-  mode: string,
-  view: 'search' | 'compare-results',
-) => {
-  const isTrueLight = mode == 'light' ? true : false;
-  const isSearch = view == 'search' ? true : false;
-  const lightBg = isSearch ? Colors.Background200 : '#ffffff';
-  const darkBg = isSearch ? Colors.Background200Dark : Colors.Background100Dark;
+export const HeaderStyles = (mode: string, isHome: boolean) => {
+  const isTrueLight = mode == 'light';
+  const lightBg = isHome ? Colors.Background200 : '#ffffff';
+  const darkBg = isHome ? Colors.Background200Dark : Colors.Background100Dark;
 
   const styles = stylesheet({
     container: {
       padding: 0,
       width: '100%',
-      minHeight: view == 'search' ? '357px' : '130px',
+      minHeight: isHome ? '357px' : '130px',
       backgroundColor: isTrueLight ? lightBg : darkBg,
-      backgroundImage: isSearch ? strings.bgLink : 'none',
+      backgroundImage: isHome ? strings.bgLink : 'none',
       backgroundPosition: 'center',
       backgroundRepeat: 'no-repeat',
       backgroundPositionY: 'top',
@@ -35,7 +31,7 @@ export const HeaderStyles = (
           margin: '0 auto',
         },
         '.perfcompare-header': {
-          marginBottom: isSearch
+          marginBottom: isHome
             ? `${Spacing.Large}px`
             : `${Spacing.xxLarge - 6}px`,
         },

--- a/src/styles/SearchContainerStyles.ts
+++ b/src/styles/SearchContainerStyles.ts
@@ -2,19 +2,15 @@ import { stylesheet } from 'typestyle';
 
 import { FontsRaw, Spacing } from '../styles';
 
-export const SearchContainerStyles = (
-  mode: string,
-  view: 'search' | 'compare-results',
-) => {
-  const isTrueLight = mode == 'light' ? true : false;
-  const isSearch = view == 'search' ? true : false;
+export const SearchContainerStyles = (mode: string, isHome: boolean) => {
+  const isTrueLight = mode == 'light';
 
   const styles = stylesheet({
     container: {
-      maxWidth: isSearch ? '810px' : '950px',
-      marginTop: isSearch ? `${Spacing.layoutLarge + 20}px` : '0px',
+      maxWidth: isHome ? '810px' : '950px',
+      marginTop: isHome ? `${Spacing.layoutLarge + 20}px` : '0px',
       margin: '0 auto',
-      marginBottom: isSearch ? '0px' : `${Spacing.layoutXLarge + 4}px`,
+      marginBottom: isHome ? '0px' : `${Spacing.layoutXLarge + 4}px`,
       display: 'flex',
       justifyContent: 'center',
       flexDirection: 'column',


### PR DESCRIPTION
Please look only at the last commits that are not prefixed with a mention.

The 2 first commits are preparatory to the Error Boundary component. They make it easier to have a similar visual design.
Commit 3 adds a simple error boundary and configures it with the router.
Commit 4 adds new tests for the router and the error boundary.

Most of the remaining missing coverage will be covered when I'll work on fetching the recent revisions using the react router, that's why I didn't cover them here.

You can test the error boundary by requesting with wrong parameters, for example:
* no parameters => https://deploy-preview-600--mozilla-perfcompare.netlify.app/compare-results
* no baseRepo => https://deploy-preview-600--mozilla-perfcompare.netlify.app/compare-results?baseRev=foo
* not the same amount of newRevs and newRepo => https://deploy-preview-600--mozilla-perfcompare.netlify.app/compare-results?baseRev=foo&baseRepo=mozilla-central&newRev=spam&newRepo=try&newRepo=mozilla-central

