### PR TITLE
Fix that the wrong item is unselected in some situations

### DIFF
--- a/src/components/Search/CompareWithBase.tsx
+++ b/src/components/Search/CompareWithBase.tsx
@@ -148,13 +148,25 @@ function CompareWithBase({
   };
 
   const handleRemoveRevisionBase = (item: Changeset) => {
+    // Currently item seems to be the same object than the one stored in
+    // baseInProgressRevs, but it might change in the future. That's why we're
+    // comparing the ids instead of using indexOf directly.
+    const indexInBaseChangesets = baseInProgressRevs.findIndex(
+      (rev) => rev.id === item.id,
+    );
     const revisionsBase = [...baseInProgressRevs];
-    revisionsBase.splice(baseInProgressRevs.indexOf(item), 1);
+    revisionsBase.splice(indexInBaseChangesets, 1);
     setInProgressBaseRevs(revisionsBase);
   };
   const handleRemoveRevisionNew = (item: Changeset) => {
+    // Currently item seems to be the same object than the one stored in
+    // newInProgressRevs, but it might change in the future. That's why we're
+    // comparing the ids instead of using indexOf directly.
+    const indexInNewChangesets = newInProgressRevs.findIndex(
+      (rev) => rev.id === item.id,
+    );
     const revisionsNew = [...newInProgressRevs];
-    revisionsNew.splice(newInProgressRevs.indexOf(item), 1);
+    revisionsNew.splice(indexInNewChangesets, 1);
     setInProgressNewRevs(revisionsNew);
   };
 
@@ -167,7 +179,14 @@ function CompareWithBase({
     maxRevisions: number;
     changesets: Changeset[];
   }) => {
-    const isChecked = changesets.map((rev) => rev.id).includes(item.id);
+    // Warning: `item` isn't always the same object than the one in
+    // `changesets`, therefore we need to compare the id. This happens when the
+    // data in `changesets` comes from the loader, but `item` comes from the
+    // search results.
+    const indexInCheckedChangesets = changesets.findIndex(
+      (rev) => rev.id === item.id,
+    );
+    const isChecked = indexInCheckedChangesets >= 0;
     const newChecked = [...changesets];
 
     // if item is not already checked, add to checked
@@ -175,15 +194,14 @@ function CompareWithBase({
       newChecked.push(item);
     } else if (isChecked) {
       // if item is already checked, remove from checked
-      newChecked.splice(changesets.indexOf(item), 1);
+      newChecked.splice(indexInCheckedChangesets, 1);
     } else {
       // if there are already `maxRevisions` checked revisions, print a warning
       const variant: VariantType = 'warning';
       enqueueSnackbar(`Maximum ${maxRevisions} revision(s).`, { variant });
     }
 
-    const filteredChecked = [...new Set(newChecked)];
-    return filteredChecked;
+    return newChecked;
   };
 
   const handleSearchResultsToggleBase = (item: Changeset) => {


### PR DESCRIPTION
Please look at the last commit only.

Here is the STR:
1. Go to https://beta--mozilla-perfcompare.netlify.app/
2. Pick a base rev, and 3 "new revs".
3. Press "Compare"
4. Reload the page (important)
5. Edit the new revs
6. Try to uncheck the first one from the search results list.

=> result: the last one is unchecked instead of the first one

When unchecking one element, the executed operation to find the index is:
```js
revs.indexOf(item)
```
Where `revs` contains the currently selected items, and `item` is the item we just clicked. 
The problem is that the object `item` isn't inside `revs`... an identical object is present, but not the exact same object with the same reference. As a result `indexOf` doesn't find the object... and returns `-1`.
Then `-1` is passed to `splice`, which helpfully removes... the last element. Tada.

Instead I changed the logic to use `findIndex` with a callback that compares the revision id instead. Then this fixes the problem accordingly.

This may be a regression from #582.

I didn't do a test for this because I thought this is an edge case. But I can do one if you prefer.