### PR TITLE
Change SearchResultsList's prop 'hasNonEditableState' to 'compact'

### DIFF
--- a/src/components/Search/SearchComponent.tsx
+++ b/src/components/Search/SearchComponent.tsx
@@ -187,7 +187,7 @@ function SearchComponent({
           />
           {searchResults.length > 0 && displayDropdown && (
             <SearchResultsList
-              hasNonEditableState={hasNonEditableState}
+              compact={hasNonEditableState}
               searchResults={searchResults}
               displayedRevisions={displayedRevisions}
               onToggle={onSearchResultsToggle}

--- a/src/components/Search/SearchOverTime.tsx
+++ b/src/components/Search/SearchOverTime.tsx
@@ -150,7 +150,7 @@ export default function SearchOverTime({
           />
           {searchResults.length > 0 && displayDropdown && (
             <SearchResultsList
-              hasNonEditableState={isEditable}
+              compact={isEditable}
               searchResults={searchResults}
               displayedRevisions={displayedRevisions}
               onToggle={handleSearchResultsEditToggle}

--- a/src/components/Search/SearchResultsList.tsx
+++ b/src/components/Search/SearchResultsList.tsx
@@ -7,14 +7,14 @@ import { Changeset } from '../../types/state';
 import SearchResultsListItem from './SearchResultsListItem';
 
 interface SearchResultsListProps {
-  hasNonEditableState: boolean;
+  compact: boolean;
   searchResults: Changeset[];
   displayedRevisions: Changeset[];
   onToggle: (item: Changeset) => void;
 }
 
 function SearchResultsList({
-  hasNonEditableState,
+  compact,
   searchResults,
   displayedRevisions,
   onToggle,
@@ -32,7 +32,7 @@ function SearchResultsList({
       alignItems='flex-end'
       data-testid='list-mode'
     >
-      <List dense={hasNonEditableState} sx={{ paddingTop: '0' }}>
+      <List dense={compact} sx={{ paddingTop: '0' }}>
         {searchResults.map((item, index) => (
           <SearchResultsListItem
             key={item.id}


### PR DESCRIPTION
This was done for `SearchInput` in a previous PR, but `SearchResultsList` used `hasNonEditableState` for more things before #626. After #626 we can change its name so that it's more descriptive.

Please look at the last commit only.