### PR TITLE
Rework styles for buttons using the palette from Material UI

### DIFF
--- a/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
@@ -273,7 +273,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
       </div>
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation compare-button fr4s9wi css-3xx06c-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-w3l8dt-MuiButtonBase-root-MuiButton-root"
       id="compare-button"
       tabindex="0"
       type="submit"
@@ -677,7 +677,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
       </div>
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation compare-button fr4s9wi css-3xx06c-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-w3l8dt-MuiButtonBase-root-MuiButton-root"
       id="compare-button"
       tabindex="0"
       type="submit"
@@ -1070,7 +1070,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
       </div>
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation compare-button fr4s9wi css-3xx06c-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-w3l8dt-MuiButtonBase-root-MuiButton-root"
       id="compare-button"
       tabindex="0"
       type="submit"

--- a/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
@@ -665,7 +665,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
       </div>
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation compare-button fr4s9wi css-3xx06c-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-w3l8dt-MuiButtonBase-root-MuiButton-root"
       id="compare-button"
       tabindex="0"
       type="submit"
@@ -950,7 +950,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
         id="cancel-save_btns"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-save cancel-button f9oipqi cancel-button-base css-12uusfv-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-save cancel-button cancel-button-base css-kcsbz2-MuiButtonBase-root-MuiButton-root"
           name="cancel-button"
           tabindex="0"
           type="button"
@@ -961,8 +961,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
           />
         </button>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-save save-button save-button-base 
-        } css-12uusfv-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-save save-button save-button-base css-i4ay87-MuiButtonBase-root-MuiButton-root"
           name="save-button"
           tabindex="0"
           type="button"
@@ -1484,7 +1483,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
       </div>
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation compare-button fr4s9wi css-3xx06c-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-w3l8dt-MuiButtonBase-root-MuiButton-root"
       id="compare-button"
       tabindex="0"
       type="submit"
@@ -1800,7 +1799,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
         id="cancel-save_btns"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-save cancel-button f9oipqi cancel-button-new css-12uusfv-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-save cancel-button cancel-button-new css-kcsbz2-MuiButtonBase-root-MuiButton-root"
           name="cancel-button"
           tabindex="0"
           type="button"
@@ -1811,8 +1810,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
           />
         </button>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-save save-button save-button-new 
-        } css-12uusfv-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-save save-button save-button-new css-i4ay87-MuiButtonBase-root-MuiButton-root"
           name="save-button"
           tabindex="0"
           type="button"
@@ -2036,7 +2034,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
       </div>
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation compare-button fr4s9wi css-3xx06c-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-w3l8dt-MuiButtonBase-root-MuiButton-root"
       id="compare-button"
       tabindex="0"
       type="submit"
@@ -2715,7 +2713,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
       </div>
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation compare-button fr4s9wi css-3xx06c-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-w3l8dt-MuiButtonBase-root-MuiButton-root"
       id="compare-button"
       tabindex="0"
       type="submit"
@@ -2870,7 +2868,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
         id="cancel-save_btns"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-save cancel-button f9oipqi cancel-button-base css-12uusfv-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-save cancel-button cancel-button-base css-kcsbz2-MuiButtonBase-root-MuiButton-root"
           name="cancel-button"
           tabindex="0"
           type="button"
@@ -2881,8 +2879,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
           />
         </button>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-save save-button save-button-base 
-        } css-12uusfv-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-save save-button save-button-base css-i4ay87-MuiButtonBase-root-MuiButton-root"
           name="save-button"
           tabindex="0"
           type="button"
@@ -3267,7 +3264,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
       </div>
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation compare-button fr4s9wi css-3xx06c-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-w3l8dt-MuiButtonBase-root-MuiButton-root"
       id="compare-button"
       tabindex="0"
       type="submit"
@@ -3297,7 +3294,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
         Skip to search
       </button>
       <div
-        class="MuiGrid-root header-container container_f38ku8z css-plh9qo-MuiGrid-root"
+        class="MuiGrid-root header-container container_f15tggp2 css-plh9qo-MuiGrid-root"
       >
         <div
           class="toggle-dark-mode f4zotac MuiBox-root css-0"
@@ -3354,7 +3351,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
             Analyze results of performance tests to detect regressions and identify opportunities for improvement.
           </div>
           <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation learn-more-btn css-12uusfv-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation learn-more-btn css-i4ay87-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"
           >
@@ -3760,7 +3757,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                   </div>
                 </div>
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation compare-button fr4s9wi css-3xx06c-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-w3l8dt-MuiButtonBase-root-MuiButton-root"
                   id="compare-button"
                   tabindex="0"
                   type="submit"
