### PR TITLE
Use a more recent jsdom with Jest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "html-webpack-plugin": "^5.5.0",
         "jest": "^28.1.3",
         "jest-axe": "^6.0.0",
-        "jest-environment-jsdom": "^28.1.2",
+        "jest-environment-jsdom": "^30.0.0-alpha.3",
         "jest-resolve": "^28.1.3",
         "jest-watch-typeahead": "^2.0.0",
         "npm-run-all2": "^6.0.6",
@@ -2891,6 +2891,292 @@
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
+    "node_modules/@jest/environment-jsdom-abstract": {
+      "version": "30.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.0.0-alpha.3.tgz",
+      "integrity": "sha512-pHKCxJD2ADZtugRBChxDSK/ZyykW60tCITE6wdv6EUjz2qZpzXZzfyohm/1HuIiiXO4qgpV0J19YfwoRuhvD8Q==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "30.0.0-alpha.3",
+        "@jest/fake-timers": "30.0.0-alpha.3",
+        "@jest/types": "30.0.0-alpha.3",
+        "@types/jsdom": "^21.1.1",
+        "@types/node": "*",
+        "jest-mock": "30.0.0-alpha.3",
+        "jest-util": "30.0.0-alpha.3"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/environment": {
+      "version": "30.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.0.0-alpha.3.tgz",
+      "integrity": "sha512-AcJ9kUhN0lVlm/cJCr59AUrsqT2ZlszG1W+ENssqkueQLObCkpv5Jpv5ISM1F2FOt136OG0vLMTAp+V+r+gPYA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/fake-timers": "30.0.0-alpha.3",
+        "@jest/types": "30.0.0-alpha.3",
+        "@types/node": "*",
+        "jest-mock": "30.0.0-alpha.3"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/fake-timers": {
+      "version": "30.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.0.0-alpha.3.tgz",
+      "integrity": "sha512-B9Oov0Bk1YRJaawZEcwXuupHIViX49pZhghdN+m1KFwuZ9smstD9VI9gXFBRtF1fHNu+1HmtD361LuDEHifzIw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "30.0.0-alpha.3",
+        "@sinonjs/fake-timers": "^11.1.0",
+        "@types/node": "*",
+        "jest-message-util": "30.0.0-alpha.3",
+        "jest-mock": "30.0.0-alpha.3",
+        "jest-util": "30.0.0-alpha.3"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/schemas": {
+      "version": "30.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.0-alpha.3.tgz",
+      "integrity": "sha512-7C75tiHmJcycvqQcRVIyTHOW45uj63SOnZbRaNRBLMFB6NOfzQz98F6Hgo832G0EfdY0ZuSRnoaXH7Fybd4epQ==",
+      "dev": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.32.1"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/types": {
+      "version": "30.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.0-alpha.3.tgz",
+      "integrity": "sha512-z8oValFWEGDRslYtcU+4rgTPin8NyHuXaOrDWWDCIrYWPISaa7CLrdA6tS6o1GnywHH7kgYMCpb39cMsqP4R8w==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "30.0.0-alpha.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@sinclair/typebox": {
+      "version": "0.32.14",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.32.14.tgz",
+      "integrity": "sha512-EC77Mw8huT2z9YlYbWfpIQgN6shZE1tH4NP4/Trig8UBel9FZNMZRJ42ubJI8PLor2uIU+waLml1dce5ReCOPg==",
+      "dev": true
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/@sinonjs/fake-timers": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/ci-info": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.0.0.tgz",
+      "integrity": "sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/jest-message-util": {
+      "version": "30.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.0.0-alpha.3.tgz",
+      "integrity": "sha512-+/Ajvi4E/0xI1gbX3q1cNTnRiweAWvsruZo/WaL1zNutu8LlMn/1p1CJAVI4jxIr9E6CMDOVSvScTsnDU5L9iQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "30.0.0-alpha.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "30.0.0-alpha.3",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/jest-mock": {
+      "version": "30.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.0.0-alpha.3.tgz",
+      "integrity": "sha512-hDIm/0ITW/WIyFudj9Dz9eS+vg9tgw51dab4Ild6ME7kBZXQS4AMgXf1AoqQY0amSyxnIZ17G7RLKft88cvkRQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "30.0.0-alpha.3",
+        "@types/node": "*",
+        "jest-util": "30.0.0-alpha.3"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/jest-util": {
+      "version": "30.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.0.0-alpha.3.tgz",
+      "integrity": "sha512-5562Xr2X8UeJL12W2UR1Mj1/Z78wPm8erPoaS29ksMh0IsDe2dVboJld0zLOulcm6zTAqHbgphCOGLDsTbG14A==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "30.0.0-alpha.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^3.0.0"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/picomatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.1.tgz",
+      "integrity": "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/pretty-format": {
+      "version": "30.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.0-alpha.3.tgz",
+      "integrity": "sha512-b1mhTF/vbYJaXOdRY0nFMwzHHpWCs0QNYJA5ImcOpQ99QZqCHqU8C+lbGoWwC3X9QEjAYJ+N5+Vmc/MXbXCZDA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "30.0.0-alpha.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jest/expect": {
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-28.1.3.tgz",
@@ -4550,14 +4836,14 @@
       }
     },
     "node_modules/@types/jsdom": {
-      "version": "16.2.15",
-      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-16.2.15.tgz",
-      "integrity": "sha512-nwF87yjBKuX/roqGYerZZM0Nv1pZDMAT5YhOHYeM/72Fic+VEqJh4nyoqoapzJnW3pUlfxPY5FhgsJtM+dRnQQ==",
+      "version": "21.1.6",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.6.tgz",
+      "integrity": "sha512-/7kkMsC+/kMs7gAYmmBR9P0vGTnOoLhQhyhQJSlXGI5bzTHp6xdo0TtKWQAsz6pmSAeVqKSbqeyP6hytqr9FDw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "@types/parse5": "^6.0.3",
-        "@types/tough-cookie": "*"
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
       }
     },
     "node_modules/@types/json-schema": {
@@ -4604,12 +4890,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
-    },
-    "node_modules/@types/parse5": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
-      "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==",
-      "dev": true
     },
     "node_modules/@types/prettier": {
       "version": "2.6.3",
@@ -4738,9 +5018,9 @@
       }
     },
     "node_modules/@types/tough-cookie": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
