### PR TITLE
Rename RevisionsList to Changeset

### DIFF
--- a/src/__tests__/utils/fixtures.ts
+++ b/src/__tests__/utils/fixtures.ts
@@ -1,7 +1,7 @@
-import type { CompareResultsItem, RevisionsList } from '../../types/state';
+import type { CompareResultsItem, Changeset } from '../../types/state';
 
 const getTestData = () => {
-  const testData: RevisionsList[] = [
+  const testData: Changeset[] = [
     {
       id: 1,
       revision: 'coconut',

--- a/src/components/Search/CompareWithBase.tsx
+++ b/src/components/Search/CompareWithBase.tsx
@@ -11,7 +11,7 @@ import { useAppDispatch, useAppSelector } from '../../hooks/app';
 import { clearCheckedRevisionforType } from '../../reducers/SearchSlice';
 import { Strings } from '../../resources/Strings';
 import { CompareCardsStyles, SearchStyles } from '../../styles';
-import type { RevisionsList, Repository } from '../../types/state';
+import type { Changeset, Repository } from '../../types/state';
 import CompareButton from './CompareButton';
 import FrameworkDropdown from './FrameworkDropdown';
 import SearchComponent from './SearchComponent';
@@ -22,19 +22,19 @@ const stringsNew = Strings.components.searchDefault.base.collapsed.revision;
 
 interface CompareWithBaseProps {
   isEditable: boolean;
-  baseRevs: RevisionsList[];
-  newRevs: RevisionsList[];
+  baseRevs: Changeset[];
+  newRevs: Changeset[];
   baseRepos: Repository['name'][];
   newRepos: Repository['name'][];
 }
 
 interface RevisionsState {
-  revs: RevisionsList[];
+  revs: Changeset[];
   repos: Repository['name'][];
 }
 
 interface InProgressState {
-  revs: RevisionsList[];
+  revs: Changeset[];
   repos: Repository['name'][];
   isInProgress: boolean;
 }
@@ -187,7 +187,7 @@ function CompareWithBase({
     });
   };
 
-  const handleRemoveEditViewRevisionBase = (item: RevisionsList) => {
+  const handleRemoveEditViewRevisionBase = (item: Changeset) => {
     const revisionsBase = [...baseInProgress.revs];
     revisionsBase.splice(baseInProgress.revs.indexOf(item), 1);
     setInProgressBase({
@@ -197,7 +197,7 @@ function CompareWithBase({
     });
   };
 
-  const handleRemoveEditViewRevisionNew = (item: RevisionsList) => {
+  const handleRemoveEditViewRevisionNew = (item: Changeset) => {
     const revisionsNew = [...newInProgress.revs];
     revisionsNew.splice(newInProgress.revs.indexOf(item), 1);
     setInProgressNew({
@@ -207,7 +207,7 @@ function CompareWithBase({
     });
   };
 
-  const handleSearchResultsEditToggleBase = (toggleArray: RevisionsList[]) => {
+  const handleSearchResultsEditToggleBase = (toggleArray: Changeset[]) => {
     const repos = toggleArray.map((rev) => repoMap[rev.repository_id] ?? 'try');
     setInProgressBase({
       revs: toggleArray || [],
@@ -216,7 +216,7 @@ function CompareWithBase({
     });
   };
 
-  const handleSearchResultsEditToggleNew = (toggleArray: RevisionsList[]) => {
+  const handleSearchResultsEditToggleNew = (toggleArray: Changeset[]) => {
     const repos = toggleArray.map((rev) => repoMap[rev.repository_id] ?? 'try');
     setInProgressNew({
       revs: toggleArray || [],

--- a/src/components/Search/SearchComponent.tsx
+++ b/src/components/Search/SearchComponent.tsx
@@ -21,7 +21,7 @@ import {
   //SearchStyles can be found in CompareCards.ts
   SearchStyles,
 } from '../../styles';
-import type { RevisionsList, InputType, Repository } from '../../types/state';
+import type { Changeset, InputType, Repository } from '../../types/state';
 import EditButton from './EditButton';
 import SaveCancelButtons from './SaveCancelButtons';
 import SearchDropdown from './SearchDropdown';
@@ -30,7 +30,7 @@ import SearchResultsList from './SearchResultsList';
 import SelectedRevisions from './SelectedRevisions';
 
 interface RevisionsState {
-  revs: RevisionsList[];
+  revs: Changeset[];
   repos: Repository['name'][];
 }
 
@@ -38,15 +38,15 @@ interface SearchProps {
   isEditable: boolean;
   isWarning: boolean;
   isBaseComp: boolean;
-  searchResults: RevisionsList[];
+  searchResults: Changeset[];
   displayedRevisions: RevisionsState;
   setPopoverIsOpen?: Dispatch<SetStateAction<boolean>>;
   handleSave: () => void;
   handleCancel: () => void;
   handleEdit: () => void;
-  handleSearchResultsEditToggle: (toggleArray: RevisionsList[]) => void;
-  handleRemoveEditViewRevision: (item: RevisionsList) => void;
-  prevRevision?: RevisionsList;
+  handleSearchResultsEditToggle: (toggleArray: Changeset[]) => void;
+  handleRemoveEditViewRevision: (item: Changeset) => void;
+  prevRevision?: Changeset;
   selectLabel: string;
   tooltip: string;
   inputPlaceholder: string;

--- a/src/components/Search/SearchContainer.tsx
+++ b/src/components/Search/SearchContainer.tsx
@@ -14,19 +14,19 @@ const strings = Strings.components.searchDefault;
 function SearchContainer(props: SearchViewProps) {
   const themeMode = useAppSelector((state) => state.theme.mode);
   const styles = SearchContainerStyles(themeMode, /* isHome */ true);
-  const checkedRevisionsListNew = useAppSelector(
+  const checkedChangesetsNew = useAppSelector(
     (state) => state.search.new.checkedRevisions,
   );
-  const checkedRevisionsListBase = useAppSelector(
+  const checkedChangesetsBase = useAppSelector(
     (state) => state.search.base.checkedRevisions,
   );
 
   // The "??" operations below are so that Typescript doesn't wonder about the
   // undefined value later.
-  const checkedNewRepos = checkedRevisionsListNew.map(
+  const checkedNewRepos = checkedChangesetsNew.map(
     (item) => repoMap[item.repository_id] ?? 'try',
   );
-  const checkedBaseRepos = checkedRevisionsListBase.map(
+  const checkedBaseRepos = checkedChangesetsBase.map(
     (item) => repoMap[item.repository_id] ?? 'try',
   );
 
@@ -39,8 +39,8 @@ function SearchContainer(props: SearchViewProps) {
       <Typography className='search-default-title'>{strings.title}</Typography>
       <CompareWithBase
         isEditable={false}
-        baseRevs={checkedRevisionsListBase}
-        newRevs={checkedRevisionsListNew}
+        baseRevs={checkedChangesetsBase}
+        newRevs={checkedChangesetsNew}
         baseRepos={checkedBaseRepos}
         newRepos={checkedNewRepos}
       />

--- a/src/components/Search/SearchResultsList.tsx
+++ b/src/components/Search/SearchResultsList.tsx
@@ -4,20 +4,20 @@ import List from '@mui/material/List';
 import { useAppSelector } from '../../hooks/app';
 import useCheckRevision from '../../hooks/useCheckRevision';
 import { SelectListStyles } from '../../styles';
-import { RevisionsList, Repository } from '../../types/state';
+import { Changeset, Repository } from '../../types/state';
 import SearchResultsListItem from './SearchResultsListItem';
 
 interface RevisionsState {
-  revs: RevisionsList[];
+  revs: Changeset[];
   repos: Repository['name'][];
 }
 
 interface SearchResultsListProps {
   isEditable: boolean;
   isBase: boolean;
-  searchResults: RevisionsList[];
+  searchResults: Changeset[];
   displayedRevisions: RevisionsState;
-  onEditToggle: (toggleArray: RevisionsList[]) => void;
+  onEditToggle: (toggleArray: Changeset[]) => void;
 }
 
 function SearchResultsList({
@@ -32,17 +32,17 @@ function SearchResultsList({
   const { handleToggle } = useCheckRevision(isBase, isEditable);
   const searchType = isBase ? 'base' : 'new';
   const revisionsCount = isBase === true ? 1 : 3;
-  const isCommittedChecked = (item: RevisionsList) => {
+  const isCommittedChecked = (item: Changeset) => {
     return useAppSelector((state) =>
       state.search[searchType].checkedRevisions.includes(item),
     );
   };
-  const isInProgressChecked = (item: RevisionsList) => {
+  const isInProgressChecked = (item: Changeset) => {
     return displayedRevisions.revs.map((rev) => rev.id).includes(item.id);
   };
   const isCheckedState = isEditable ? isInProgressChecked : isCommittedChecked;
 
-  const handleToggleAction = (item: RevisionsList) => {
+  const handleToggleAction = (item: Changeset) => {
     const toggleArray = handleToggle(
       item,
       revisionsCount,

--- a/src/components/Search/SearchResultsListItem.tsx
+++ b/src/components/Search/SearchResultsListItem.tsx
@@ -12,15 +12,15 @@ import dayjs from 'dayjs';
 import { style } from 'typestyle';
 
 import { Spacing } from '../../styles';
-import type { RevisionsList } from '../../types/state';
+import type { Changeset } from '../../types/state';
 import { truncateHash, getLatestCommitMessage } from '../../utils/helpers';
 
 interface SearchResultsListItemProps {
   index: number;
-  item: RevisionsList;
+  item: Changeset;
   revisionsCount: number;
-  isCheckedState: (item: RevisionsList) => boolean;
-  onToggle: (item: RevisionsList) => void;
+  isCheckedState: (item: Changeset) => boolean;
+  onToggle: (item: Changeset) => void;
 }
 
 const styles = {

--- a/src/components/Search/SelectedRevisionItem.tsx
+++ b/src/components/Search/SelectedRevisionItem.tsx
@@ -16,7 +16,7 @@ import dayjs from 'dayjs';
 import { useAppSelector } from '../../hooks/app';
 import { Strings } from '../../resources/Strings';
 import { SelectRevsStyles } from '../../styles';
-import { Repository, RevisionsList } from '../../types/state';
+import { Repository, Changeset } from '../../types/state';
 import {
   truncateHash,
   getLatestCommitMessage,
@@ -28,12 +28,12 @@ const warning = base.collapsed.warnings.comparison;
 
 interface SelectedRevisionItemProps {
   index: number;
-  item: RevisionsList;
+  item: Changeset;
   repository: Repository['name'];
   isBase: boolean;
   isWarning: boolean;
   iconClassName: string;
-  removeRevision: (item: RevisionsList) => void;
+  removeRevision: (item: Changeset) => void;
 }
 
 function SelectedRevisionItem({

--- a/src/components/Search/SelectedRevisions.tsx
+++ b/src/components/Search/SelectedRevisions.tsx
@@ -4,7 +4,7 @@ import List from '@mui/material/List';
 import { useAppSelector } from '../../hooks/app';
 import useCheckRevision from '../../hooks/useCheckRevision';
 import { SelectRevsStyles } from '../../styles';
-import { Repository, RevisionsList } from '../../types/state';
+import { Repository, Changeset } from '../../types/state';
 import SelectedRevisionItem from './SelectedRevisionItem';
 
 interface SelectedRevisionsProps {
@@ -13,11 +13,11 @@ interface SelectedRevisionsProps {
   isEditable: boolean;
   isWarning: boolean;
   displayedRevisions: RevisionsState;
-  onEditRemove: (item: RevisionsList) => void;
+  onEditRemove: (item: Changeset) => void;
 }
 
 interface RevisionsState {
-  revs: RevisionsList[];
+  revs: Changeset[];
   repos: Repository['name'][];
 }
 
@@ -33,16 +33,16 @@ function SelectedRevisions({
   const styles = SelectRevsStyles(mode);
   const searchType = isBase ? 'base' : 'new';
 
-  const onEditRemoveAction = (item: RevisionsList) => {
+  const onEditRemoveAction = (item: Changeset) => {
     onEditRemove(item);
   };
 
   const { removeCheckedRevision } = useCheckRevision(isBase, isEditable);
 
-  const handleRemoveRevision = (item: RevisionsList) => {
+  const handleRemoveRevision = (item: Changeset) => {
     removeCheckedRevision(item);
   };
-  const removeRevision = (item: RevisionsList) => {
+  const removeRevision = (item: Changeset) => {
     if (isEditable) {
       onEditRemoveAction(item);
     } else {

--- a/src/hooks/useCheckRevision.ts
+++ b/src/hooks/useCheckRevision.ts
@@ -1,7 +1,7 @@
 import { useSnackbar, VariantType } from 'notistack';
 
 import { updateCheckedRevisions } from '../reducers/SearchSlice';
-import { InputType, RevisionsList } from '../types/state';
+import { InputType, Changeset } from '../types/state';
 import { useAppDispatch, useAppSelector } from './app';
 
 const useCheckRevision = (isBase: boolean, isEditable: boolean) => {
@@ -9,14 +9,14 @@ const useCheckRevision = (isBase: boolean, isEditable: boolean) => {
   const dispatch = useAppDispatch();
   const searchType: InputType = isBase ? 'base' : 'new';
 
-  const searchCheckedRevisions: RevisionsList[] = useAppSelector(
+  const searchCheckedRevisions: Changeset[] = useAppSelector(
     (state) => state.search[searchType].checkedRevisions,
   );
 
   const setToggleState = (
-    revision: RevisionsList,
+    revision: Changeset,
     maxRevisions: number,
-    revisionsList: RevisionsList[],
+    revisionsList: Changeset[],
   ) => {
     const isChecked = revisionsList.map((rev) => rev.id).includes(revision.id);
     const newChecked = [...revisionsList];
@@ -38,9 +38,9 @@ const useCheckRevision = (isBase: boolean, isEditable: boolean) => {
   };
 
   const handleToggle = (
-    revision: RevisionsList,
+    revision: Changeset,
     maxRevisions: number,
-    inProgressRevisions: RevisionsList[],
+    inProgressRevisions: Changeset[],
   ) => {
     //handle the state of "in progress" revisions in results view
     if (isEditable) {
@@ -65,7 +65,7 @@ const useCheckRevision = (isBase: boolean, isEditable: boolean) => {
     return filteredChecked;
   };
 
-  const removeCheckedRevision = (revision: RevisionsList) => {
+  const removeCheckedRevision = (revision: Changeset) => {
     const newChecked = [...searchCheckedRevisions];
     newChecked.splice(searchCheckedRevisions.indexOf(revision), 1);
     dispatch(updateCheckedRevisions({ newChecked, searchType }));

--- a/src/hooks/useSelectedRevisions.ts
+++ b/src/hooks/useSelectedRevisions.ts
@@ -1,15 +1,15 @@
 import { setSelectedRevisions } from '../reducers/SelectedRevisionsSlice';
-import { RevisionsList } from '../types/state';
+import { Changeset } from '../types/state';
 import { useAppDispatch, useAppSelector } from './app';
 
 const useSelectRevision = () => {
   const dispatch = useAppDispatch();
 
-  const baseCheckedRevisions: RevisionsList[] = useAppSelector(
+  const baseCheckedRevisions: Changeset[] = useAppSelector(
     (state) => state.search.base.checkedRevisions,
   );
 
-  const newCheckedRevisions: RevisionsList[] = useAppSelector(
+  const newCheckedRevisions: Changeset[] = useAppSelector(
     (state) => state.search.new.checkedRevisions,
   );
 

--- a/src/logic/treeherder.ts
+++ b/src/logic/treeherder.ts
@@ -1,4 +1,4 @@
-import { CompareResultsItem, Repository, RevisionsList } from '../types/state';
+import { CompareResultsItem, Repository, Changeset } from '../types/state';
 import { Framework } from '../types/types';
 
 // This file contains functions to request the Treeherder API
@@ -102,6 +102,6 @@ export async function fetchRecentRevisions(params: RecentRevisionsParams) {
     }
   }
 
-  const json = (await response.json()) as { results: RevisionsList[] };
+  const json = (await response.json()) as { results: Changeset[] };
   return json.results;
 }

--- a/src/reducers/SearchSlice.ts
+++ b/src/reducers/SearchSlice.ts
@@ -7,7 +7,7 @@ import {
 } from '../thunks/searchThunk';
 import type {
   Repository,
-  RevisionsList,
+  Changeset,
   SearchState,
   SearchStateForInput,
   InputType,
@@ -45,7 +45,7 @@ const search = createSlice({
     updateSearchResults(
       state,
       action: PayloadAction<{
-        results: RevisionsList[];
+        results: Changeset[];
         searchType: InputType;
       }>,
     ) {
@@ -69,7 +69,7 @@ const search = createSlice({
     updateCheckedRevisions(
       state,
       action: PayloadAction<{
-        newChecked: RevisionsList[];
+        newChecked: Changeset[];
         searchType: InputType;
       }>,
     ) {

--- a/src/reducers/SelectedRevisionsSlice.ts
+++ b/src/reducers/SelectedRevisionsSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import { RevisionsList, SelectedRevisionsState } from '../types/state';
+import { Changeset, SelectedRevisionsState } from '../types/state';
 
 const initialState: SelectedRevisionsState = {
   revisions: [],
@@ -16,7 +16,7 @@ const selectedRevisions = createSlice({
     setSelectedRevisions(
       state,
       action: PayloadAction<{
-        selectedRevisions: RevisionsList[];
+        selectedRevisions: Changeset[];
       }>,
     ) {
       state.revisions = action.payload.selectedRevisions;

--- a/src/thunks/searchThunk.ts
+++ b/src/thunks/searchThunk.ts
@@ -3,7 +3,7 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 
 import { treeherderBaseURL } from '../common/constants';
 import type { APIPushResponse } from '../types/api';
-import type { Repository, RevisionsList, InputType } from '../types/state';
+import type { Repository, Changeset, InputType } from '../types/state';
 
 interface FetchDataArgs {
   repository: Repository['name'];
@@ -17,7 +17,7 @@ interface FetchDataArgsIDEmail {
 }
 
 export const fetchRecentRevisions = createAsyncThunk<
-  RevisionsList[],
+  Changeset[],
   FetchDataArgs,
   { rejectValue: string }
 >(
@@ -43,7 +43,7 @@ export const fetchRecentRevisions = createAsyncThunk<
 );
 
 export const fetchRevisionByID = createAsyncThunk<
-  RevisionsList[],
+  Changeset[],
   FetchDataArgsIDEmail,
   { rejectValue: string }
 >(
@@ -68,7 +68,7 @@ export const fetchRevisionByID = createAsyncThunk<
 );
 
 export const fetchRevisionsByAuthor = createAsyncThunk<
-  RevisionsList[],
+  Changeset[],
   FetchDataArgsIDEmail,
   { rejectValue: string }
 >(

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,4 +1,4 @@
-import type { Repository, RevisionsList } from './state';
+import type { Repository, Changeset } from './state';
 
 type APIFilterParams = {
   full: boolean;
@@ -13,5 +13,5 @@ type APIPushMeta = {
 
 export type APIPushResponse = {
   meta: APIPushMeta;
-  results: RevisionsList[];
+  results: Changeset[];
 };

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -21,7 +21,7 @@ export type SubRevision = {
   comments: string;
 };
 
-export type RevisionsList = {
+export type Changeset = {
   id: number;
   revision: string;
   author: string;
@@ -95,11 +95,11 @@ export type CompareResultsItem = {
 
 export type SearchStateForInput = {
   repository: Repository['name'];
-  searchResults: RevisionsList[];
+  searchResults: Changeset[];
   searchValue: string;
   inputError: boolean;
   inputHelperText: string;
-  checkedRevisions: RevisionsList[];
+  checkedRevisions: Changeset[];
 };
 
 export type InputType = 'base' | 'new';
@@ -111,9 +111,9 @@ export type ThemeMode = 'light' | 'dark';
 export type SearchState = Record<InputType, SearchStateForInput>;
 
 export type SelectedRevisionsState = {
-  revisions: RevisionsList[];
-  baseCommittedRevisions: RevisionsList[];
-  newCommittedRevisions: RevisionsList[];
+  revisions: Changeset[];
+  baseCommittedRevisions: Changeset[];
+  newCommittedRevisions: Changeset[];
 };
 
 export type PlatformInfo = {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -6,15 +6,14 @@ import {
   nonDocumentedTestsDevTools,
   supportedPerfdocsFrameworks,
 } from '../common/constants';
-import type { Repository, RevisionsList } from '../types/state';
+import type { Repository, Changeset } from '../types/state';
 import type { Framework, SupportedPerfdocsFramework } from '../types/types';
 
-const truncateHash = (revision: RevisionsList['revision']) =>
-  revision.slice(0, 12);
+const truncateHash = (revision: Changeset['revision']) => revision.slice(0, 12);
 
 // return only most recent commit message
 // first commit is usually 'try_task_config'
-const getLatestCommitMessage = (item: RevisionsList) => {
+const getLatestCommitMessage = (item: Changeset) => {
   const { repository_id: repositoryId, revisions } = item;
   const isTry = repositoryId === 4;
   const lastUsefulRevision =
@@ -47,7 +46,7 @@ const formatDate = (timestamp: number): string => {
 };
 
 const getTreeherderURL = (
-  revision: RevisionsList['revision'],
+  revision: Changeset['revision'],
   repository: Repository['name'],
 ) =>
   `https://treeherder.mozilla.org/jobs?repo=${repository}&revision=${revision}`;


### PR DESCRIPTION
This was confusing me a lot. Indeed in the code base, the term "revisionsList" was used for both a Changeset and a list of Changesets (`RevisionsList[]`).
So I think the term Changeset is more idiomatic. This is how Firefox developers call this object.
For example on hg.mozilla.org: https://hg.mozilla.org/mozilla-central/pushloghtml or https://hg.mozilla.org/integration/autoland/rev/64e14543839c59fc9fc3d71a1cc60507bb9c7064
Note that 64e... is the changeset's revision, so it's exactly the same object we have here.