@@ -4078,7 +4075,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                   </div>
                 </div>
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation compare-button fr4s9wi css-3xx06c-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-w3l8dt-MuiButtonBase-root-MuiButton-root"
                   id="compare-button"
                   tabindex="0"
                   type="submit"
@@ -4239,7 +4236,7 @@ exports[`Compare With Base should save the updated BASE revision when Save is cl
         id="cancel-save_btns"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-save cancel-button f9oipqi cancel-button-base css-12uusfv-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-save cancel-button cancel-button-base css-kcsbz2-MuiButtonBase-root-MuiButton-root"
           name="cancel-button"
           tabindex="0"
           type="button"
@@ -4250,8 +4247,7 @@ exports[`Compare With Base should save the updated BASE revision when Save is cl
           />
         </button>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-save save-button save-button-base 
-        } css-12uusfv-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-save save-button save-button-base css-i4ay87-MuiButtonBase-root-MuiButton-root"
           name="save-button"
           tabindex="0"
           type="button"
@@ -4773,7 +4769,7 @@ exports[`Compare With Base should save the updated BASE revision when Save is cl
       </div>
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation compare-button fr4s9wi css-3xx06c-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-w3l8dt-MuiButtonBase-root-MuiButton-root"
       id="compare-button"
       tabindex="0"
       type="submit"
@@ -5226,7 +5222,7 @@ exports[`Compare With Base should save the updated NEW revision when Save is cli
         id="cancel-save_btns"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-save cancel-button f9oipqi cancel-button-new css-12uusfv-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-save cancel-button cancel-button-new css-kcsbz2-MuiButtonBase-root-MuiButton-root"
           name="cancel-button"
           tabindex="0"
           type="button"
@@ -5237,8 +5233,7 @@ exports[`Compare With Base should save the updated NEW revision when Save is cli
           />
         </button>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-save save-button save-button-new 
-        } css-12uusfv-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-save save-button save-button-new css-i4ay87-MuiButtonBase-root-MuiButton-root"
           name="save-button"
           tabindex="0"
           type="button"
@@ -5462,7 +5457,7 @@ exports[`Compare With Base should save the updated NEW revision when Save is cli
       </div>
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation compare-button fr4s9wi css-3xx06c-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-w3l8dt-MuiButtonBase-root-MuiButton-root"
       id="compare-button"
       tabindex="0"
       type="submit"

--- a/src/__tests__/Search/__snapshots__/SearchContainer.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchContainer.test.tsx.snap
@@ -398,7 +398,7 @@ exports[`Search Containter should match snapshot 1`] = `
                 </div>
               </div>
               <button
-                class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation compare-button fr4s9wi css-3xx06c-MuiButtonBase-root-MuiButton-root"
+                class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-w3l8dt-MuiButtonBase-root-MuiButton-root"
                 id="compare-button"
                 tabindex="0"
                 type="submit"
@@ -716,7 +716,7 @@ exports[`Search Containter should match snapshot 1`] = `
                 </div>
               </div>
               <button
-                class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation compare-button fr4s9wi css-3xx06c-MuiButtonBase-root-MuiButton-root"
+                class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-w3l8dt-MuiButtonBase-root-MuiButton-root"
                 id="compare-button"
                 tabindex="0"
                 type="submit"

--- a/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
         Skip to search
       </button>
       <div
-        class="MuiGrid-root header-container container_f38ku8z css-plh9qo-MuiGrid-root"
+        class="MuiGrid-root header-container container_f15tggp2 css-plh9qo-MuiGrid-root"
       >
         <div
           class="toggle-dark-mode f4zotac MuiBox-root css-0"
@@ -71,7 +71,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
             Analyze results of performance tests to detect regressions and identify opportunities for improvement.
           </div>
           <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation learn-more-btn css-12uusfv-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation learn-more-btn css-i4ay87-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"
           >
@@ -962,7 +962,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                   </div>
                 </div>
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation compare-button fr4s9wi css-3xx06c-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-w3l8dt-MuiButtonBase-root-MuiButton-root"
                   id="compare-button"
                   tabindex="0"
                   type="submit"
@@ -1280,7 +1280,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                   </div>
                 </div>
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation compare-button fr4s9wi css-3xx06c-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-w3l8dt-MuiButtonBase-root-MuiButton-root"
                   id="compare-button"
                   tabindex="0"
                   type="submit"

--- a/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
         Skip to search
       </button>
       <div
-        class="MuiGrid-root header-container container_f38ku8z css-plh9qo-MuiGrid-root"
+        class="MuiGrid-root header-container container_f15tggp2 css-plh9qo-MuiGrid-root"
       >
         <div
           class="toggle-dark-mode f4zotac MuiBox-root css-0"
@@ -71,7 +71,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
             Analyze results of performance tests to detect regressions and identify opportunities for improvement.
           </div>
           <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation learn-more-btn css-12uusfv-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation learn-more-btn css-i4ay87-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"
           >
@@ -477,7 +477,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                   </div>
                 </div>
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation compare-button fr4s9wi css-3xx06c-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-w3l8dt-MuiButtonBase-root-MuiButton-root"
                   id="compare-button"
                   tabindex="0"
                   type="submit"
@@ -795,7 +795,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                   </div>
                 </div>
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation compare-button fr4s9wi css-3xx06c-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-w3l8dt-MuiButtonBase-root-MuiButton-root"
                   id="compare-button"
                   tabindex="0"
                   type="submit"

--- a/src/__tests__/__snapshots__/App.test.tsx.snap
+++ b/src/__tests__/__snapshots__/App.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
       class="fcndgf6"
     >
       <div
-        class="MuiGrid-root header-container container_flkg2b4 css-plh9qo-MuiGrid-root"
+        class="MuiGrid-root header-container container_f18obq8l css-plh9qo-MuiGrid-root"
       >
         <div
           class="toggle-dark-mode f4zotac MuiBox-root css-0"
@@ -311,7 +311,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
       class="fcndgf6"
     >
       <div
-        class="MuiGrid-root header-container container_flkg2b4 css-plh9qo-MuiGrid-root"
+        class="MuiGrid-root header-container container_f18obq8l css-plh9qo-MuiGrid-root"
       >
         <div
           class="toggle-dark-mode f4zotac MuiBox-root css-0"
@@ -464,7 +464,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
       class="fcndgf6"
     >
       <div
-        class="MuiGrid-root header-container container_flkg2b4 css-plh9qo-MuiGrid-root"
+        class="MuiGrid-root header-container container_f18obq8l css-plh9qo-MuiGrid-root"
       >
         <div
           class="toggle-dark-mode f4zotac MuiBox-root css-0"

--- a/src/components/CompareResults/DownloadButton.tsx
+++ b/src/components/CompareResults/DownloadButton.tsx
@@ -7,7 +7,7 @@ import { style } from 'typestyle';
 import { RootState } from '../../common/store';
 import { useAppSelector } from '../../hooks/app';
 import { Strings } from '../../resources/Strings';
-import { ButtonsLightRaw, Spacing } from '../../styles';
+import { Spacing } from '../../styles';
 import type { CompareResultsItem } from '../../types/state';
 import { truncateHash } from '../../utils/helpers';
 import type { LoaderReturnValue } from './loader';
@@ -80,7 +80,6 @@ const styles = {
     height: '41px',
     $nest: {
       '.MuiButtonBase-root': {
-        ...ButtonsLightRaw.Secondary,
         height: '100%',
       },
     },
@@ -128,7 +127,13 @@ function DownloadButton() {
 
   return (
     <div className={styles.downloadButton}>
-      <Button onClick={handleDownloadClick}>Download JSON</Button>
+      <Button
+        variant='contained'
+        color='secondary'
+        onClick={handleDownloadClick}
+      >
+        Download JSON
+      </Button>
     </div>
   );
 }

--- a/src/components/CompareResults/SearchInput.tsx
+++ b/src/components/CompareResults/SearchInput.tsx
@@ -3,7 +3,7 @@ import SearchIcon from '@mui/icons-material/Search';
 import { FormControl, InputAdornment, TextField, Button } from '@mui/material';
 import { style } from 'typestyle';
 
-import { ButtonsLightRaw, Spacing } from '../../styles';
+import { Spacing } from '../../styles';
 
 const styles = {
   container: style({
@@ -14,10 +14,7 @@ const styles = {
       '.form-container': {
         maxWidth: '447px',
       },
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       '.MuiButtonBase-root': {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        ...ButtonsLightRaw.Secondary,
         marginLeft: Spacing.Small,
       },
     },

--- a/src/components/Search/CompareButton.tsx
+++ b/src/components/Search/CompareButton.tsx
@@ -1,27 +1,18 @@
 import Button from '@mui/material/Button';
-import { style } from 'typestyle';
-
-import { useAppSelector } from '../../hooks/app';
-import { ButtonStyles } from '../../styles';
 
 interface CompareButtonProps {
   label: string;
 }
 
 export default function CompareButton({ label }: CompareButtonProps) {
-  const mode = useAppSelector((state) => state.theme.mode);
-  const btnStyles = ButtonStyles(mode);
-
-  const styles = {
-    button: style({ ...btnStyles.Primary }),
-  };
-
   return (
     <Button
       id='compare-button'
-      className={`compare-button ${styles.button}`}
-      sx={{ textTransform: 'none !important' }}
+      color='primary'
       type='submit'
+      sx={{
+        height: 32,
+      }}
     >
       {label}
     </Button>

--- a/src/components/Search/SaveCancelButtons.tsx
+++ b/src/components/Search/SaveCancelButtons.tsx
@@ -42,8 +42,7 @@ export default function SaveCancelButtons({
         {cancel}
       </Button>
       <Button
-        className={`cancel-save save-button save-button-${searchType} 
-        }`}
+        className={`cancel-save save-button save-button-${searchType}`}
         name='save-button'
         onClick={onSave}
       >

--- a/src/components/Search/SaveCancelButtons.tsx
+++ b/src/components/Search/SaveCancelButtons.tsx
@@ -1,9 +1,6 @@
 import Button from '@mui/material/Button';
-import { style } from 'typestyle';
 
-import { useAppSelector } from '../../hooks/app';
 import { Strings } from '../../resources/Strings';
-import { ButtonStyles } from '../../styles';
 import type { InputType } from '../../types/state';
 
 interface SaveCancelButtonsProps {
@@ -21,22 +18,12 @@ export default function SaveCancelButtons({
   onCancel,
   onSave,
 }: SaveCancelButtonsProps) {
-  const mode = useAppSelector((state) => state.theme.mode);
-  const btnStyles = ButtonStyles(mode);
-  const cancelBtn = {
-    main: style({
-      $nest: {
-        '&.MuiButtonBase-root': {
-          ...btnStyles.Secondary,
-        },
-      },
-    }),
-  };
   return (
     <div className='cancel-save-btns' id='cancel-save_btns'>
       <Button
-        className={`cancel-save cancel-button ${cancelBtn.main} cancel-button-${searchType}`}
+        className={`cancel-save cancel-button cancel-button-${searchType}`}
         name='cancel-button'
+        color='secondary'
         onClick={onCancel}
       >
         {cancel}

--- a/src/styles/Buttons.ts
+++ b/src/styles/Buttons.ts
@@ -14,16 +14,6 @@ const sharedDropDownBtnStyles = {
 
 //BUTTONS LIGHT
 export const ButtonsLightRaw = {
-  Secondary: {
-    color: Colors.PrimaryText,
-    backgroundColor: Colors.SecondaryDefault,
-    '&:hover': {
-      backgroundColor: Colors.SecondaryHover,
-    },
-    '&:active': {
-      backgroundColor: Colors.SecondaryActive,
-    },
-  },
   Dropdown: {
     ...sharedDropDownBtnStyles,
     backgroundColor: Colors.SecondaryDefault,
@@ -76,23 +66,12 @@ export const ButtonsLightRaw = {
 };
 
 export const ButtonsLight = {
-  Secondary: style(ButtonsLightRaw.Secondary),
   Dropdown: style(ButtonsLightRaw.Dropdown),
 };
 
 ////////////////////BUTTONS DARK///////////////////////
 
 export const ButtonsDarkRaw = {
-  Secondary: {
-    color: Colors.PrimaryTextDark,
-    backgroundColor: Colors.Background300Dark,
-    '&:hover': {
-      backgroundColor: Colors.SecondaryHoverDark,
-    },
-    '&:active': {
-      backgroundColor: Colors.SecondaryActiveDark,
-    },
-  },
   Dropdown: {
     ...sharedDropDownBtnStyles,
     backgroundColor: Colors.Background300Dark,
@@ -130,16 +109,10 @@ export const ButtonsDarkRaw = {
 };
 
 export const ButtonsDark = {
-  Secondary: style(ButtonsDarkRaw.Secondary),
   Dropdown: style(ButtonsDarkRaw.Dropdown),
 };
 
 export const ButtonStyles = (mode: string) => {
   const isTrueLight = mode == 'light' ? true : false;
   return isTrueLight ? ButtonsLightRaw : ButtonsDarkRaw;
-};
-
-export const ButtonStylesSecondary = (mode: string) => {
-  const isTrueLight = mode == 'light' ? true : false;
-  return isTrueLight ? ButtonsLight.Secondary : ButtonsDark.Secondary;
 };

--- a/src/styles/Buttons.ts
+++ b/src/styles/Buttons.ts
@@ -12,27 +12,8 @@ const sharedDropDownBtnStyles = {
   marginTop: '0',
 };
 
-const sharedButtonStyles = {
-  padding: `${Spacing.xSmall}px ${Spacing.Medium}px !important`,
-  height: `${Spacing.xLarge}px`,
-  margin: '0 !important',
-};
-
 //BUTTONS LIGHT
 export const ButtonsLightRaw = {
-  Primary: {
-    ...sharedButtonStyles,
-    color: Colors.InvertedText,
-    backgroundColor: Colors.PrimaryDefault,
-    $nest: {
-      '&:hover': {
-        backgroundColor: Colors.PrimaryHover,
-      },
-      '&:active': {
-        backgroundColor: Colors.PrimaryActive,
-      },
-    },
-  },
   Secondary: {
     color: Colors.PrimaryText,
     backgroundColor: Colors.SecondaryDefault,
@@ -95,7 +76,6 @@ export const ButtonsLightRaw = {
 };
 
 export const ButtonsLight = {
-  Primary: style(ButtonsLightRaw.Primary),
   Secondary: style(ButtonsLightRaw.Secondary),
   Dropdown: style(ButtonsLightRaw.Dropdown),
 };
@@ -103,17 +83,6 @@ export const ButtonsLight = {
 ////////////////////BUTTONS DARK///////////////////////
 
 export const ButtonsDarkRaw = {
-  Primary: {
-    ...sharedButtonStyles,
-    color: Colors.InvertedTextDark,
-    backgroundColor: Colors.PrimaryDark,
-    '&:hover': {
-      backgroundColor: Colors.PrimaryHoverDark,
-    },
-    '&:active': {
-      backgroundColor: Colors.PrimaryActiveDark,
-    },
-  },
   Secondary: {
     color: Colors.PrimaryTextDark,
     backgroundColor: Colors.Background300Dark,
@@ -161,7 +130,6 @@ export const ButtonsDarkRaw = {
 };
 
 export const ButtonsDark = {
-  Primary: style(ButtonsDarkRaw.Primary),
   Secondary: style(ButtonsDarkRaw.Secondary),
   Dropdown: style(ButtonsDarkRaw.Dropdown),
 };

--- a/src/styles/Header.ts
+++ b/src/styles/Header.ts
@@ -1,7 +1,6 @@
 import { stylesheet } from 'typestyle';
 
 import { Strings } from '../resources/Strings';
-import { ButtonsLightRaw, ButtonsDarkRaw } from './Buttons';
 import { Colors } from './Colors';
 import { Spacing } from './Spacing';
 
@@ -42,9 +41,6 @@ export const HeaderStyles = (mode: string, isHome: boolean) => {
           marginBottom: `${Spacing.layoutLarge + 14}px`,
           maxWidth: '104px',
           alignSelf: 'center',
-          ...(isTrueLight
-            ? ButtonsLightRaw.Secondary
-            : ButtonsDarkRaw.Secondary),
         },
         '.learn-more-btn': {
           //hidden until purpose is determined

--- a/src/theme/components.js
+++ b/src/theme/components.js
@@ -48,12 +48,6 @@ const components = {
             },
           },
         },
-        '&.compare-button': {
-          lineHeight: '1.4375em',
-          padding: '16.5px 14px',
-          textTransform: 'uppercase',
-          marginBottom: '30px',
-        },
       },
     },
   },

--- a/src/theme/protocolTheme.ts
+++ b/src/theme/protocolTheme.ts
@@ -16,6 +16,7 @@ const lightMode = {
   },
   secondary: {
     main: Colors.SecondaryDefault,
+    dark: Colors.SecondaryHover,
   },
   text: {
     primary: Colors.PrimaryText,
@@ -32,7 +33,8 @@ const darkMode = {
     main: Colors.PrimaryDark,
   },
   secondary: {
-    main: Colors.SecondaryDark,
+    main: Colors.Background300Dark,
+    dark: Colors.SecondaryHoverDark,
   },
   text: {
     primary: Colors.PrimaryTextDark,


### PR DESCRIPTION
This PR started as a simple nit PR but ended up doing some more. This changes the button using the "primary" and "secondary" colors, I didn't touch to the dropdown styles though because I didn't need that... maybe later ;-)

There are 4 commits then:
* Commit 1: Small nit regarding the compare button
* Commit 2: Use MUI's palette for primary buttons
* Commit 3: Use MUI's palette for secondary buttons
* Commit 4: Update tests

More comments in the commits themselves.

There should be no visible change with this PR besides the Download Button. That one now works with dark mode, and also gains a box shadow that should be removed with #665.