-      "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true
     },
     "node_modules/@types/use-sync-external-store": {
@@ -5173,6 +5453,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+      "deprecated": "Use your platform's native atob() and btoa() methods instead",
       "dev": true
     },
     "node_modules/accepts": {
@@ -5198,28 +5479,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/acorn-globals": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
-      "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^7.1.1",
-        "acorn-walk": "^7.1.1"
-      }
-    },
-    "node_modules/acorn-globals/node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/acorn-import-assertions": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
@@ -5235,15 +5494,6 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
-      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -5934,12 +6184,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/browser-process-hrtime": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
-      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
-      "dev": true
     },
     "node_modules/browserslist": {
       "version": "4.21.9",
@@ -6654,29 +6898,17 @@
         "node": ">=4"
       }
     },
-    "node_modules/cssom": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
-      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
-      "dev": true
-    },
     "node_modules/cssstyle": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-3.0.0.tgz",
+      "integrity": "sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==",
       "dev": true,
       "dependencies": {
-        "cssom": "~0.3.6"
+        "rrweb-cssom": "^0.6.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=14"
       }
-    },
-    "node_modules/cssstyle/node_modules/cssom": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
-      "dev": true
     },
     "node_modules/csstype": {
       "version": "3.1.1",
@@ -6709,30 +6941,17 @@
       }
     },
     "node_modules/data-urls": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
-      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-4.0.0.tgz",
+      "integrity": "sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==",
       "dev": true,
       "dependencies": {
         "abab": "^2.0.6",
         "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^11.0.0"
+        "whatwg-url": "^12.0.0"
       },
       "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/data-urls/node_modules/whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-      "dev": true,
-      "dependencies": {
-        "tr46": "^3.0.0",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/dayjs": {
@@ -6757,9 +6976,9 @@
       }
     },
     "node_modules/decimal.js": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
