### PR TITLE
set non exapnded row to display none

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -463,7 +463,7 @@ exports[`Results Table Should match snapshot 1`] = `
             </div>
           </div>
           <div
-            class="content-row content-row--default container_f1tn6fhk "
+            class="content-row content-row--default container_f16sbjml "
             data-testid="expanded-row-content"
           >
             <div
@@ -774,7 +774,7 @@ exports[`Results Table Should match snapshot 1`] = `
             </div>
           </div>
           <div
-            class="content-row content-row--default container_f1tn6fhk "
+            class="content-row content-row--default container_f16sbjml "
             data-testid="expanded-row-content"
           >
             <div
@@ -1091,7 +1091,7 @@ exports[`Results Table Should match snapshot 1`] = `
             </div>
           </div>
           <div
-            class="content-row content-row--default container_f1tn6fhk "
+            class="content-row content-row--default container_f16sbjml "
             data-testid="expanded-row-content"
           >
             <div
@@ -1407,7 +1407,7 @@ exports[`Results Table Should match snapshot 1`] = `
             </div>
           </div>
           <div
-            class="content-row content-row--default container_f1tn6fhk "
+            class="content-row content-row--default container_f16sbjml "
             data-testid="expanded-row-content"
           >
             <div

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Results View Should display Base, New and Common graphs with tooltips 1`] = `
 <div
-  class="content-row content-row--expanded container_f1tn6fhk "
+  class="content-row content-row--expanded container_f16sbjml "
   data-testid="expanded-row-content"
 >
   <div
@@ -659,7 +659,7 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="content-row content-row--default container_f1tn6fhk "
+        class="content-row content-row--default container_f16sbjml "
         data-testid="expanded-row-content"
       >
         <div
@@ -970,7 +970,7 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="content-row content-row--default container_f1tn6fhk "
+        class="content-row content-row--default container_f16sbjml "
         data-testid="expanded-row-content"
       >
         <div
@@ -1287,7 +1287,7 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="content-row content-row--default container_f1tn6fhk "
+        class="content-row content-row--default container_f16sbjml "
         data-testid="expanded-row-content"
       >
         <div
@@ -1603,7 +1603,7 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="content-row content-row--default container_f1tn6fhk "
+        class="content-row content-row--default container_f16sbjml "
         data-testid="expanded-row-content"
       >
         <div

--- a/src/styles/ExpandableRow.ts
+++ b/src/styles/ExpandableRow.ts
@@ -13,10 +13,7 @@ export const ExpandableRowStyles = () => {
       transition: 'border-radius 0.4s ease-in-out',
       $nest: {
         '&.content-row': {
-          minHeight: '0',
-          height: '0',
-          overflow: 'hidden',
-          transition: 'min-height 0.4s ease-in-out',
+          display: 'none',
           cursor: 'default',
           $nest: {
             '&.content-row--expanded': {


### PR DESCRIPTION
Closes this issue: [Non-expanded rows should not render at all (or use display: none)](https://mozilla-hub.atlassian.net/browse/PCF-359)
