### PR TITLE
Do not store repository information in the CompareWithBase state

### DIFF
--- a/src/__tests__/Search/CompareWithBase.test.tsx
+++ b/src/__tests__/Search/CompareWithBase.test.tsx
@@ -23,7 +23,7 @@ function setUpTestData() {
     })
     .get('begin:https://treeherder.mozilla.org/api/perfcompare/results/', [])
     .get(
-      'begin:https://treeherder.mozilla.org/api/project/mozilla-central/push/?revision=coconut',
+      'begin:https://treeherder.mozilla.org/api/project/try/push/?revision=coconut',
       {
         results: [testData[0]],
       },
@@ -48,7 +48,7 @@ function renderWithCompareResultsURL(component: ReactElement) {
   return renderWithRouter(component, {
     route: '/compare-results/',
     search:
-      '?baseRev=coconut&baseRepo=mozilla-central&newRev=spam&newRepo=mozilla-central&framework=2',
+      '?baseRev=coconut&baseRepo=try&newRev=spam&newRepo=mozilla-central&framework=2',
     loader,
   });
 }

--- a/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
@@ -175,13 +175,13 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
             <input
               name="baseRepo"
               type="hidden"
-              value="mozilla-central"
+              value="try"
             />
             <div
               class="repo_f1bx8by5"
             >
               <div>
-                mozilla-central
+                try
               </div>
             </div>
             <div
@@ -200,7 +200,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
-                      href="https://treeherder.mozilla.org/jobs?repo=mozilla-central&revision=coconut"
+                      href="https://treeherder.mozilla.org/jobs?repo=try&revision=coconut"
                       target="_blank"
                       title="open treeherder view for coconut"
                     >
@@ -952,13 +952,13 @@ exports[`Compare With Base should have an edit mode in Results View: After click
             <input
               name="baseRepo"
               type="hidden"
-              value="mozilla-central"
+              value="try"
             />
             <div
               class="repo_f1bx8by5"
             >
               <div>
-                mozilla-central
+                try
               </div>
             </div>
             <div
@@ -977,7 +977,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
-                      href="https://treeherder.mozilla.org/jobs?repo=mozilla-central&revision=coconut"
+                      href="https://treeherder.mozilla.org/jobs?repo=try&revision=coconut"
                       target="_blank"
                       title="open treeherder view for coconut"
                     >
@@ -2119,13 +2119,13 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
             <input
               name="baseRepo"
               type="hidden"
-              value="mozilla-central"
+              value="try"
             />
             <div
               class="repo_f1bx8by5"
             >
               <div>
-                mozilla-central
+                try
               </div>
             </div>
             <div
@@ -2144,7 +2144,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
-                      href="https://treeherder.mozilla.org/jobs?repo=mozilla-central&revision=coconut"
+                      href="https://treeherder.mozilla.org/jobs?repo=try&revision=coconut"
                       target="_blank"
                       title="open treeherder view for coconut"
                     >

--- a/src/components/CompareResults/ResultsView.tsx
+++ b/src/components/CompareResults/ResultsView.tsx
@@ -19,14 +19,8 @@ interface ResultsViewProps {
 }
 function ResultsView(props: ResultsViewProps) {
   const dispatch = useAppDispatch();
-  const {
-    baseRevInfo,
-    baseRepo,
-    newRevsInfo,
-    newRepos,
-    frameworkId,
-    frameworkName,
-  } = useLoaderData() as LoaderReturnValue;
+  const { baseRevInfo, newRevsInfo, frameworkId, frameworkName } =
+    useLoaderData() as LoaderReturnValue;
 
   // The CompareWithBase component wants arrays. So that we keep the same array
   // reference if the data doesn't change, we use `useMemo` for these 2 variables.
@@ -34,7 +28,6 @@ function ResultsView(props: ResultsViewProps) {
     () => (baseRevInfo ? [baseRevInfo] : []),
     [baseRevInfo],
   );
-  const baseRepos = useMemo(() => [baseRepo], [baseRepo]);
 
   const { title } = props;
   const themeMode = useAppSelector((state) => state.theme.mode);
@@ -75,8 +68,6 @@ function ResultsView(props: ResultsViewProps) {
           isEditable={true}
           baseRevs={baseRevInfos}
           newRevs={newRevsInfo ?? []}
-          baseRepos={baseRepos}
-          newRepos={newRepos}
         />
       </section>
       <Grid container alignItems='center' justifyContent='center'>

--- a/src/components/Search/SearchComponent.tsx
+++ b/src/components/Search/SearchComponent.tsx
@@ -21,7 +21,7 @@ import {
   //SearchStyles can be found in CompareCards.ts
   SearchStyles,
 } from '../../styles';
-import type { Changeset, InputType, Repository } from '../../types/state';
+import type { Changeset, InputType } from '../../types/state';
 import EditButton from './EditButton';
 import SaveCancelButtons from './SaveCancelButtons';
 import SearchDropdown from './SearchDropdown';
@@ -29,17 +29,12 @@ import SearchInput from './SearchInput';
 import SearchResultsList from './SearchResultsList';
 import SelectedRevisions from './SelectedRevisions';
 
-interface RevisionsState {
-  revs: Changeset[];
-  repos: Repository['name'][];
-}
-
 interface SearchProps {
   isEditable: boolean;
   isWarning: boolean;
   isBaseComp: boolean;
   searchResults: Changeset[];
-  displayedRevisions: RevisionsState;
+  displayedRevisions: Changeset[];
   setPopoverIsOpen?: Dispatch<SetStateAction<boolean>>;
   handleSave: () => void;
   handleCancel: () => void;

--- a/src/components/Search/SearchContainer.tsx
+++ b/src/components/Search/SearchContainer.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import Typography from '@mui/material/Typography';
 
-import { repoMap } from '../../common/constants';
 import { useAppSelector } from '../../hooks/app';
 import { Strings } from '../../resources/Strings';
 import { SearchContainerStyles } from '../../styles';
@@ -21,15 +20,6 @@ function SearchContainer(props: SearchViewProps) {
     (state) => state.search.base.checkedRevisions,
   );
 
-  // The "??" operations below are so that Typescript doesn't wonder about the
-  // undefined value later.
-  const checkedNewRepos = checkedChangesetsNew.map(
-    (item) => repoMap[item.repository_id] ?? 'try',
-  );
-  const checkedBaseRepos = checkedChangesetsBase.map(
-    (item) => repoMap[item.repository_id] ?? 'try',
-  );
-
   return (
     <section
       data-testid='search-section'
@@ -41,8 +31,6 @@ function SearchContainer(props: SearchViewProps) {
         isEditable={false}
         baseRevs={checkedChangesetsBase}
         newRevs={checkedChangesetsNew}
-        baseRepos={checkedBaseRepos}
-        newRepos={checkedNewRepos}
       />
       {/* hidden until post-mvp release */}
       <CompareOverTime />

--- a/src/components/Search/SearchResultsList.tsx
+++ b/src/components/Search/SearchResultsList.tsx
@@ -4,19 +4,14 @@ import List from '@mui/material/List';
 import { useAppSelector } from '../../hooks/app';
 import useCheckRevision from '../../hooks/useCheckRevision';
 import { SelectListStyles } from '../../styles';
-import { Changeset, Repository } from '../../types/state';
+import { Changeset } from '../../types/state';
 import SearchResultsListItem from './SearchResultsListItem';
-
-interface RevisionsState {
-  revs: Changeset[];
-  repos: Repository['name'][];
-}
 
 interface SearchResultsListProps {
   isEditable: boolean;
   isBase: boolean;
   searchResults: Changeset[];
-  displayedRevisions: RevisionsState;
+  displayedRevisions: Changeset[];
   onEditToggle: (toggleArray: Changeset[]) => void;
 }
 
@@ -38,16 +33,12 @@ function SearchResultsList({
     );
   };
   const isInProgressChecked = (item: Changeset) => {
-    return displayedRevisions.revs.map((rev) => rev.id).includes(item.id);
+    return displayedRevisions.map((rev) => rev.id).includes(item.id);
   };
   const isCheckedState = isEditable ? isInProgressChecked : isCommittedChecked;
 
   const handleToggleAction = (item: Changeset) => {
-    const toggleArray = handleToggle(
-      item,
-      revisionsCount,
-      displayedRevisions.revs,
-    );
+    const toggleArray = handleToggle(item, revisionsCount, displayedRevisions);
 
     if (isEditable) {
       onEditToggle(toggleArray);

--- a/src/components/Search/SelectedRevisionItem.tsx
+++ b/src/components/Search/SelectedRevisionItem.tsx
@@ -13,10 +13,11 @@ import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import dayjs from 'dayjs';
 
+import { repoMap } from '../../common/constants';
 import { useAppSelector } from '../../hooks/app';
 import { Strings } from '../../resources/Strings';
 import { SelectRevsStyles } from '../../styles';
-import { Repository, Changeset } from '../../types/state';
+import { Changeset } from '../../types/state';
 import {
   truncateHash,
   getLatestCommitMessage,
@@ -29,7 +30,6 @@ const warning = base.collapsed.warnings.comparison;
 interface SelectedRevisionItemProps {
   index: number;
   item: Changeset;
-  repository: Repository['name'];
   isBase: boolean;
   isWarning: boolean;
   iconClassName: string;
@@ -39,7 +39,6 @@ interface SelectedRevisionItemProps {
 function SelectedRevisionItem({
   index,
   item,
-  repository,
   iconClassName,
   isBase,
   isWarning,
@@ -51,6 +50,7 @@ function SelectedRevisionItem({
   const revisionHash = truncateHash(item.revision);
   const commitMessage = getLatestCommitMessage(item);
   const itemDate = new Date(item.push_timestamp * 1000);
+  const repository = repoMap[item.repository_id] ?? 'try';
 
   const onRemoveRevision = () => {
     removeRevision(item);

--- a/src/components/Search/SelectedRevisions.tsx
+++ b/src/components/Search/SelectedRevisions.tsx
@@ -4,7 +4,7 @@ import List from '@mui/material/List';
 import { useAppSelector } from '../../hooks/app';
 import useCheckRevision from '../../hooks/useCheckRevision';
 import { SelectRevsStyles } from '../../styles';
-import { Repository, Changeset } from '../../types/state';
+import { Changeset } from '../../types/state';
 import SelectedRevisionItem from './SelectedRevisionItem';
 
 interface SelectedRevisionsProps {
@@ -12,13 +12,8 @@ interface SelectedRevisionsProps {
   formIsDisplayed: boolean;
   isEditable: boolean;
   isWarning: boolean;
-  displayedRevisions: RevisionsState;
+  displayedRevisions: Changeset[];
   onEditRemove: (item: Changeset) => void;
-}
-
-interface RevisionsState {
-  revs: Changeset[];
-  repos: Repository['name'][];
 }
 
 function SelectedRevisions({
@@ -63,12 +58,11 @@ function SelectedRevisions({
       }`}
     >
       <List>
-        {displayedRevisions.revs.map((item, index) => (
+        {displayedRevisions.map((item, index) => (
           <SelectedRevisionItem
             key={item.id}
             index={index}
             item={item}
-            repository={displayedRevisions.repos[index]}
             isBase={isBase}
             isWarning={isWarning}
             removeRevision={removeRevision}


### PR DESCRIPTION
Please look at the last commit only, as the first one is #617. Also of course I can rebase and change it if we decide to use another type name than `Changeset`.

This is a small simplification of how we deal with the repository information.
Indeed we were always computing them from the items before setting the state anyway, so it's easier to compute them when and where needed. This simplifies some code.