-      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
       "dev": true
     },
     "node_modules/decode-uri-component": {
@@ -6981,6 +7200,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
       "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "deprecated": "Use your platform's native DOMException instead",
       "dev": true,
       "dependencies": {
         "webidl-conversions": "^7.0.0"
@@ -7239,89 +7459,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/escodegen": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
-      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
-      "dev": true,
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/escodegen/node_modules/levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-      "dev": true,
-      "dependencies": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "dev": true,
-      "dependencies": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-      "dev": true,
-      "dependencies": {
-        "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/eslint": {
@@ -10863,22 +11000,286 @@
       }
     },
     "node_modules/jest-environment-jsdom": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-28.1.3.tgz",
-      "integrity": "sha512-HnlGUmZRdxfCByd3GM2F100DgQOajUBzEitjGqIREcb45kGjZvRrKUdlaF6escXBdcXNl0OBh+1ZrfeZT3GnAg==",
+      "version": "30.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.0.0-alpha.3.tgz",
+      "integrity": "sha512-n/xk8YlZvyvJQXHSrH8Z6oiAgN1R0ocGF81z8FMMZrTrm1KpoqagKmGaUzIWekA0RZhIO5eBQa6rYcwzHptukA==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^28.1.3",
-        "@jest/fake-timers": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "@types/jsdom": "^16.2.4",
+        "@jest/environment": "30.0.0-alpha.3",
+        "@jest/environment-jsdom-abstract": "30.0.0-alpha.3",
+        "@types/jsdom": "^21.1.1",
         "@types/node": "*",
-        "jest-mock": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "jsdom": "^19.0.0"
+        "jsdom": "^22.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@jest/environment": {
+      "version": "30.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.0.0-alpha.3.tgz",
+      "integrity": "sha512-AcJ9kUhN0lVlm/cJCr59AUrsqT2ZlszG1W+ENssqkueQLObCkpv5Jpv5ISM1F2FOt136OG0vLMTAp+V+r+gPYA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/fake-timers": "30.0.0-alpha.3",
+        "@jest/types": "30.0.0-alpha.3",
+        "@types/node": "*",
+        "jest-mock": "30.0.0-alpha.3"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@jest/fake-timers": {
+      "version": "30.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.0.0-alpha.3.tgz",
+      "integrity": "sha512-B9Oov0Bk1YRJaawZEcwXuupHIViX49pZhghdN+m1KFwuZ9smstD9VI9gXFBRtF1fHNu+1HmtD361LuDEHifzIw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "30.0.0-alpha.3",
+        "@sinonjs/fake-timers": "^11.1.0",
+        "@types/node": "*",
+        "jest-message-util": "30.0.0-alpha.3",
+        "jest-mock": "30.0.0-alpha.3",
+        "jest-util": "30.0.0-alpha.3"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@jest/schemas": {
+      "version": "30.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.0-alpha.3.tgz",
+      "integrity": "sha512-7C75tiHmJcycvqQcRVIyTHOW45uj63SOnZbRaNRBLMFB6NOfzQz98F6Hgo832G0EfdY0ZuSRnoaXH7Fybd4epQ==",
+      "dev": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.32.1"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@jest/types": {
+      "version": "30.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.0-alpha.3.tgz",
+      "integrity": "sha512-z8oValFWEGDRslYtcU+4rgTPin8NyHuXaOrDWWDCIrYWPISaa7CLrdA6tS6o1GnywHH7kgYMCpb39cMsqP4R8w==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "30.0.0-alpha.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@sinclair/typebox": {
+      "version": "0.32.14",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.32.14.tgz",
+      "integrity": "sha512-EC77Mw8huT2z9YlYbWfpIQgN6shZE1tH4NP4/Trig8UBel9FZNMZRJ42ubJI8PLor2uIU+waLml1dce5ReCOPg==",
+      "dev": true
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/@sinonjs/fake-timers": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/ci-info": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.0.0.tgz",
+      "integrity": "sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-environment-jsdom/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/jest-message-util": {
+      "version": "30.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.0.0-alpha.3.tgz",
+      "integrity": "sha512-+/Ajvi4E/0xI1gbX3q1cNTnRiweAWvsruZo/WaL1zNutu8LlMn/1p1CJAVI4jxIr9E6CMDOVSvScTsnDU5L9iQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "30.0.0-alpha.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "30.0.0-alpha.3",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/jest-mock": {
+      "version": "30.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.0.0-alpha.3.tgz",
+      "integrity": "sha512-hDIm/0ITW/WIyFudj9Dz9eS+vg9tgw51dab4Ild6ME7kBZXQS4AMgXf1AoqQY0amSyxnIZ17G7RLKft88cvkRQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "30.0.0-alpha.3",
+        "@types/node": "*",
+        "jest-util": "30.0.0-alpha.3"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/jest-util": {
+      "version": "30.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.0.0-alpha.3.tgz",
+      "integrity": "sha512-5562Xr2X8UeJL12W2UR1Mj1/Z78wPm8erPoaS29ksMh0IsDe2dVboJld0zLOulcm6zTAqHbgphCOGLDsTbG14A==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "30.0.0-alpha.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^3.0.0"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/picomatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.1.tgz",
+      "integrity": "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/pretty-format": {
+      "version": "30.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.0-alpha.3.tgz",
+      "integrity": "sha512-b1mhTF/vbYJaXOdRY0nFMwzHHpWCs0QNYJA5ImcOpQ99QZqCHqU8C+lbGoWwC3X9QEjAYJ+N5+Vmc/MXbXCZDA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "30.0.0-alpha.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jest-environment-node": {
@@ -12467,41 +12868,37 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-19.0.0.tgz",
-      "integrity": "sha512-RYAyjCbxy/vri/CfnjUWJQQtZ3LKlLnDqj+9XLNnJPgEGeirZs3hllKR20re8LUZ6o1b1X4Jat+Qd26zmP41+A==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-22.1.0.tgz",
+      "integrity": "sha512-/9AVW7xNbsBv6GfWho4TTNjEo9fe6Zhf9O7s0Fhhr3u+awPwAJMKwAMXnkk5vBxflqLW9hTHX/0cs+P3gW+cQw==",
       "dev": true,
       "dependencies": {
-        "abab": "^2.0.5",
-        "acorn": "^8.5.0",
-        "acorn-globals": "^6.0.0",
-        "cssom": "^0.5.0",
-        "cssstyle": "^2.3.0",
-        "data-urls": "^3.0.1",
-        "decimal.js": "^10.3.1",
+        "abab": "^2.0.6",
+        "cssstyle": "^3.0.0",
+        "data-urls": "^4.0.0",
+        "decimal.js": "^10.4.3",
         "domexception": "^4.0.0",
-        "escodegen": "^2.0.0",
         "form-data": "^4.0.0",
         "html-encoding-sniffer": "^3.0.0",
         "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
         "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.0",
-        "parse5": "6.0.1",
-        "saxes": "^5.0.1",
+        "nwsapi": "^2.2.4",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.6.0",
+        "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.0.0",
-        "w3c-hr-time": "^1.0.2",
-        "w3c-xmlserializer": "^3.0.0",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
         "webidl-conversions": "^7.0.0",
         "whatwg-encoding": "^2.0.0",
         "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^10.0.0",
-        "ws": "^8.2.3",
+        "whatwg-url": "^12.0.1",
+        "ws": "^8.13.0",
         "xml-name-validator": "^4.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=16"
       },
       "peerDependencies": {
         "canvas": "^2.5.0"
@@ -13190,9 +13587,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.1.tgz",
-      "integrity": "sha512-JYOWTeFoS0Z93587vRJgASD5Ut11fYl5NyihP3KrYBvMe1FRRs6RN7m20SA/16GM4P6hTnZjT+UmDOt38UeXNg==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
+      "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==",
       "dev": true
     },
     "node_modules/object-assign": {
@@ -13499,10 +13896,28 @@
       }
     },
     "node_modules/parse5": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-      "dev": true
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -14520,6 +14935,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
+      "dev": true
+    },
     "node_modules/run": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/run/-/run-1.4.0.tgz",
@@ -14582,15 +15003,15 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/saxes": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
-      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "dev": true,
       "dependencies": {
         "xmlchars": "^2.2.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -15573,15 +15994,15 @@
       }
     },
     "node_modules/tr46": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
       "dev": true,
       "dependencies": {
-        "punycode": "^2.1.1"
+        "punycode": "^2.3.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/ts-jest": {
@@ -16125,25 +16546,16 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/w3c-hr-time": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
-      "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
-      "dev": true,
-      "dependencies": {
-        "browser-process-hrtime": "^1.0.0"
-      }
-    },
     "node_modules/w3c-xmlserializer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-3.0.0.tgz",
-      "integrity": "sha512-3WFqGEgSXIyGhOmAFtlicJNMjEps8b1MG31NCA0/vOF9+nKMUW1ckhi9cnNHmf88Rzw5V+dwIwsm2C7X8k9aQg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
       "dev": true,
       "dependencies": {
         "xml-name-validator": "^4.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/walker": {
@@ -16629,16 +17041,16 @@
       }
     },
     "node_modules/whatwg-url": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-10.0.0.tgz",
-      "integrity": "sha512-CLxxCmdUby142H5FZzn4D8ikO1cmypvXVQktsgosNy4a4BHrDHeciBBGZhb0bNoR5/MltoCatso+vFjjGx8t0w==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
+      "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
       "dev": true,
       "dependencies": {
-        "tr46": "^3.0.0",
+        "tr46": "^4.1.1",
         "webidl-conversions": "^7.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/which": {
@@ -16774,16 +17186,16 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
-      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -18884,6 +19296,218 @@
         "jest-mock": "^28.1.3"
       }
     },
+    "@jest/environment-jsdom-abstract": {
+      "version": "30.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.0.0-alpha.3.tgz",
+      "integrity": "sha512-pHKCxJD2ADZtugRBChxDSK/ZyykW60tCITE6wdv6EUjz2qZpzXZzfyohm/1HuIiiXO4qgpV0J19YfwoRuhvD8Q==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "30.0.0-alpha.3",
+        "@jest/fake-timers": "30.0.0-alpha.3",
+        "@jest/types": "30.0.0-alpha.3",
+        "@types/jsdom": "^21.1.1",
+        "@types/node": "*",
+        "jest-mock": "30.0.0-alpha.3",
+        "jest-util": "30.0.0-alpha.3"
+      },
+      "dependencies": {
+        "@jest/environment": {
+          "version": "30.0.0-alpha.3",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.0.0-alpha.3.tgz",
+          "integrity": "sha512-AcJ9kUhN0lVlm/cJCr59AUrsqT2ZlszG1W+ENssqkueQLObCkpv5Jpv5ISM1F2FOt136OG0vLMTAp+V+r+gPYA==",
+          "dev": true,
+          "requires": {
+            "@jest/fake-timers": "30.0.0-alpha.3",
+            "@jest/types": "30.0.0-alpha.3",
+            "@types/node": "*",
+            "jest-mock": "30.0.0-alpha.3"
+          }
+        },
+        "@jest/fake-timers": {
+          "version": "30.0.0-alpha.3",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.0.0-alpha.3.tgz",
+          "integrity": "sha512-B9Oov0Bk1YRJaawZEcwXuupHIViX49pZhghdN+m1KFwuZ9smstD9VI9gXFBRtF1fHNu+1HmtD361LuDEHifzIw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "30.0.0-alpha.3",
+            "@sinonjs/fake-timers": "^11.1.0",
+            "@types/node": "*",
+            "jest-message-util": "30.0.0-alpha.3",
+            "jest-mock": "30.0.0-alpha.3",
+            "jest-util": "30.0.0-alpha.3"
+          }
+        },
+        "@jest/schemas": {
+          "version": "30.0.0-alpha.3",
+          "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.0-alpha.3.tgz",
+          "integrity": "sha512-7C75tiHmJcycvqQcRVIyTHOW45uj63SOnZbRaNRBLMFB6NOfzQz98F6Hgo832G0EfdY0ZuSRnoaXH7Fybd4epQ==",
+          "dev": true,
+          "requires": {
+            "@sinclair/typebox": "^0.32.1"
+          }
+        },
+        "@jest/types": {
+          "version": "30.0.0-alpha.3",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.0-alpha.3.tgz",
+          "integrity": "sha512-z8oValFWEGDRslYtcU+4rgTPin8NyHuXaOrDWWDCIrYWPISaa7CLrdA6tS6o1GnywHH7kgYMCpb39cMsqP4R8w==",
+          "dev": true,
+          "requires": {
+            "@jest/schemas": "30.0.0-alpha.3",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^17.0.8",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@sinclair/typebox": {
+          "version": "0.32.14",
+          "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.32.14.tgz",
+          "integrity": "sha512-EC77Mw8huT2z9YlYbWfpIQgN6shZE1tH4NP4/Trig8UBel9FZNMZRJ42ubJI8PLor2uIU+waLml1dce5ReCOPg==",
+          "dev": true
+        },
+        "@sinonjs/commons": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+          "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+          "dev": true,
+          "requires": {
+            "type-detect": "4.0.8"
+          }
+        },
+        "@sinonjs/fake-timers": {
+          "version": "11.2.2",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+          "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^3.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "ci-info": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.0.0.tgz",
+          "integrity": "sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg==",
+          "dev": true
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-message-util": {
+          "version": "30.0.0-alpha.3",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.0.0-alpha.3.tgz",
+          "integrity": "sha512-+/Ajvi4E/0xI1gbX3q1cNTnRiweAWvsruZo/WaL1zNutu8LlMn/1p1CJAVI4jxIr9E6CMDOVSvScTsnDU5L9iQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.12.13",
+            "@jest/types": "30.0.0-alpha.3",
+            "@types/stack-utils": "^2.0.0",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.9",
+            "micromatch": "^4.0.4",
+            "pretty-format": "30.0.0-alpha.3",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.3"
+          }
+        },
+        "jest-mock": {
+          "version": "30.0.0-alpha.3",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.0.0-alpha.3.tgz",
+          "integrity": "sha512-hDIm/0ITW/WIyFudj9Dz9eS+vg9tgw51dab4Ild6ME7kBZXQS4AMgXf1AoqQY0amSyxnIZ17G7RLKft88cvkRQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "30.0.0-alpha.3",
+            "@types/node": "*",
+            "jest-util": "30.0.0-alpha.3"
+          }
+        },
+        "jest-util": {
+          "version": "30.0.0-alpha.3",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.0.0-alpha.3.tgz",
+          "integrity": "sha512-5562Xr2X8UeJL12W2UR1Mj1/Z78wPm8erPoaS29ksMh0IsDe2dVboJld0zLOulcm6zTAqHbgphCOGLDsTbG14A==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "30.0.0-alpha.3",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^4.0.0",
+            "graceful-fs": "^4.2.9",
+            "picomatch": "^3.0.0"
+          }
+        },
+        "picomatch": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.1.tgz",
+          "integrity": "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "30.0.0-alpha.3",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.0-alpha.3.tgz",
+          "integrity": "sha512-b1mhTF/vbYJaXOdRY0nFMwzHHpWCs0QNYJA5ImcOpQ99QZqCHqU8C+lbGoWwC3X9QEjAYJ+N5+Vmc/MXbXCZDA==",
+          "dev": true,
+          "requires": {
+            "@jest/schemas": "30.0.0-alpha.3",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^18.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+              "dev": true
+            }
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@jest/expect": {
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-28.1.3.tgz",
@@ -20071,14 +20695,14 @@
       }
     },
     "@types/jsdom": {
-      "version": "16.2.15",
-      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-16.2.15.tgz",
-      "integrity": "sha512-nwF87yjBKuX/roqGYerZZM0Nv1pZDMAT5YhOHYeM/72Fic+VEqJh4nyoqoapzJnW3pUlfxPY5FhgsJtM+dRnQQ==",
+      "version": "21.1.6",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.6.tgz",
+      "integrity": "sha512-/7kkMsC+/kMs7gAYmmBR9P0vGTnOoLhQhyhQJSlXGI5bzTHp6xdo0TtKWQAsz6pmSAeVqKSbqeyP6hytqr9FDw==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "@types/parse5": "^6.0.3",
-        "@types/tough-cookie": "*"
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
       }
     },
     "@types/json-schema": {
@@ -20125,12 +20749,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
-    },
-    "@types/parse5": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
-      "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==",
-      "dev": true
     },
     "@types/prettier": {
       "version": "2.6.3",
@@ -20259,9 +20877,9 @@
       }
     },
     "@types/tough-cookie": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
