### PR TITLE
Simplify callbacks in Compare With Base child comps

### DIFF
--- a/src/components/Search/CompareWithBase.tsx
+++ b/src/components/Search/CompareWithBase.tsx
@@ -140,112 +140,94 @@ function CompareWithBase({
   const toggleIsExpanded = () => {
     setExpanded(!expanded);
   };
+  const handleCancelBase = () => {
+    setInProgressBase({ ...revRepos, isInProgress: false });
+    dispatch(clearCheckedRevisionforType({ searchType: 'base' }));
+  };
 
-  const handleCancel = (isBase: boolean) => {
-    if (isBase) {
-      setInProgressBase({ ...revRepos, isInProgress: false });
-      dispatch(clearCheckedRevisionforType({ searchType: 'base' }));
-    }
+  const handleCancelNew = () => {
+    setInProgressNew({ ...revRepos, isInProgress: false });
+    dispatch(clearCheckedRevisionforType({ searchType: 'new' }));
+  };
 
-    if (!isBase) {
-      setInProgressNew({ ...revRepos, isInProgress: false });
-      dispatch(clearCheckedRevisionforType({ searchType: 'new' }));
+  const handleSaveBase = () => {
+    setStagingBase(baseInProgress);
+    handleCancelBase();
+  };
+
+  const handleSaveNew = () => {
+    setStagingNew(newInProgress);
+    handleCancelNew();
+  };
+
+  const handleDisplayedRevisionsBase = () => {
+    if (baseInProgress.isInProgress) {
+      setDisplayedRevisionsBase(baseInProgress);
+    } else {
+      setDisplayedRevisionsBase(baseStaging);
     }
   };
 
-  const handleSave = (isBase: boolean) => {
-    if (isBase) {
-      setStagingBase(baseInProgress);
-      handleCancel(true);
-    }
-
-    if (!isBase) {
-      setStagingNew(newInProgress);
-      handleCancel(false);
-    }
-  };
-  const handleDisplayedRevisions = (isBase: boolean) => {
-    if (isBase) {
-      if (baseInProgress.isInProgress) {
-        setDisplayedRevisionsBase(baseInProgress);
-      } else {
-        setDisplayedRevisionsBase(baseStaging);
-      }
-    }
-    if (!isBase) {
-      if (newInProgress.isInProgress) {
-        setDisplayedRevisionsNew(newInProgress);
-      } else {
-        setDisplayedRevisionsNew(newStaging);
-      }
+  const handleDisplayedRevisionsNew = () => {
+    if (newInProgress.isInProgress) {
+      setDisplayedRevisionsNew(newInProgress);
+    } else {
+      setDisplayedRevisionsNew(newStaging);
     }
   };
 
-  const handleEdit = (isBase: boolean) => {
-    if (isBase) {
-      setInProgressBase({
-        ...baseStaging,
-        isInProgress: true,
-      });
-      handleDisplayedRevisions(true);
-    }
-
-    if (!isBase) {
-      setInProgressNew({
-        ...newStaging,
-        isInProgress: true,
-      });
-      handleDisplayedRevisions(true);
-    }
+  const handleEditBase = () => {
+    setInProgressBase({
+      ...baseStaging,
+      isInProgress: true,
+    });
+    handleDisplayedRevisionsBase();
   };
 
-  const handleRemoveEditViewRevision = (
-    isBase: boolean,
-    item: RevisionsList,
-  ) => {
+  const handleEditNew = () => {
+    setInProgressNew({
+      ...newStaging,
+      isInProgress: true,
+    });
+    handleDisplayedRevisionsNew();
+  };
+
+  const handleRemoveEditViewRevisionBase = (item: RevisionsList) => {
     const revisionsBase = [...baseInProgress.revs];
-    const revisionsNew = [...newInProgress.revs];
-
-    if (isBase) {
-      revisionsBase.splice(baseInProgress.revs.indexOf(item), 1);
-      setInProgressBase({
-        revs: revisionsBase,
-        repos: baseInProgress.repos,
-        isInProgress: true,
-      });
-    }
-
-    if (!isBase) {
-      revisionsNew.splice(newInProgress.revs.indexOf(item), 1);
-      setInProgressNew({
-        revs: revisionsNew,
-        repos: newInProgress.repos,
-        isInProgress: true,
-      });
-    }
+    revisionsBase.splice(baseInProgress.revs.indexOf(item), 1);
+    setInProgressBase({
+      revs: revisionsBase,
+      repos: baseInProgress.repos,
+      isInProgress: true,
+    });
   };
 
-  const handleSearchResultsEditToggle = (
-    isBase: boolean,
-    toggleArray: RevisionsList[],
-  ) => {
+  const handleRemoveEditViewRevisionNew = (item: RevisionsList) => {
+    const revisionsNew = [...newInProgress.revs];
+    revisionsNew.splice(newInProgress.revs.indexOf(item), 1);
+    setInProgressNew({
+      revs: revisionsNew,
+      repos: newInProgress.repos,
+      isInProgress: true,
+    });
+  };
+
+  const handleSearchResultsEditToggleBase = (toggleArray: RevisionsList[]) => {
     const repos = toggleArray.map((rev) => repoMap[rev.repository_id] ?? 'try');
+    setInProgressBase({
+      revs: toggleArray || [],
+      repos,
+      isInProgress: true,
+    });
+  };
 
-    if (isBase) {
-      setInProgressBase({
-        revs: toggleArray || [],
-        repos,
-        isInProgress: true,
-      });
-    }
-
-    if (!isBase) {
-      setInProgressNew({
-        revs: toggleArray || [],
-        repos,
-        isInProgress: true,
-      });
-    }
+  const handleSearchResultsEditToggleNew = (toggleArray: RevisionsList[]) => {
+    const repos = toggleArray.map((rev) => repoMap[rev.repository_id] ?? 'try');
+    setInProgressNew({
+      revs: toggleArray || [],
+      repos,
+      isInProgress: true,
+    });
   };
 
   return (
@@ -281,12 +263,12 @@ function CompareWithBase({
             isWarning={isWarning}
             isEditable={isEditable}
             searchResults={searchResultsBase}
-            handleSave={handleSave}
-            handleCancel={handleCancel}
-            handleEdit={handleEdit}
-            handleSearchResultsEditToggle={handleSearchResultsEditToggle}
-            handleRemoveEditViewRevision={handleRemoveEditViewRevision}
             displayedRevisions={displayedRevisionsBase}
+            handleSave={handleSaveBase}
+            handleCancel={handleCancelBase}
+            handleEdit={handleEditBase}
+            handleSearchResultsEditToggle={handleSearchResultsEditToggleBase}
+            handleRemoveEditViewRevision={handleRemoveEditViewRevisionBase}
           />
           <SearchComponent
             {...stringsNew}
@@ -294,12 +276,12 @@ function CompareWithBase({
             isEditable={isEditable}
             isWarning={isWarning}
             searchResults={searchResultsNew}
-            handleSave={handleSave}
-            handleCancel={handleCancel}
-            handleEdit={handleEdit}
-            handleSearchResultsEditToggle={handleSearchResultsEditToggle}
-            handleRemoveEditViewRevision={handleRemoveEditViewRevision}
             displayedRevisions={displayedRevisionsNew}
+            handleSave={handleSaveNew}
+            handleCancel={handleCancelNew}
+            handleEdit={handleEditNew}
+            handleSearchResultsEditToggle={handleSearchResultsEditToggleNew}
+            handleRemoveEditViewRevision={handleRemoveEditViewRevisionNew}
           />
           <Grid
             item

--- a/src/components/Search/SearchComponent.tsx
+++ b/src/components/Search/SearchComponent.tsx
@@ -41,14 +41,11 @@ interface SearchProps {
   searchResults: RevisionsList[];
   displayedRevisions: RevisionsState;
   setPopoverIsOpen?: Dispatch<SetStateAction<boolean>>;
-  handleSave: (isBase: boolean) => void;
-  handleCancel: (isBase: boolean) => void;
-  handleEdit: (isBase: boolean) => void;
-  handleSearchResultsEditToggle: (
-    isBase: boolean,
-    toggleArray: RevisionsList[],
-  ) => void;
-  handleRemoveEditViewRevision: (isBase: boolean, item: RevisionsList) => void;
+  handleSave: () => void;
+  handleCancel: () => void;
+  handleEdit: () => void;
+  handleSearchResultsEditToggle: (toggleArray: RevisionsList[]) => void;
+  handleRemoveEditViewRevision: (item: RevisionsList) => void;
   prevRevision?: RevisionsList;
   selectLabel: string;
   tooltip: string;
@@ -120,34 +117,6 @@ function SearchComponent({
     }
   };
 
-  const onCancel = () => {
-    if (isBaseComp) handleCancel(true);
-    if (!isBaseComp) handleCancel(false);
-    setFormIsDisplayed(false);
-  };
-
-  const onSave = () => {
-    if (isBaseComp) handleSave(true);
-    if (!isBaseComp) handleSave(false);
-    setFormIsDisplayed(false);
-  };
-
-  const onEdit = () => {
-    if (isBaseComp) handleEdit(true);
-    if (!isBaseComp) handleEdit(false);
-    setFormIsDisplayed(true);
-  };
-
-  const onResultsListEditToggle = (toggleArray: RevisionsList[]) => {
-    if (isBaseComp) handleSearchResultsEditToggle(true, toggleArray);
-    if (!isBaseComp) handleSearchResultsEditToggle(false, toggleArray);
-  };
-
-  const onEditRemove = (item: RevisionsList) => {
-    if (isBaseComp) handleRemoveEditViewRevision(true, item);
-    if (!isBaseComp) handleRemoveEditViewRevision(false, item);
-  };
-
   useEffect(() => {
     document.addEventListener('mousedown', handleDocumentMousedown);
     return () => {
@@ -182,7 +151,13 @@ function SearchComponent({
         </InputLabel>
         {/**** Edit Button ****/}
         {isEditable && !formIsDisplayed && (
-          <EditButton isBase={isBaseComp} onEditAction={onEdit} />
+          <EditButton
+            isBase={isBaseComp}
+            onEditAction={() => {
+              handleEdit();
+              setFormIsDisplayed(true);
+            }}
+          />
         )}
       </Grid>
       {/**** Search - DropDown Section ****/}
@@ -229,7 +204,7 @@ function SearchComponent({
               isBase={isBaseComp}
               searchResults={searchResults}
               displayedRevisions={displayedRevisions}
-              onEditToggle={onResultsListEditToggle}
+              onEditToggle={handleSearchResultsEditToggle}
             />
           )}
         </Grid>
@@ -237,8 +212,14 @@ function SearchComponent({
         {isEditable && formIsDisplayed && (
           <SaveCancelButtons
             searchType={searchType}
-            onSave={onSave}
-            onCancel={onCancel}
+            onSave={() => {
+              handleSave();
+              setFormIsDisplayed(false);
+            }}
+            onCancel={() => {
+              handleCancel();
+              setFormIsDisplayed(false);
+            }}
           />
         )}
       </Grid>
@@ -251,7 +232,7 @@ function SearchComponent({
             formIsDisplayed={formIsDisplayed}
             isWarning={isWarning}
             displayedRevisions={displayedRevisions}
-            onEditRemove={onEditRemove}
+            onEditRemove={handleRemoveEditViewRevision}
           />
         </Grid>
       )}


### PR DESCRIPTION
@julienw, I kept the `isBaseComp` for styling reasons. Otherwise, it's removed from any state updates.  In a new patch, I'll redo the styles so we can eliminate the prop completely. 