### PR TITLE
Small cleanup for SearchComponent

### DIFF
--- a/src/components/Search/SearchComponent.tsx
+++ b/src/components/Search/SearchComponent.tsx
@@ -188,7 +188,6 @@ function SearchComponent({
           {searchResults.length > 0 && displayDropdown && (
             <SearchResultsList
               hasNonEditableState={hasNonEditableState}
-              isBase={isBaseComp}
               searchResults={searchResults}
               displayedRevisions={displayedRevisions}
               onToggle={onSearchResultsToggle}

--- a/src/components/Search/SearchComponent.tsx
+++ b/src/components/Search/SearchComponent.tsx
@@ -1,10 +1,4 @@
-import {
-  Dispatch,
-  SetStateAction,
-  useEffect,
-  useState,
-  useCallback,
-} from 'react';
+import { useEffect, useState, useCallback } from 'react';
 
 import InfoIcon from '@mui/icons-material/InfoOutlined';
 import Grid from '@mui/material/Grid';
@@ -35,13 +29,11 @@ interface SearchProps {
   isBaseComp: boolean;
   searchResults: Changeset[];
   displayedRevisions: Changeset[];
-  setPopoverIsOpen?: Dispatch<SetStateAction<boolean>>;
   onSave: () => void;
   onCancel: () => void;
   onEdit: () => void;
   onSearchResultsToggle: (item: Changeset) => void;
   onRemoveRevision: (item: Changeset) => void;
-  prevRevision?: Changeset;
   selectLabel: string;
   tooltip: string;
   inputPlaceholder: string;

--- a/src/components/Search/SearchOverTime.tsx
+++ b/src/components/Search/SearchOverTime.tsx
@@ -151,7 +151,6 @@ export default function SearchOverTime({
           {searchResults.length > 0 && displayDropdown && (
             <SearchResultsList
               hasNonEditableState={isEditable}
-              isBase={false}
               searchResults={searchResults}
               displayedRevisions={displayedRevisions}
               onToggle={handleSearchResultsEditToggle}

--- a/src/components/Search/SearchResultsList.tsx
+++ b/src/components/Search/SearchResultsList.tsx
@@ -8,7 +8,6 @@ import SearchResultsListItem from './SearchResultsListItem';
 
 interface SearchResultsListProps {
   hasNonEditableState: boolean;
-  isBase: boolean;
   searchResults: Changeset[];
   displayedRevisions: Changeset[];
   onToggle: (item: Changeset) => void;
@@ -16,14 +15,12 @@ interface SearchResultsListProps {
 
 function SearchResultsList({
   hasNonEditableState,
-  isBase,
   searchResults,
   displayedRevisions,
   onToggle,
 }: SearchResultsListProps) {
   const mode = useAppSelector((state) => state.theme.mode);
   const styles = SelectListStyles(mode);
-  const revisionsCount = isBase === true ? 1 : 3;
   const isInProgressChecked = (item: Changeset) => {
     return displayedRevisions.map((rev) => rev.id).includes(item.id);
   };
@@ -41,7 +38,6 @@ function SearchResultsList({
             key={item.id}
             index={index}
             item={item}
-            revisionsCount={revisionsCount}
             isChecked={isInProgressChecked(item)}
             onToggle={onToggle}
           />

--- a/src/components/Search/SearchResultsListItem.tsx
+++ b/src/components/Search/SearchResultsListItem.tsx
@@ -18,7 +18,6 @@ import { truncateHash, getLatestCommitMessage } from '../../utils/helpers';
 interface SearchResultsListItemProps {
   index: number;
   item: Changeset;
-  revisionsCount: number;
   isChecked: boolean;
   onToggle: (item: Changeset) => void;
 }


### PR DESCRIPTION
Please look at the last 2 commits only.

This removes some unused props for `SearchComponent` and `SearchResultsListItem`.