-      "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true
     },
     "@types/use-sync-external-store": {
@@ -20598,24 +21216,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
       "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A=="
     },
-    "acorn-globals": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
-      "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
-      "dev": true,
-      "requires": {
-        "acorn": "^7.1.1",
-        "acorn-walk": "^7.1.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "7.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-          "dev": true
-        }
-      }
-    },
     "acorn-import-assertions": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
@@ -20628,12 +21228,6 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "requires": {}
-    },
-    "acorn-walk": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
-      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
-      "dev": true
     },
     "agent-base": {
       "version": "6.0.2",
@@ -21167,12 +21761,6 @@
         "fill-range": "^7.0.1"
       }
     },
-    "browser-process-hrtime": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
-      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
-      "dev": true
-    },
     "browserslist": {
       "version": "4.21.9",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
@@ -21693,27 +22281,13 @@
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
     },
-    "cssom": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
-      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
-      "dev": true
-    },
     "cssstyle": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-3.0.0.tgz",
+      "integrity": "sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==",
       "dev": true,
       "requires": {
-        "cssom": "~0.3.6"
-      },
-      "dependencies": {
-        "cssom": {
-          "version": "0.3.8",
-          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
-          "dev": true
-        }
+        "rrweb-cssom": "^0.6.0"
       }
     },
     "csstype": {
@@ -21741,26 +22315,14 @@
       "peer": true
     },
     "data-urls": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
