### PR TITLE
Move the repository information from Redux to a local state in CompareWithBase

### DIFF
--- a/src/__tests__/Search/SearchContainer.test.tsx
+++ b/src/__tests__/Search/SearchContainer.test.tsx
@@ -1,9 +1,22 @@
 import React from 'react';
 
 import SearchContainer from '../../components/Search/SearchContainer';
-import { renderWithRouter } from '../utils/test-utils';
+import getTestData from '../utils/fixtures';
+import { renderWithRouter, FetchMockSandbox } from '../utils/test-utils';
+
+// This can be removed once SearchViewInit is removed.
+function setupTestData() {
+  const { testData } = getTestData();
+  (global.fetch as FetchMockSandbox).get(
+    'begin:https://treeherder.mozilla.org/api/project/try/push/',
+    {
+      results: testData,
+    },
+  );
+}
 
 function renderComponent() {
+  setupTestData();
   const ref: React.RefObject<HTMLInputElement> = React.createRef();
   renderWithRouter(<SearchContainer containerRef={ref} />);
 }

--- a/src/__tests__/Search/SearchView.test.tsx
+++ b/src/__tests__/Search/SearchView.test.tsx
@@ -70,7 +70,7 @@ describe('Search Container', () => {
     const baseInput = screen.getByPlaceholderText(
       'Search base by ID number or author email',
     );
-    const repoDropdown = screen.getAllByTestId('dropdown-select-base')[0];
+    const repoDropdown = screen.getAllByRole('button', { name: 'Base' })[0];
 
     expect(compTitle).toBeInTheDocument();
     expect(baseInput).toBeInTheDocument();

--- a/src/components/CompareResults/ResultsView.tsx
+++ b/src/components/CompareResults/ResultsView.tsx
@@ -8,7 +8,6 @@ import { useAppDispatch, useAppSelector } from '../../hooks/app';
 import { updateFramework } from '../../reducers/FrameworkSlice';
 import { SearchContainerStyles, background } from '../../styles';
 import CompareWithBase from '../Search/CompareWithBase';
-import SearchViewInit from '../Search/SearchViewInit';
 import { LinkToHome } from '../Shared/LinkToHome';
 import PerfCompareHeader from '../Shared/PerfCompareHeader';
 import type { LoaderReturnValue } from './loader';
@@ -62,7 +61,6 @@ function ResultsView(props: ResultsViewProps) {
       <PerfCompareHeader />
       <section className={sectionStyles.container}>
         <LinkToHome />
-        <SearchViewInit />
 
         <CompareWithBase
           hasNonEditableState={true}

--- a/src/components/Search/CompareWithBase.tsx
+++ b/src/components/Search/CompareWithBase.tsx
@@ -10,10 +10,11 @@ import { style } from 'typestyle';
 import { useAppSelector } from '../../hooks/app';
 import { Strings } from '../../resources/Strings';
 import { CompareCardsStyles, SearchStyles, Spacing } from '../../styles';
-import type { Changeset } from '../../types/state';
+import type { Changeset, Repository } from '../../types/state';
 import CompareButton from './CompareButton';
 import FrameworkDropdown from './FrameworkDropdown';
 import SearchComponent from './SearchComponent';
+import SearchViewInit from './SearchViewInit';
 
 const strings = Strings.components.searchDefault;
 const stringsBase = Strings.components.searchDefault.base.collapsed.base;
@@ -83,14 +84,18 @@ function CompareWithBase({
     useState<Changeset[]>(baseRevs);
   const [newInProgressRevs, setInProgressNewRevs] =
     useState<Changeset[]>(newRevs);
+  const [baseRepository, setBaseRepository] = useState(
+    'try' as Repository['name'],
+  );
+  const [newRepository, setNewRepository] = useState(
+    'try' as Repository['name'],
+  );
 
   const mode = useAppSelector((state) => state.theme.mode);
 
   const styles = CompareCardsStyles(mode);
   const dropDownStyles = SearchStyles(mode);
   const search = useAppSelector((state) => state.search);
-  const baseRepository = search.base.repository;
-  const newRepository = search.new.repository;
   const searchResultsBase = search.base.searchResults;
   const searchResultsNew = search.new.searchResults;
 
@@ -223,6 +228,10 @@ function CompareWithBase({
 
   return (
     <Grid className={`wrapper--withbase ${wrapperStyles.wrapper}`}>
+      <SearchViewInit
+        repositoryBase={baseRepository}
+        repositoryNew={newRepository}
+      />
       <div
         className={`compare-card-container compare-card-container--${
           expanded ? 'expanded' : 'hidden'
@@ -266,6 +275,10 @@ function CompareWithBase({
             onEdit={handleEditBase}
             onSearchResultsToggle={handleSearchResultsToggleBase}
             onRemoveRevision={handleRemoveRevisionBase}
+            repository={baseRepository}
+            onRepositoryChange={(repo: Repository['name']) =>
+              setBaseRepository(repo)
+            }
           />
           <SearchComponent
             {...stringsNew}
@@ -279,6 +292,10 @@ function CompareWithBase({
             onEdit={handleEditNew}
             onSearchResultsToggle={handleSearchResultsToggleNew}
             onRemoveRevision={handleRemoveRevisionNew}
+            repository={newRepository}
+            onRepositoryChange={(repo: Repository['name']) =>
+              setNewRepository(repo)
+            }
           />
           <Grid
             item

--- a/src/components/Search/SearchComponent.tsx
+++ b/src/components/Search/SearchComponent.tsx
@@ -15,7 +15,7 @@ import {
   //SearchStyles can be found in CompareCards.ts
   SearchStyles,
 } from '../../styles';
-import type { Changeset, InputType } from '../../types/state';
+import type { Changeset, InputType, Repository } from '../../types/state';
 import EditButton from './EditButton';
 import SaveCancelButtons from './SaveCancelButtons';
 import SearchDropdown from './SearchDropdown';
@@ -37,6 +37,8 @@ interface SearchProps {
   selectLabel: string;
   tooltip: string;
   inputPlaceholder: string;
+  repository: Repository['name'];
+  onRepositoryChange: (repo: Repository['name']) => unknown;
 }
 
 function SearchComponent({
@@ -53,6 +55,8 @@ function SearchComponent({
   tooltip,
   inputPlaceholder,
   isWarning,
+  repository,
+  onRepositoryChange,
 }: SearchProps) {
   const mode = useAppSelector((state) => state.theme.mode);
   const styles = SearchStyles(mode);
@@ -167,8 +171,9 @@ function SearchComponent({
           <SearchDropdown
             compact={hasNonEditableState}
             selectLabel={selectLabel}
-            tooltipText={tooltip}
             searchType={searchType}
+            repository={repository}
+            onChange={onRepositoryChange}
           />
         </Grid>
         <Grid
@@ -184,6 +189,7 @@ function SearchComponent({
             compact={hasNonEditableState}
             inputPlaceholder={inputPlaceholder}
             searchType={searchType}
+            repository={repository}
           />
           {searchResults.length > 0 && displayDropdown && (
             <SearchResultsList

--- a/src/components/Search/SearchDropdown.tsx
+++ b/src/components/Search/SearchDropdown.tsx
@@ -5,7 +5,6 @@ import { style, cssRule } from 'typestyle';
 
 import { repoMap } from '../../common/constants';
 import { useAppSelector, useAppDispatch } from '../../hooks/app';
-import { updateRepository } from '../../reducers/SearchSlice';
 import {
   ButtonsLightRaw,
   ButtonsDarkRaw,
@@ -19,8 +18,9 @@ import { InputType, Repository } from '../../types/state';
 interface SearchDropdownProps {
   compact: boolean;
   selectLabel: string;
-  tooltipText: string;
   searchType: InputType;
+  repository: Repository['name'];
+  onChange: (val: Repository['name']) => unknown;
 }
 
 //handle in progress repos here if necessary
@@ -28,22 +28,16 @@ function SearchDropdown({
   compact,
   selectLabel,
   searchType,
+  repository,
+  onChange,
 }: SearchDropdownProps) {
   const size = compact ? 'small' : undefined;
   const mode = useAppSelector((state) => state.theme.mode);
-  const repository = useAppSelector(
-    (state) => state.search[searchType].repository,
-  );
   const dispatch = useAppDispatch();
 
   const handleRepoSelect = async (event: SelectChangeEvent) => {
     const selectedRepository = event.target.value as Repository['name'];
-    dispatch(
-      updateRepository({
-        repository: selectedRepository,
-        searchType: searchType,
-      }),
-    );
+    onChange(selectedRepository);
 
     // Fetch 10 most recent revisions when repository changes
     await dispatch(

--- a/src/components/Search/SearchInput.tsx
+++ b/src/components/Search/SearchInput.tsx
@@ -7,13 +7,14 @@ import { style } from 'typestyle';
 import { useAppSelector } from '../../hooks/app';
 import useHandleChangeSearch from '../../hooks/useHandleChangeSearch';
 import { InputStylesRaw } from '../../styles';
-import { InputType } from '../../types/state';
+import { InputType, Repository } from '../../types/state';
 
 interface SearchInputProps {
   onFocus: () => unknown;
   inputPlaceholder: string;
   compact: boolean;
   searchType: InputType;
+  repository: Repository['name'];
 }
 
 function SearchInput({
@@ -21,11 +22,12 @@ function SearchInput({
   compact,
   inputPlaceholder,
   searchType,
+  repository,
 }: SearchInputProps) {
   const { handleChangeSearch } = useHandleChangeSearch();
   const searchState = useAppSelector((state) => state.search[searchType]);
   const mode = useAppSelector((state) => state.theme.mode);
-  const { inputError, inputHelperText, repository } = searchState;
+  const { inputError, inputHelperText } = searchState;
   const size = compact ? 'small' : undefined;
 
   const styles = {

--- a/src/components/Search/SearchOverTime.tsx
+++ b/src/components/Search/SearchOverTime.tsx
@@ -15,7 +15,7 @@ import {
   //SearchStyles can be found in CompareCards.ts
   SearchStyles,
 } from '../../styles';
-import { Changeset } from '../../types/state';
+import { Changeset, Repository } from '../../types/state';
 import SearchDropdown from './SearchDropdown';
 import SearchInput from './SearchInput';
 import SearchResultsList from './SearchResultsList';
@@ -38,6 +38,8 @@ export default function SearchOverTime({
   const mode = useAppSelector((state) => state.theme.mode);
   const styles = SearchStyles(mode);
   const [displayDropdown, setDisplayDropdown] = useState(false);
+  const [repository, setRepository] = useState('try' as Repository['name']);
+
   //temporary until next PR covers selected revisions
   const handleSearchResultsEditToggle = (item: Changeset) => {
     console.log('handleSearchResultsEditToggle', item);
@@ -130,8 +132,9 @@ export default function SearchOverTime({
           <SearchDropdown
             compact={false}
             selectLabel={selectLabel}
-            tooltipText={tooltip}
             searchType='new'
+            repository={repository}
+            onChange={(repo: Repository['name']) => setRepository(repo)}
           />
         </Grid>
         <Grid
@@ -147,6 +150,7 @@ export default function SearchOverTime({
             compact={false}
             inputPlaceholder={inputPlaceholder}
             searchType='new'
+            repository={repository}
           />
           {searchResults.length > 0 && displayDropdown && (
             <SearchResultsList

--- a/src/components/Search/SearchView.tsx
+++ b/src/components/Search/SearchView.tsx
@@ -8,7 +8,6 @@ import { skipLink } from '../../styles';
 import SkipLink from '../Accessibility/SkipLink';
 import PerfCompareHeader from '../Shared/PerfCompareHeader';
 import SearchContainer from './SearchContainer';
-import SearchViewInit from './SearchViewInit';
 
 function SearchView(props: SearchViewProps) {
   const containerRef = useRef(null);
@@ -33,7 +32,6 @@ function SearchView(props: SearchViewProps) {
         </button>
       </SkipLink>
       <PerfCompareHeader isHome />
-      <SearchViewInit />
       <SearchContainer containerRef={containerRef} />
     </div>
   );

--- a/src/components/Search/SearchViewInit.tsx
+++ b/src/components/Search/SearchViewInit.tsx
@@ -1,17 +1,18 @@
 import { useEffect } from 'react';
 
 import { useAppDispatch } from '../../hooks/app';
-import { useAppSelector } from '../../hooks/app';
 import { fetchRecentRevisions } from '../../thunks/searchThunk';
-import { InputType } from '../../types/state';
+import { InputType, Repository } from '../../types/state';
 
 // component to fetch recent revisions when search view is loaded
-function SearchViewInit() {
+function SearchViewInit({
+  repositoryBase,
+  repositoryNew,
+}: {
+  repositoryBase: Repository['name'];
+  repositoryNew: Repository['name'];
+}) {
   const dispatch = useAppDispatch();
-  const repositoryBase = useAppSelector(
-    (state) => state.search.base.repository,
-  );
-  const repositoryNew = useAppSelector((state) => state.search.new.repository);
 
   useEffect(() => {
     const repository = repositoryBase;

--- a/src/reducers/SearchSlice.ts
+++ b/src/reducers/SearchSlice.ts
@@ -6,7 +6,6 @@ import {
   fetchRevisionsByAuthor,
 } from '../thunks/searchThunk';
 import type {
-  Repository,
   Changeset,
   SearchState,
   SearchStateForInput,
@@ -14,7 +13,6 @@ import type {
 } from '../types/state';
 
 const DEFAULT_VALUES: SearchStateForInput = {
-  repository: 'try',
   searchResults: [],
   searchValue: '',
   inputError: false,
@@ -52,17 +50,6 @@ const search = createSlice({
       state[type].searchResults = action.payload.results;
       state[type].inputError = false;
       state[type].inputHelperText = '';
-    },
-
-    updateRepository(
-      state,
-      action: PayloadAction<{
-        repository: Repository['name'];
-        searchType: InputType;
-      }>,
-    ) {
-      const type = action.payload.searchType;
-      state[type].repository = action.payload.repository;
     },
 
     setInputError(
@@ -118,10 +105,6 @@ const search = createSlice({
   },
 });
 
-export const {
-  updateSearchValue,
-  updateSearchResults,
-  updateRepository,
-  setInputError,
-} = search.actions;
+export const { updateSearchValue, updateSearchResults, setInputError } =
+  search.actions;
 export default search.reducer;

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -94,7 +94,6 @@ export type CompareResultsItem = {
 };
 
 export type SearchStateForInput = {
-  repository: Repository['name'];
   searchResults: Changeset[];
   searchValue: string;
   inputError: boolean;


### PR DESCRIPTION
The goal is to make `SearchContainer` and all other components in the tree more self-contained that they were before.

This also moves SearchViewInit to CompareWithBase. But this is only
temporary because this component will be removed later.
