### PR TITLE
Donot render non expanded rows

### DIFF
--- a/src/__tests__/CompareResults/ResultsView.test.tsx
+++ b/src/__tests__/CompareResults/ResultsView.test.tsx
@@ -82,40 +82,6 @@ describe('Results View', () => {
     expect(linkToSuite).not.toBeInTheDocument();
   });
 
-  it('Should display the expande row when expand button is clicked', async () => {
-    const user = userEvent.setup({ delay: null });
-    // We set up a compare data that has 1 result but with several runs, so that
-    // the graphs are displayed for this result.
-    const { testCompareDataWithMultipleRuns, testData } = getTestData();
-    (window.fetch as FetchMockSandbox)
-      .get(
-        'begin:https://treeherder.mozilla.org/api/perfcompare/results/',
-        testCompareDataWithMultipleRuns,
-      )
-      .get('begin:https://treeherder.mozilla.org/api/project/', {
-        results: [testData[0]],
-      });
-
-    renderWithRouter(
-      <ResultsView title={Strings.metaData.pageTitle.results} />,
-      {
-        route: '/compare-results/',
-        search: '?baseRev=spam&baseRepo=mozilla-central&framework=2',
-        loader,
-      },
-    );
-
-    const expandedRowContent = screen.queryByTestId('expanded-row-content');
-    expect(expandedRowContent).not.toBeInTheDocument();
-
-    const expandButton = await screen.findByRole('button', {
-      name: 'expand this row',
-    });
-    await user.click(expandButton);
-    expect(
-      await screen.findByTestId('expanded-row-content'),
-    ).toBeInTheDocument();
-  });
 
   it('Should display Base, New and Common graphs with tooltips', async () => {
     const user = userEvent.setup({ delay: null });

--- a/src/__tests__/CompareResults/ResultsView.test.tsx
+++ b/src/__tests__/CompareResults/ResultsView.test.tsx
@@ -82,7 +82,6 @@ describe('Results View', () => {
     expect(linkToSuite).not.toBeInTheDocument();
   });
 
-
   it('Should display Base, New and Common graphs with tooltips', async () => {
     const user = userEvent.setup({ delay: null });
 

--- a/src/__tests__/CompareResults/ResultsView.test.tsx
+++ b/src/__tests__/CompareResults/ResultsView.test.tsx
@@ -82,6 +82,41 @@ describe('Results View', () => {
     expect(linkToSuite).not.toBeInTheDocument();
   });
 
+  it('Should display the expande row when expand button is clicked', async () => {
+    const user = userEvent.setup({ delay: null });
+    // We set up a compare data that has 1 result but with several runs, so that
+    // the graphs are displayed for this result.
+    const { testCompareDataWithMultipleRuns, testData } = getTestData();
+    (window.fetch as FetchMockSandbox)
+      .get(
+        'begin:https://treeherder.mozilla.org/api/perfcompare/results/',
+        testCompareDataWithMultipleRuns,
+      )
+      .get('begin:https://treeherder.mozilla.org/api/project/', {
+        results: [testData[0]],
+      });
+
+    renderWithRouter(
+      <ResultsView title={Strings.metaData.pageTitle.results} />,
+      {
+        route: '/compare-results/',
+        search: '?baseRev=spam&baseRepo=mozilla-central&framework=2',
+        loader,
+      },
+    );
+
+    const expandedRowContent = screen.queryByTestId('expanded-row-content');
+    expect(expandedRowContent).not.toBeInTheDocument();
+
+    const expandButton = await screen.findByRole('button', {
+      name: 'expand this row',
+    });
+    await user.click(expandButton);
+    expect(
+      await screen.findByTestId('expanded-row-content'),
+    ).toBeInTheDocument();
+  });
+
   it('Should display Base, New and Common graphs with tooltips', async () => {
     const user = userEvent.setup({ delay: null });
 

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -464,10 +464,6 @@ exports[`Results Table Should match snapshot 1`] = `
             </div>
           </div>
           <div
-            class="content-row content-row--default container_f1izwqil "
-            data-testid="expanded-row-content"
-          />
-          <div
             class="revisionRow f1x1c13s fp4ugv1"
             role="row"
           >
@@ -706,10 +702,6 @@ exports[`Results Table Should match snapshot 1`] = `
               </div>
             </div>
           </div>
-          <div
-            class="content-row content-row--default container_f1izwqil "
-            data-testid="expanded-row-content"
-          />
           <div
             class="revisionRow f1x1c13s fp4ugv1"
             role="row"
@@ -956,10 +948,6 @@ exports[`Results Table Should match snapshot 1`] = `
             </div>
           </div>
           <div
-            class="content-row content-row--default container_f1izwqil "
-            data-testid="expanded-row-content"
-          />
-          <div
             class="revisionRow f1x1c13s fp4ugv1"
             role="row"
           >
@@ -1203,10 +1191,6 @@ exports[`Results Table Should match snapshot 1`] = `
               </div>
             </div>
           </div>
-          <div
-            class="content-row content-row--default container_f1izwqil "
-            data-testid="expanded-row-content"
-          />
         </div>
       </div>
     </div>

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -464,78 +464,9 @@ exports[`Results Table Should match snapshot 1`] = `
             </div>
           </div>
           <div
-            class="content-row content-row--default container_f16sbjml "
+            class="content-row content-row--default container_f1izwqil "
             data-testid="expanded-row-content"
-          >
-            <div
-              class="ff20o48"
-            >
-              <div
-                class="f19s1n7z"
-              >
-                <div
-                  class="fc8wfj0"
-                >
-                  <b>
-                    macosx1015-64-shippable-qr
-                  </b>
-                   
-                  <br />
-                </div>
-                <div
-                  class="fc8wfj0"
-                >
-                  <hr
-                    class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"
-                  />
-                   
-                </div>
-                <div
-                  class="fc8wfj0"
-                >
-                  <div>
-                    Only one run (consider more runs for greater confidence).
-                     
-                  </div>
-                </div>
-                <div
-                  class="fc8wfj0"
-                >
-                  <b>
-                    Mean Difference
-                  </b>
-                  : 
-                  1.08
-                  %
-                   
-                  worse
-                   (
-                  7.6
-                  )
-                </div>
-                <div>
-                  <div>
-                    <b>
-                      Confidence
-                    </b>
-                    : 
-                    Low
-                     
-                  </div>
-                  <div
-                    class="fj8mg7a"
-                  >
-                    <b>
-                      **Note
-                    </b>
-                    : 
-                    A value of 'low' suggests less confidence that there is a sustained, significant change between the two revisions.
-                     
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+          />
           <div
             class="revisionRow f1x1c13s fp4ugv1"
             role="row"
@@ -776,78 +707,9 @@ exports[`Results Table Should match snapshot 1`] = `
             </div>
           </div>
           <div
-            class="content-row content-row--default container_f16sbjml "
+            class="content-row content-row--default container_f1izwqil "
             data-testid="expanded-row-content"
-          >
-            <div
-              class="ff20o48"
-            >
-              <div
-                class="f19s1n7z"
-              >
-                <div
-                  class="fc8wfj0"
-                >
-                  <b>
-                    linux1804-64-shippable-qr
-                  </b>
-                   
-                  <br />
-                </div>
-                <div
-                  class="fc8wfj0"
-                >
-                  <hr
-                    class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"
-                  />
-                   
-                </div>
-                <div
-                  class="fc8wfj0"
-                >
-                  <div>
-                    Only one run (consider more runs for greater confidence).
-                     
-                  </div>
-                </div>
-                <div
-                  class="fc8wfj0"
-                >
-                  <b>
-                    Mean Difference
-                  </b>
-                  : 
-                  1.85
-                  %
-                   
-                  worse
-                   (
-                  14.37
-                  )
-                </div>
-                <div>
-                  <div>
-                    <b>
-                      Confidence
-                    </b>
-                    : 
-                    Medium
-                     
-                  </div>
-                  <div
-                    class="fj8mg7a"
-                  >
-                    <b>
-                      **Note
-                    </b>
-                    : 
-                    A value of 'med' indicates uncertainty that there is a significant change. If you haven't already, consider retriggering the job to be more sure.
-                     
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+          />
           <div
             class="revisionRow f1x1c13s fp4ugv1"
             role="row"
@@ -1094,78 +956,9 @@ exports[`Results Table Should match snapshot 1`] = `
             </div>
           </div>
           <div
-            class="content-row content-row--default container_f16sbjml "
+            class="content-row content-row--default container_f1izwqil "
             data-testid="expanded-row-content"
-          >
-            <div
-              class="ff20o48"
-            >
-              <div
-                class="f19s1n7z"
-              >
-                <div
-                  class="fc8wfj0"
-                >
-                  <b>
-                    windows10-64-shippable-qr
-                  </b>
-                   
-                  <br />
-                </div>
-                <div
-                  class="fc8wfj0"
-                >
-                  <hr
-                    class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"
-                  />
-                   
-                </div>
-                <div
-                  class="fc8wfj0"
-                >
-                  <div>
-                    Only one run (consider more runs for greater confidence).
-                     
-                  </div>
-                </div>
-                <div
-                  class="fc8wfj0"
-                >
-                  <b>
-                    Mean Difference
-                  </b>
-                  : 
-                  -2.4
-                  %
-                   
-                  better
-                   (
-                  -15.46
-                  )
-                </div>
-                <div>
-                  <div>
-                    <b>
-                      Confidence
-                    </b>
-                    : 
-                    High
-                     
-                  </div>
-                  <div
-                    class="fj8mg7a"
-                  >
-                    <b>
-                      **Note
-                    </b>
-                    : 
-                    A value of 'high' indicates more confidence that there is a significant change, however you should check the historical record for the test by looking at the graph to be more sure (some noisy tests can provide inconsistent results).
-                     
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+          />
           <div
             class="revisionRow f1x1c13s fp4ugv1"
             role="row"
@@ -1411,67 +1204,9 @@ exports[`Results Table Should match snapshot 1`] = `
             </div>
           </div>
           <div
-            class="content-row content-row--default container_f16sbjml "
+            class="content-row content-row--default container_f1izwqil "
             data-testid="expanded-row-content"
-          >
-            <div
-              class="ff20o48"
-            >
-              <div
-                class="f19s1n7z"
-              >
-                <div
-                  class="fc8wfj0"
-                >
-                  <b>
-                    windows10-64-shippable-qr
-                  </b>
-                   
-                  <br />
-                </div>
-                <div
-                  class="fc8wfj0"
-                >
-                  <hr
-                    class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"
-                  />
-                   
-                </div>
-                <div
-                  class="fc8wfj0"
-                >
-                  <div>
-                    Only one run (consider more runs for greater confidence).
-                     
-                  </div>
-                </div>
-                <div
-                  class="fc8wfj0"
-                >
-                  <b>
-                    Mean Difference
-                  </b>
-                  : 
-                  -2.4
-                  %
-                   
-                  better
-                   (
-                  -15.46
-                  )
-                </div>
-                <div>
-                  <div>
-                    <b>
-                      Confidence
-                    </b>
-                    : Not available
-                     
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+          />
         </div>
       </div>
     </div>

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Results View Should display Base, New and Common graphs with tooltips 1`] = `
 <div
-  class="content-row content-row--expanded container_f16sbjml "
+  class="content-row content-row--expanded container_f1izwqil "
   data-testid="expanded-row-content"
 >
   <div
@@ -660,78 +660,9 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="content-row content-row--default container_f16sbjml "
+        class="content-row content-row--default container_f1izwqil "
         data-testid="expanded-row-content"
-      >
-        <div
-          class="ff20o48"
-        >
-          <div
-            class="f19s1n7z"
-          >
-            <div
-              class="fc8wfj0"
-            >
-              <b>
-                macosx1015-64-shippable-qr
-              </b>
-               
-              <br />
-            </div>
-            <div
-              class="fc8wfj0"
-            >
-              <hr
-                class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"
-              />
-               
-            </div>
-            <div
-              class="fc8wfj0"
-            >
-              <div>
-                Only one run (consider more runs for greater confidence).
-                 
-              </div>
-            </div>
-            <div
-              class="fc8wfj0"
-            >
-              <b>
-                Mean Difference
-              </b>
-              : 
-              1.08
-              %
-               
-              worse
-               (
-              7.6
-              )
-            </div>
-            <div>
-              <div>
-                <b>
-                  Confidence
-                </b>
-                : 
-                Low
-                 
-              </div>
-              <div
-                class="fj8mg7a"
-              >
-                <b>
-                  **Note
-                </b>
-                : 
-                A value of 'low' suggests less confidence that there is a sustained, significant change between the two revisions.
-                 
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+      />
       <div
         class="revisionRow f1x1c13s fp4ugv1"
         role="row"
@@ -972,78 +903,9 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="content-row content-row--default container_f16sbjml "
+        class="content-row content-row--default container_f1izwqil "
         data-testid="expanded-row-content"
-      >
-        <div
-          class="ff20o48"
-        >
-          <div
-            class="f19s1n7z"
-          >
-            <div
-              class="fc8wfj0"
-            >
-              <b>
-                linux1804-64-shippable-qr
-              </b>
-               
-              <br />
-            </div>
-            <div
-              class="fc8wfj0"
-            >
-              <hr
-                class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"
-              />
-               
-            </div>
-            <div
-              class="fc8wfj0"
-            >
-              <div>
-                Only one run (consider more runs for greater confidence).
-                 
-              </div>
-            </div>
-            <div
-              class="fc8wfj0"
-            >
-              <b>
-                Mean Difference
-              </b>
-              : 
-              1.85
-              %
-               
-              worse
-               (
-              14.37
-              )
-            </div>
-            <div>
-              <div>
-                <b>
-                  Confidence
-                </b>
-                : 
-                Medium
-                 
-              </div>
-              <div
-                class="fj8mg7a"
-              >
-                <b>
-                  **Note
-                </b>
-                : 
-                A value of 'med' indicates uncertainty that there is a significant change. If you haven't already, consider retriggering the job to be more sure.
-                 
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+      />
       <div
         class="revisionRow f1x1c13s fp4ugv1"
         role="row"
@@ -1290,78 +1152,9 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="content-row content-row--default container_f16sbjml "
+        class="content-row content-row--default container_f1izwqil "
         data-testid="expanded-row-content"
-      >
-        <div
-          class="ff20o48"
-        >
-          <div
-            class="f19s1n7z"
-          >
-            <div
-              class="fc8wfj0"
-            >
-              <b>
-                windows10-64-shippable-qr
-              </b>
-               
-              <br />
-            </div>
-            <div
-              class="fc8wfj0"
-            >
-              <hr
-                class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"
-              />
-               
-            </div>
-            <div
-              class="fc8wfj0"
-            >
-              <div>
-                Only one run (consider more runs for greater confidence).
-                 
-              </div>
-            </div>
-            <div
-              class="fc8wfj0"
-            >
-              <b>
-                Mean Difference
-              </b>
-              : 
-              -2.4
-              %
-               
-              better
-               (
-              -15.46
-              )
-            </div>
-            <div>
-              <div>
-                <b>
-                  Confidence
-                </b>
-                : 
-                High
-                 
-              </div>
-              <div
-                class="fj8mg7a"
-              >
-                <b>
-                  **Note
-                </b>
-                : 
-                A value of 'high' indicates more confidence that there is a significant change, however you should check the historical record for the test by looking at the graph to be more sure (some noisy tests can provide inconsistent results).
-                 
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+      />
       <div
         class="revisionRow f1x1c13s fp4ugv1"
         role="row"
@@ -1607,67 +1400,9 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="content-row content-row--default container_f16sbjml "
+        class="content-row content-row--default container_f1izwqil "
         data-testid="expanded-row-content"
-      >
-        <div
-          class="ff20o48"
-        >
-          <div
-            class="f19s1n7z"
-          >
-            <div
-              class="fc8wfj0"
-            >
-              <b>
-                windows10-64-shippable-qr
-              </b>
-               
-              <br />
-            </div>
-            <div
-              class="fc8wfj0"
-            >
-              <hr
-                class="MuiDivider-root MuiDivider-fullWidth css-9mgopn-MuiDivider-root"
-              />
-               
-            </div>
-            <div
-              class="fc8wfj0"
-            >
-              <div>
-                Only one run (consider more runs for greater confidence).
-                 
-              </div>
-            </div>
-            <div
-              class="fc8wfj0"
-            >
-              <b>
-                Mean Difference
-              </b>
-              : 
-              -2.4
-              %
-               
-              better
-               (
-              -15.46
-              )
-            </div>
-            <div>
-              <div>
-                <b>
-                  Confidence
-                </b>
-                : Not available
-                 
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+      />
     </div>
   </div>
 </div>

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Results View Should display Base, New and Common graphs with tooltips 1`] = `
 <div
-  class="content-row content-row--expanded container_f1izwqil "
+  class="content-row container_fd0x6jr"
   data-testid="expanded-row-content"
 >
   <div
@@ -660,10 +660,6 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="content-row content-row--default container_f1izwqil "
-        data-testid="expanded-row-content"
-      />
-      <div
         class="revisionRow f1x1c13s fp4ugv1"
         role="row"
       >
@@ -902,10 +898,6 @@ exports[`Results View The table should match snapshot and other elements should 
           </div>
         </div>
       </div>
-      <div
-        class="content-row content-row--default container_f1izwqil "
-        data-testid="expanded-row-content"
-      />
       <div
         class="revisionRow f1x1c13s fp4ugv1"
         role="row"
@@ -1152,10 +1144,6 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="content-row content-row--default container_f1izwqil "
-        data-testid="expanded-row-content"
-      />
-      <div
         class="revisionRow f1x1c13s fp4ugv1"
         role="row"
       >
@@ -1399,10 +1387,6 @@ exports[`Results View The table should match snapshot and other elements should 
           </div>
         </div>
       </div>
-      <div
-        class="content-row content-row--default container_f1izwqil "
-        data-testid="expanded-row-content"
-      />
     </div>
   </div>
 </div>

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -262,15 +262,14 @@ function RevisionRow(props: RevisionRowProps) {
           </div>
         </div>
       </div>
-
-      <div
-        className={`content-row content-row--${
-          expanded ? 'expanded' : 'default'
-        } ${stylesCard.container} `}
-        data-testid='expanded-row-content'
-      >
-        {expanded && <RevisionRowExpandable result={result} />}
-      </div>
+      {expanded && (
+        <div
+          className={`content-row ${stylesCard.container}`}
+          data-testid='expanded-row-content'
+        >
+          <RevisionRowExpandable result={result} />
+        </div>
+      )}
     </>
   );
 }

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -269,7 +269,7 @@ function RevisionRow(props: RevisionRowProps) {
         } ${stylesCard.container} `}
         data-testid='expanded-row-content'
       >
-        <RevisionRowExpandable result={result} />
+        {expanded && <RevisionRowExpandable result={result} />}
       </div>
     </>
   );

--- a/src/styles/ExpandableRow.ts
+++ b/src/styles/ExpandableRow.ts
@@ -6,14 +6,12 @@ export const ExpandableRowStyles = () => {
   const expandedRowCSS = stylesheet({
     container: {
       width: '100%',
-      display: 'none',
       flexDirection: 'row',
       flexWrap: 'wrap',
       cursor: 'pointer',
       transition: 'border-radius 0.4s ease-in-out',
       $nest: {
         '&.content-row': {
-          display: 'none',
           cursor: 'default',
           $nest: {
             '&.content-row--expanded': {

--- a/src/styles/ExpandableRow.ts
+++ b/src/styles/ExpandableRow.ts
@@ -13,14 +13,10 @@ export const ExpandableRowStyles = () => {
       $nest: {
         '&.content-row': {
           cursor: 'default',
-          $nest: {
-            '&.content-row--expanded': {
-              borderRadius: `0px 0px ${Spacing.Small}px ${Spacing.Small}px`,
-              display: 'flex',
-              minHeight: '200px',
-              height: '100%',
-            },
-          },
+          borderRadius: `0px 0px ${Spacing.Small}px ${Spacing.Small}px`,
+          display: 'flex',
+          minHeight: '200px',
+          height: '100%',
         },
       },
     },


### PR DESCRIPTION
In this PR, the non expanded rows are not rendered unless `expanded` is true. Ran the profiler and it reduces the jank significantly especially in my compare-over-time patch. Closes https://mozilla-hub.atlassian.net/browse/PCF-439