-      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-4.0.0.tgz",
+      "integrity": "sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==",
       "dev": true,
       "requires": {
         "abab": "^2.0.6",
         "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^11.0.0"
-      },
-      "dependencies": {
-        "whatwg-url": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-          "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-          "dev": true,
-          "requires": {
-            "tr46": "^3.0.0",
-            "webidl-conversions": "^7.0.0"
-          }
-        }
+        "whatwg-url": "^12.0.0"
       }
     },
     "dayjs": {
@@ -21777,9 +22339,9 @@
       }
     },
     "decimal.js": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
-      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
       "dev": true
     },
     "decode-uri-component": {
@@ -22147,67 +22709,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
-    },
-    "escodegen": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
-      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
-      "dev": true,
-      "requires": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "levn": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-          "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-          "dev": true,
-          "requires": {
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2"
-          }
-        },
-        "optionator": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-          "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-          "dev": true,
-          "requires": {
-            "deep-is": "~0.1.3",
-            "fast-levenshtein": "~2.0.6",
-            "levn": "~0.3.0",
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2",
-            "word-wrap": "~1.2.3"
-          }
-        },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-          "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
-          "optional": true
-        },
-        "type-check": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-          "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-          "dev": true,
-          "requires": {
-            "prelude-ls": "~1.1.2"
-          }
-        }
-      }
     },
     "eslint": {
       "version": "8.20.0",
@@ -24733,19 +25234,213 @@
       }
     },
     "jest-environment-jsdom": {
-      "version": "28.1.3",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-28.1.3.tgz",
-      "integrity": "sha512-HnlGUmZRdxfCByd3GM2F100DgQOajUBzEitjGqIREcb45kGjZvRrKUdlaF6escXBdcXNl0OBh+1ZrfeZT3GnAg==",
+      "version": "30.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.0.0-alpha.3.tgz",
+      "integrity": "sha512-n/xk8YlZvyvJQXHSrH8Z6oiAgN1R0ocGF81z8FMMZrTrm1KpoqagKmGaUzIWekA0RZhIO5eBQa6rYcwzHptukA==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^28.1.3",
-        "@jest/fake-timers": "^28.1.3",
-        "@jest/types": "^28.1.3",
-        "@types/jsdom": "^16.2.4",
+        "@jest/environment": "30.0.0-alpha.3",
+        "@jest/environment-jsdom-abstract": "30.0.0-alpha.3",
+        "@types/jsdom": "^21.1.1",
         "@types/node": "*",
-        "jest-mock": "^28.1.3",
-        "jest-util": "^28.1.3",
-        "jsdom": "^19.0.0"
+        "jsdom": "^22.0.0"
+      },
+      "dependencies": {
+        "@jest/environment": {
+          "version": "30.0.0-alpha.3",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.0.0-alpha.3.tgz",
+          "integrity": "sha512-AcJ9kUhN0lVlm/cJCr59AUrsqT2ZlszG1W+ENssqkueQLObCkpv5Jpv5ISM1F2FOt136OG0vLMTAp+V+r+gPYA==",
+          "dev": true,
+          "requires": {
+            "@jest/fake-timers": "30.0.0-alpha.3",
+            "@jest/types": "30.0.0-alpha.3",
+            "@types/node": "*",
+            "jest-mock": "30.0.0-alpha.3"
+          }
+        },
+        "@jest/fake-timers": {
+          "version": "30.0.0-alpha.3",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.0.0-alpha.3.tgz",
+          "integrity": "sha512-B9Oov0Bk1YRJaawZEcwXuupHIViX49pZhghdN+m1KFwuZ9smstD9VI9gXFBRtF1fHNu+1HmtD361LuDEHifzIw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "30.0.0-alpha.3",
+            "@sinonjs/fake-timers": "^11.1.0",
+            "@types/node": "*",
+            "jest-message-util": "30.0.0-alpha.3",
+            "jest-mock": "30.0.0-alpha.3",
+            "jest-util": "30.0.0-alpha.3"
+          }
+        },
+        "@jest/schemas": {
+          "version": "30.0.0-alpha.3",
+          "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.0-alpha.3.tgz",
+          "integrity": "sha512-7C75tiHmJcycvqQcRVIyTHOW45uj63SOnZbRaNRBLMFB6NOfzQz98F6Hgo832G0EfdY0ZuSRnoaXH7Fybd4epQ==",
+          "dev": true,
+          "requires": {
+            "@sinclair/typebox": "^0.32.1"
+          }
+        },
+        "@jest/types": {
+          "version": "30.0.0-alpha.3",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.0-alpha.3.tgz",
+          "integrity": "sha512-z8oValFWEGDRslYtcU+4rgTPin8NyHuXaOrDWWDCIrYWPISaa7CLrdA6tS6o1GnywHH7kgYMCpb39cMsqP4R8w==",
+          "dev": true,
+          "requires": {
+            "@jest/schemas": "30.0.0-alpha.3",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^17.0.8",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@sinclair/typebox": {
+          "version": "0.32.14",
+          "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.32.14.tgz",
+          "integrity": "sha512-EC77Mw8huT2z9YlYbWfpIQgN6shZE1tH4NP4/Trig8UBel9FZNMZRJ42ubJI8PLor2uIU+waLml1dce5ReCOPg==",
+          "dev": true
+        },
+        "@sinonjs/commons": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+          "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+          "dev": true,
+          "requires": {
+            "type-detect": "4.0.8"
+          }
+        },
+        "@sinonjs/fake-timers": {
+          "version": "11.2.2",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+          "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^3.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "ci-info": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.0.0.tgz",
+          "integrity": "sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg==",
+          "dev": true
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-message-util": {
+          "version": "30.0.0-alpha.3",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.0.0-alpha.3.tgz",
+          "integrity": "sha512-+/Ajvi4E/0xI1gbX3q1cNTnRiweAWvsruZo/WaL1zNutu8LlMn/1p1CJAVI4jxIr9E6CMDOVSvScTsnDU5L9iQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.12.13",
+            "@jest/types": "30.0.0-alpha.3",
+            "@types/stack-utils": "^2.0.0",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.9",
+            "micromatch": "^4.0.4",
+            "pretty-format": "30.0.0-alpha.3",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.3"
+          }
+        },
+        "jest-mock": {
+          "version": "30.0.0-alpha.3",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.0.0-alpha.3.tgz",
+          "integrity": "sha512-hDIm/0ITW/WIyFudj9Dz9eS+vg9tgw51dab4Ild6ME7kBZXQS4AMgXf1AoqQY0amSyxnIZ17G7RLKft88cvkRQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "30.0.0-alpha.3",
+            "@types/node": "*",
+            "jest-util": "30.0.0-alpha.3"
+          }
+        },
+        "jest-util": {
+          "version": "30.0.0-alpha.3",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.0.0-alpha.3.tgz",
+          "integrity": "sha512-5562Xr2X8UeJL12W2UR1Mj1/Z78wPm8erPoaS29ksMh0IsDe2dVboJld0zLOulcm6zTAqHbgphCOGLDsTbG14A==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "30.0.0-alpha.3",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^4.0.0",
+            "graceful-fs": "^4.2.9",
+            "picomatch": "^3.0.0"
+          }
+        },
+        "picomatch": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.1.tgz",
+          "integrity": "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "30.0.0-alpha.3",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.0-alpha.3.tgz",
+          "integrity": "sha512-b1mhTF/vbYJaXOdRY0nFMwzHHpWCs0QNYJA5ImcOpQ99QZqCHqU8C+lbGoWwC3X9QEjAYJ+N5+Vmc/MXbXCZDA==",
+          "dev": true,
+          "requires": {
+            "@jest/schemas": "30.0.0-alpha.3",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^18.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+              "dev": true
+            }
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "jest-environment-node": {
@@ -25913,37 +26608,33 @@
       }
     },
     "jsdom": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-19.0.0.tgz",
