### PR TITLE
Rename isEditable to hasNonEditableState

### DIFF
--- a/src/components/CompareResults/ResultsView.tsx
+++ b/src/components/CompareResults/ResultsView.tsx
@@ -65,7 +65,7 @@ function ResultsView(props: ResultsViewProps) {
         <SearchViewInit />
 
         <CompareWithBase
-          isEditable={true}
+          hasNonEditableState={true}
           baseRevs={baseRevInfos}
           newRevs={newRevsInfo ?? []}
         />

--- a/src/components/Search/CompareWithBase.tsx
+++ b/src/components/Search/CompareWithBase.tsx
@@ -20,7 +20,7 @@ const stringsBase = Strings.components.searchDefault.base.collapsed.base;
 const stringsNew = Strings.components.searchDefault.base.collapsed.revision;
 
 interface CompareWithBaseProps {
-  isEditable: boolean;
+  hasNonEditableState: boolean;
   baseRevs: Changeset[];
   newRevs: Changeset[];
 }
@@ -30,8 +30,44 @@ interface InProgressState {
   isInProgress: boolean;
 }
 
+/**
+ * This component implements the form where the user can enter the input to
+ * compare some revisions with a base revision.
+ * It is fairly complex because it has several states, that also depend on where
+ * it's used.
+ *
+ * In the Search View, the user can edit it always, then presses the
+ * "Compare" button to move to the Results View. Pressing the "Compare" button
+ * is a normal Form submission, that goes through React Router to change the URL
+ * and rerender the page.
+ *
+ * In the Results View, it is initially displayed as non-editable, but presents
+ * an Edit button on each part (base revision / new revisions). When the user
+ * presses this Edit button, the corresponding part will move to an editable
+ * state, similar to the initial state of the Search View. The user will be
+ * able to Cancel or Save the changes, in which case the state moves back to
+ * "non-editable" with respectively the previous selections or the new
+ * selections being displayed. The user can also presses "Compare" directly to
+ * search using the new input.
+ *
+ * Therefore these 3 different states exist:
+ * - The initial state comes from the URL in the ResultsView, and is empty in the
+ *   SearchView (aka the Homepage). It is passed to this component with the
+ *   props. When the user presses "Compare", the URL changes, and so change the
+ *   props too.
+ * - The non-editable state (also known as the staging state) is used in the
+ *   ResultsView only: it contains the snapshot of the revisions, that the user
+ *   will go back if they presses "cancel" after starting editing. It's
+ *   initialized with the initial state.
+ * - The in-progress state represents the set of revisions that the user is
+ *   currently selecting. In the SearchView it can be changed always, but in the
+ *   ResultsView the user will need to press Edit first. If the user presses
+ *   "Save" at this point, the in-progress state is copied to the non-editable
+ *   state. If the user presses "Cancel", the previous non-editable state is
+ *   recalled.
+ */
 function CompareWithBase({
-  isEditable,
+  hasNonEditableState,
   baseRevs,
   newRevs,
 }: CompareWithBaseProps) {
@@ -223,7 +259,7 @@ function CompareWithBase({
             {...stringsBase}
             isBaseComp={true}
             isWarning={isWarning}
-            isEditable={isEditable}
+            hasNonEditableState={hasNonEditableState}
             searchResults={searchResultsBase}
             displayedRevisions={displayedRevisionsBaseRevs}
             handleSave={handleSaveBase}
@@ -235,7 +271,7 @@ function CompareWithBase({
           <SearchComponent
             {...stringsNew}
             isBaseComp={false}
-            isEditable={isEditable}
+            hasNonEditableState={hasNonEditableState}
             isWarning={isWarning}
             searchResults={searchResultsNew}
             displayedRevisions={displayedRevisionsNewRevs}

--- a/src/components/Search/SearchComponent.tsx
+++ b/src/components/Search/SearchComponent.tsx
@@ -30,7 +30,7 @@ import SearchResultsList from './SearchResultsList';
 import SelectedRevisions from './SelectedRevisions';
 
 interface SearchProps {
-  isEditable: boolean;
+  hasNonEditableState: boolean;
   isWarning: boolean;
   isBaseComp: boolean;
   searchResults: Changeset[];
@@ -48,7 +48,7 @@ interface SearchProps {
 }
 
 function SearchComponent({
-  isEditable,
+  hasNonEditableState,
   isBaseComp,
   searchResults,
   displayedRevisions,
@@ -89,7 +89,7 @@ function SearchComponent({
   });
 
   const [displayDropdown, setDisplayDropdown] = useState(false);
-  const [formIsDisplayed, setFormIsDisplayed] = useState(!isEditable);
+  const [formIsDisplayed, setFormIsDisplayed] = useState(!hasNonEditableState);
 
   const handleDocumentMousedown = useCallback(
     (e: MouseEvent) => {
@@ -145,7 +145,7 @@ function SearchComponent({
           </Tooltip>
         </InputLabel>
         {/**** Edit Button ****/}
-        {isEditable && !formIsDisplayed && (
+        {hasNonEditableState && !formIsDisplayed && (
           <EditButton
             isBase={isBaseComp}
             onEditAction={() => {
@@ -169,11 +169,11 @@ function SearchComponent({
           xs={2}
           id={`${searchType}_search-dropdown`}
           className={`${searchType}-search-dropdown ${styles.dropDown} ${
-            isEditable ? 'small' : ''
-          } ${isEditable ? compareView : ''}-base-dropdown`}
+            hasNonEditableState ? 'small' : ''
+          } ${hasNonEditableState ? compareView : ''}-base-dropdown`}
         >
           <SearchDropdown
-            isEditable={isEditable}
+            hasNonEditableState={hasNonEditableState}
             selectLabel={selectLabel}
             tooltipText={tooltip}
             searchType={searchType}
@@ -184,18 +184,18 @@ function SearchComponent({
           xs={7}
           id={`${searchType}_search-input`}
           className={`${searchType}-search-input  ${styles.baseSearchInput} ${
-            isEditable ? 'big' : ''
+            hasNonEditableState ? 'big' : ''
           } `}
         >
           <SearchInput
             onFocus={() => setDisplayDropdown(true)}
-            isEditable={isEditable}
+            hasNonEditableState={hasNonEditableState}
             inputPlaceholder={inputPlaceholder}
             searchType={searchType}
           />
           {searchResults.length > 0 && displayDropdown && (
             <SearchResultsList
-              isEditable={isEditable}
+              hasNonEditableState={hasNonEditableState}
               isBase={isBaseComp}
               searchResults={searchResults}
               displayedRevisions={displayedRevisions}
@@ -204,7 +204,7 @@ function SearchComponent({
           )}
         </Grid>
         {/****** Cancel Save Buttons ******/}
-        {isEditable && formIsDisplayed && (
+        {hasNonEditableState && formIsDisplayed && (
           <SaveCancelButtons
             searchType={searchType}
             onSave={() => {
@@ -223,7 +223,7 @@ function SearchComponent({
         <Grid className='d-flex'>
           <SelectedRevisions
             isBase={isBaseComp}
-            isEditable={isEditable}
+            hasNonEditableState={hasNonEditableState}
             formIsDisplayed={formIsDisplayed}
             isWarning={isWarning}
             displayedRevisions={displayedRevisions}

--- a/src/components/Search/SearchComponent.tsx
+++ b/src/components/Search/SearchComponent.tsx
@@ -173,7 +173,7 @@ function SearchComponent({
           } ${hasNonEditableState ? compareView : ''}-base-dropdown`}
         >
           <SearchDropdown
-            hasNonEditableState={hasNonEditableState}
+            compact={hasNonEditableState}
             selectLabel={selectLabel}
             tooltipText={tooltip}
             searchType={searchType}
@@ -189,7 +189,7 @@ function SearchComponent({
         >
           <SearchInput
             onFocus={() => setDisplayDropdown(true)}
-            hasNonEditableState={hasNonEditableState}
+            compact={hasNonEditableState}
             inputPlaceholder={inputPlaceholder}
             searchType={searchType}
           />

--- a/src/components/Search/SearchContainer.tsx
+++ b/src/components/Search/SearchContainer.tsx
@@ -28,7 +28,7 @@ function SearchContainer(props: SearchViewProps) {
     >
       <Typography className='search-default-title'>{strings.title}</Typography>
       <CompareWithBase
-        isEditable={false}
+        hasNonEditableState={false}
         baseRevs={checkedChangesetsBase}
         newRevs={checkedChangesetsNew}
       />

--- a/src/components/Search/SearchDropdown.tsx
+++ b/src/components/Search/SearchDropdown.tsx
@@ -17,7 +17,7 @@ import { fetchRecentRevisions } from '../../thunks/searchThunk';
 import { InputType, Repository } from '../../types/state';
 
 interface SearchDropdownProps {
-  isEditable?: boolean;
+  hasNonEditableState?: boolean;
   selectLabel: string;
   tooltipText: string;
   searchType: InputType;
@@ -25,11 +25,11 @@ interface SearchDropdownProps {
 
 //handle in progress repos here if necessary
 function SearchDropdown({
-  isEditable,
+  hasNonEditableState,
   selectLabel,
   searchType,
 }: SearchDropdownProps) {
-  const size = isEditable == true ? 'small' : undefined;
+  const size = hasNonEditableState == true ? 'small' : undefined;
   const mode = useAppSelector((state) => state.theme.mode);
   const repository = useAppSelector(
     (state) => state.search[searchType].repository,

--- a/src/components/Search/SearchDropdown.tsx
+++ b/src/components/Search/SearchDropdown.tsx
@@ -17,7 +17,7 @@ import { fetchRecentRevisions } from '../../thunks/searchThunk';
 import { InputType, Repository } from '../../types/state';
 
 interface SearchDropdownProps {
-  hasNonEditableState?: boolean;
+  compact: boolean;
   selectLabel: string;
   tooltipText: string;
   searchType: InputType;
@@ -25,11 +25,11 @@ interface SearchDropdownProps {
 
 //handle in progress repos here if necessary
 function SearchDropdown({
-  hasNonEditableState,
+  compact,
   selectLabel,
   searchType,
 }: SearchDropdownProps) {
-  const size = hasNonEditableState == true ? 'small' : undefined;
+  const size = compact ? 'small' : undefined;
   const mode = useAppSelector((state) => state.theme.mode);
   const repository = useAppSelector(
     (state) => state.search[searchType].repository,

--- a/src/components/Search/SearchInput.tsx
+++ b/src/components/Search/SearchInput.tsx
@@ -12,13 +12,13 @@ import { InputType } from '../../types/state';
 interface SearchInputProps {
   onFocus: () => unknown;
   inputPlaceholder: string;
-  isEditable?: boolean;
+  hasNonEditableState?: boolean;
   searchType: InputType;
 }
 
 function SearchInput({
   onFocus,
-  isEditable,
+  hasNonEditableState,
   inputPlaceholder,
   searchType,
 }: SearchInputProps) {
@@ -26,7 +26,7 @@ function SearchInput({
   const searchState = useAppSelector((state) => state.search[searchType]);
   const mode = useAppSelector((state) => state.theme.mode);
   const { inputError, inputHelperText, repository } = searchState;
-  const size = isEditable === true ? 'small' : undefined;
+  const size = hasNonEditableState === true ? 'small' : undefined;
 
   const styles = {
     container: style({

--- a/src/components/Search/SearchInput.tsx
+++ b/src/components/Search/SearchInput.tsx
@@ -12,13 +12,13 @@ import { InputType } from '../../types/state';
 interface SearchInputProps {
   onFocus: () => unknown;
   inputPlaceholder: string;
-  hasNonEditableState?: boolean;
+  compact: boolean;
   searchType: InputType;
 }
 
 function SearchInput({
   onFocus,
-  hasNonEditableState,
+  compact,
   inputPlaceholder,
   searchType,
 }: SearchInputProps) {
@@ -26,7 +26,7 @@ function SearchInput({
   const searchState = useAppSelector((state) => state.search[searchType]);
   const mode = useAppSelector((state) => state.theme.mode);
   const { inputError, inputHelperText, repository } = searchState;
-  const size = hasNonEditableState === true ? 'small' : undefined;
+  const size = compact ? 'small' : undefined;
 
   const styles = {
     container: style({

--- a/src/components/Search/SearchResultsList.tsx
+++ b/src/components/Search/SearchResultsList.tsx
@@ -8,7 +8,7 @@ import { Changeset } from '../../types/state';
 import SearchResultsListItem from './SearchResultsListItem';
 
 interface SearchResultsListProps {
-  isEditable: boolean;
+  hasNonEditableState: boolean;
   isBase: boolean;
   searchResults: Changeset[];
   displayedRevisions: Changeset[];
@@ -16,7 +16,7 @@ interface SearchResultsListProps {
 }
 
 function SearchResultsList({
-  isEditable,
+  hasNonEditableState,
   isBase,
   searchResults,
   displayedRevisions,
@@ -24,7 +24,7 @@ function SearchResultsList({
 }: SearchResultsListProps) {
   const mode = useAppSelector((state) => state.theme.mode);
   const styles = SelectListStyles(mode);
-  const { handleToggle } = useCheckRevision(isBase, isEditable);
+  const { handleToggle } = useCheckRevision(isBase, hasNonEditableState);
   const searchType = isBase ? 'base' : 'new';
   const revisionsCount = isBase === true ? 1 : 3;
   const isCommittedChecked = (item: Changeset) => {
@@ -35,12 +35,14 @@ function SearchResultsList({
   const isInProgressChecked = (item: Changeset) => {
     return displayedRevisions.map((rev) => rev.id).includes(item.id);
   };
-  const isCheckedState = isEditable ? isInProgressChecked : isCommittedChecked;
+  const isCheckedState = hasNonEditableState
+    ? isInProgressChecked
+    : isCommittedChecked;
 
   const handleToggleAction = (item: Changeset) => {
     const toggleArray = handleToggle(item, revisionsCount, displayedRevisions);
 
-    if (isEditable) {
+    if (hasNonEditableState) {
       onEditToggle(toggleArray);
     }
   };
@@ -52,7 +54,7 @@ function SearchResultsList({
       alignItems='flex-end'
       data-testid='list-mode'
     >
-      <List dense={isEditable} sx={{ paddingTop: '0' }}>
+      <List dense={hasNonEditableState} sx={{ paddingTop: '0' }}>
         {searchResults.map((item, index) => (
           <SearchResultsListItem
             key={item.id}

--- a/src/components/Search/SearchResultsList.tsx
+++ b/src/components/Search/SearchResultsList.tsx
@@ -52,7 +52,7 @@ function SearchResultsList({
       alignItems='flex-end'
       data-testid='list-mode'
     >
-      <List dense={isEditable == true} sx={{ paddingTop: '0' }}>
+      <List dense={isEditable} sx={{ paddingTop: '0' }}>
         {searchResults.map((item, index) => (
           <SearchResultsListItem
             key={item.id}

--- a/src/components/Search/SelectedRevisions.tsx
+++ b/src/components/Search/SelectedRevisions.tsx
@@ -10,7 +10,7 @@ import SelectedRevisionItem from './SelectedRevisionItem';
 interface SelectedRevisionsProps {
   isBase: boolean;
   formIsDisplayed: boolean;
-  isEditable: boolean;
+  hasNonEditableState: boolean;
   isWarning: boolean;
   displayedRevisions: Changeset[];
   onEditRemove: (item: Changeset) => void;
@@ -19,7 +19,7 @@ interface SelectedRevisionsProps {
 function SelectedRevisions({
   isBase,
   formIsDisplayed,
-  isEditable,
+  hasNonEditableState,
   isWarning,
   displayedRevisions,
   onEditRemove,
@@ -32,13 +32,16 @@ function SelectedRevisions({
     onEditRemove(item);
   };
 
-  const { removeCheckedRevision } = useCheckRevision(isBase, isEditable);
+  const { removeCheckedRevision } = useCheckRevision(
+    isBase,
+    hasNonEditableState,
+  );
 
   const handleRemoveRevision = (item: Changeset) => {
     removeCheckedRevision(item);
   };
   const removeRevision = (item: Changeset) => {
-    if (isEditable) {
+    if (hasNonEditableState) {
       onEditRemoveAction(item);
     } else {
       handleRemoveRevision(item);
@@ -46,7 +49,7 @@ function SelectedRevisions({
   };
 
   const iconClassName =
-    !formIsDisplayed && isEditable
+    !formIsDisplayed && hasNonEditableState
       ? 'icon icon-close-hidden'
       : 'icon icon-close-show';
 
@@ -54,7 +57,7 @@ function SelectedRevisions({
     <Box
       className={`${styles.box} ${searchType}-box`}
       data-testid={`selected-revs-${
-        isEditable ? '--editable-revisions' : '--search-revisions'
+        hasNonEditableState ? '--editable-revisions' : '--search-revisions'
       }`}
     >
       <List>


### PR DESCRIPTION
This one is optional and mostly cosmetic, but I find it easier to reason with.

Indeed, the forms in SearchView and ResultsView are both editable! The difference is that the one is ResultsView has a "non editable" state, or a "staging" state, that the user can revert to.
Therefore I find that the term `hasNonEditableState` makes more sense.
Tell me what you think! I'm also happy to rename it or just abandoning this change.

As part of this change, I also added a pretty big comment as an explanation of the 3 states of the CompareWithBase form. I'd like to keep that one at least.