-      "integrity": "sha512-RYAyjCbxy/vri/CfnjUWJQQtZ3LKlLnDqj+9XLNnJPgEGeirZs3hllKR20re8LUZ6o1b1X4Jat+Qd26zmP41+A==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-22.1.0.tgz",
+      "integrity": "sha512-/9AVW7xNbsBv6GfWho4TTNjEo9fe6Zhf9O7s0Fhhr3u+awPwAJMKwAMXnkk5vBxflqLW9hTHX/0cs+P3gW+cQw==",
       "dev": true,
       "requires": {
-        "abab": "^2.0.5",
-        "acorn": "^8.5.0",
-        "acorn-globals": "^6.0.0",
-        "cssom": "^0.5.0",
-        "cssstyle": "^2.3.0",
-        "data-urls": "^3.0.1",
-        "decimal.js": "^10.3.1",
+        "abab": "^2.0.6",
+        "cssstyle": "^3.0.0",
+        "data-urls": "^4.0.0",
+        "decimal.js": "^10.4.3",
         "domexception": "^4.0.0",
-        "escodegen": "^2.0.0",
         "form-data": "^4.0.0",
         "html-encoding-sniffer": "^3.0.0",
         "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
         "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.0",
-        "parse5": "6.0.1",
-        "saxes": "^5.0.1",
+        "nwsapi": "^2.2.4",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.6.0",
+        "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.0.0",
-        "w3c-hr-time": "^1.0.2",
-        "w3c-xmlserializer": "^3.0.0",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
         "webidl-conversions": "^7.0.0",
         "whatwg-encoding": "^2.0.0",
         "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^10.0.0",
-        "ws": "^8.2.3",
+        "whatwg-url": "^12.0.1",
+        "ws": "^8.13.0",
         "xml-name-validator": "^4.0.0"
       }
     },
@@ -26447,9 +27138,9 @@
       }
     },
     "nwsapi": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.1.tgz",
-      "integrity": "sha512-JYOWTeFoS0Z93587vRJgASD5Ut11fYl5NyihP3KrYBvMe1FRRs6RN7m20SA/16GM4P6hTnZjT+UmDOt38UeXNg==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
+      "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==",
       "dev": true
     },
     "object-assign": {
@@ -26673,10 +27364,21 @@
       }
     },
     "parse5": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-      "dev": true
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dev": true,
+      "requires": {
+        "entities": "^4.4.0"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+          "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+          "dev": true
+        }
+      }
     },
     "parseurl": {
       "version": "1.3.3",
@@ -27397,6 +28099,12 @@
         "glob": "^7.1.3"
       }
     },
+    "rrweb-cssom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
+      "dev": true
+    },
     "run": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/run/-/run-1.4.0.tgz",
@@ -27436,9 +28144,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "saxes": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
-      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "dev": true,
       "requires": {
         "xmlchars": "^2.2.0"
@@ -28205,12 +28913,12 @@
       }
     },
     "tr46": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.1"
+        "punycode": "^2.3.0"
       }
     },
     "ts-jest": {
@@ -28584,19 +29292,10 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
-    "w3c-hr-time": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
-      "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
-      "dev": true,
-      "requires": {
-        "browser-process-hrtime": "^1.0.0"
-      }
-    },
     "w3c-xmlserializer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-3.0.0.tgz",
-      "integrity": "sha512-3WFqGEgSXIyGhOmAFtlicJNMjEps8b1MG31NCA0/vOF9+nKMUW1ckhi9cnNHmf88Rzw5V+dwIwsm2C7X8k9aQg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
       "dev": true,
       "requires": {
         "xml-name-validator": "^4.0.0"
@@ -28951,12 +29650,12 @@
       "dev": true
     },
     "whatwg-url": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-10.0.0.tgz",
-      "integrity": "sha512-CLxxCmdUby142H5FZzn4D8ikO1cmypvXVQktsgosNy4a4BHrDHeciBBGZhb0bNoR5/MltoCatso+vFjjGx8t0w==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
+      "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
       "dev": true,
       "requires": {
-        "tr46": "^3.0.0",
+        "tr46": "^4.1.1",
         "webidl-conversions": "^7.0.0"
       }
     },
@@ -29059,9 +29758,9 @@
       }
     },
     "ws": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
-      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "html-webpack-plugin": "^5.5.0",
     "jest": "^28.1.3",
     "jest-axe": "^6.0.0",
-    "jest-environment-jsdom": "^28.1.2",
+    "jest-environment-jsdom": "^30.0.0-alpha.3",
     "jest-resolve": "^28.1.3",
     "jest-watch-typeahead": "^2.0.0",
     "npm-run-all2": "^6.0.6",


### PR DESCRIPTION
This fixes a performance issue with getComputedStyle, which is used heavily by testing-library's `queryAllByRole` (which is used by all `*ByRole` queries).

This upgrades jsdom from v19 to v22.
This version of jsdom (v22) includes [this fix](https://github.com/jsdom/jsdom/pull/3482).

On my machine, running all tests goes from 25 seconds down to 14 seconds with this simple update. I expect that will be even better on slower machines having less cores.

Note: this installs some other jest packages with a newer version too, in parallel to our current version. I think it's OK. We can update to v30 when the stable version is released.