### PR TITLE
added edit button to results view for compare over time

### DIFF
--- a/src/__tests__/Search/__snapshots__/SearchContainer.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchContainer.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`Search Containter should match snapshot 1`] = `
               class="MuiGrid-root component_f14z0jsa css-plh9qo-MuiGrid-root"
             >
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fl6uoag label-edit-wrapper css-13eijkh-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1098v0k label-edit-wrapper css-13eijkh-MuiGrid-root"
               >
                 <label
                   class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -81,7 +81,7 @@ exports[`Search Containter should match snapshot 1`] = `
                 id="base-search-container"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fl6uoag  -base-dropdown css-1awobkc-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1098v0k  -base-dropdown css-1awobkc-MuiGrid-root"
                   id="base_search-dropdown"
                 >
                   <div
@@ -196,7 +196,7 @@ exports[`Search Containter should match snapshot 1`] = `
               class="MuiGrid-root component_f14z0jsa css-plh9qo-MuiGrid-root"
             >
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag label-edit-wrapper css-13eijkh-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1098v0k label-edit-wrapper css-13eijkh-MuiGrid-root"
               >
                 <label
                   class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -223,7 +223,7 @@ exports[`Search Containter should match snapshot 1`] = `
                 id="new-search-container"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag  -base-dropdown css-1awobkc-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1098v0k  -base-dropdown css-1awobkc-MuiGrid-root"
                   id="new_search-dropdown"
                 >
                   <div
@@ -335,7 +335,7 @@ exports[`Search Containter should match snapshot 1`] = `
               </div>
             </div>
             <div
-              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fl6uoag fjuaqdk css-13eijkh-MuiGrid-root"
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1098v0k fjuaqdk css-13eijkh-MuiGrid-root"
             >
               <div
                 class="MuiFormControl-root framework-dropdown f1pm9d4y css-1nrlq1o-MuiFormControl-root"
@@ -452,7 +452,7 @@ exports[`Search Containter should match snapshot 1`] = `
               class="MuiGrid-root component_f14z0jsa css-plh9qo-MuiGrid-root"
             >
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag label-edit-wrapper css-13eijkh-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1098v0k label-edit-wrapper css-13eijkh-MuiGrid-root"
               >
                 <label
                   class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -475,11 +475,11 @@ exports[`Search Containter should match snapshot 1`] = `
                 </label>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-container container_f1psuwcf css-1ljzhs0-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-container container_f1psuwcf show-container  css-1ljzhs0-MuiGrid-root"
                 id="new-search-container--time"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag  -new-dropdown css-1awobkc-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1098v0k  -new-dropdown css-1awobkc-MuiGrid-root"
                   id="new_search-dropdown--time"
                 >
                   <div
@@ -591,7 +591,7 @@ exports[`Search Containter should match snapshot 1`] = `
               </div>
             </div>
             <div
-              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fl6uoag fx35f8m css-13eijkh-MuiGrid-root"
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1098v0k fx35f8m css-13eijkh-MuiGrid-root"
             >
               <div
                 class="bottom-dropdowns"

--- a/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
@@ -133,7 +133,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                 class="MuiGrid-root component_f14z0jsa css-plh9qo-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fl6uoag label-edit-wrapper css-13eijkh-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1098v0k label-edit-wrapper css-13eijkh-MuiGrid-root"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -160,7 +160,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                   id="base-search-container"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fl6uoag  -base-dropdown css-1awobkc-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1098v0k  -base-dropdown css-1awobkc-MuiGrid-root"
                     id="base_search-dropdown"
                   >
                     <div
@@ -760,7 +760,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                 class="MuiGrid-root component_f14z0jsa css-plh9qo-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag label-edit-wrapper css-13eijkh-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1098v0k label-edit-wrapper css-13eijkh-MuiGrid-root"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -787,7 +787,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                   id="new-search-container"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag  -base-dropdown css-1awobkc-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1098v0k  -base-dropdown css-1awobkc-MuiGrid-root"
                     id="new_search-dropdown"
                   >
                     <div
@@ -899,7 +899,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fl6uoag fjuaqdk css-13eijkh-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1098v0k fjuaqdk css-13eijkh-MuiGrid-root"
               >
                 <div
                   class="MuiFormControl-root framework-dropdown f1pm9d4y css-1nrlq1o-MuiFormControl-root"
@@ -1016,7 +1016,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                 class="MuiGrid-root component_f14z0jsa css-plh9qo-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag label-edit-wrapper css-13eijkh-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1098v0k label-edit-wrapper css-13eijkh-MuiGrid-root"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1039,11 +1039,11 @@ exports[`SearchResultsList should match snapshot 1`] = `
                   </label>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-container container_f1psuwcf css-1ljzhs0-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-container container_f1psuwcf show-container  css-1ljzhs0-MuiGrid-root"
                   id="new-search-container--time"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag  -new-dropdown css-1awobkc-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1098v0k  -new-dropdown css-1awobkc-MuiGrid-root"
                     id="new_search-dropdown--time"
                   >
                     <div
@@ -1155,7 +1155,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fl6uoag fx35f8m css-13eijkh-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1098v0k fx35f8m css-13eijkh-MuiGrid-root"
               >
                 <div
                   class="bottom-dropdowns"

--- a/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
@@ -133,7 +133,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                 class="MuiGrid-root component_f14z0jsa css-plh9qo-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fl6uoag label-edit-wrapper css-13eijkh-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1098v0k label-edit-wrapper css-13eijkh-MuiGrid-root"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -160,7 +160,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                   id="base-search-container"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fl6uoag  -base-dropdown css-1awobkc-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1098v0k  -base-dropdown css-1awobkc-MuiGrid-root"
                     id="base_search-dropdown"
                   >
                     <div
@@ -275,7 +275,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                 class="MuiGrid-root component_f14z0jsa css-plh9qo-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag label-edit-wrapper css-13eijkh-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1098v0k label-edit-wrapper css-13eijkh-MuiGrid-root"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -302,7 +302,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                   id="new-search-container"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag  -base-dropdown css-1awobkc-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1098v0k  -base-dropdown css-1awobkc-MuiGrid-root"
                     id="new_search-dropdown"
                   >
                     <div
@@ -414,7 +414,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fl6uoag fjuaqdk css-13eijkh-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1098v0k fjuaqdk css-13eijkh-MuiGrid-root"
               >
                 <div
                   class="MuiFormControl-root framework-dropdown f1pm9d4y css-1nrlq1o-MuiFormControl-root"
@@ -531,7 +531,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                 class="MuiGrid-root component_f14z0jsa css-plh9qo-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag label-edit-wrapper css-13eijkh-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1098v0k label-edit-wrapper css-13eijkh-MuiGrid-root"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -554,11 +554,11 @@ exports[`Search View renders correctly when there are no results 1`] = `
                   </label>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-container container_f1psuwcf css-1ljzhs0-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-container container_f1psuwcf show-container  css-1ljzhs0-MuiGrid-root"
                   id="new-search-container--time"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag  -new-dropdown css-1awobkc-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1098v0k  -new-dropdown css-1awobkc-MuiGrid-root"
                     id="new_search-dropdown--time"
                   >
                     <div
@@ -670,7 +670,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fl6uoag fx35f8m css-13eijkh-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1098v0k fx35f8m css-13eijkh-MuiGrid-root"
               >
                 <div
                   class="bottom-dropdowns"

--- a/src/components/CompareResults/OverTimeResultsView.tsx
+++ b/src/components/CompareResults/OverTimeResultsView.tsx
@@ -43,7 +43,7 @@ function ResultsView(props: ResultsViewProps) {
         <LinkToHome />
 
         <CompareOverTime
-          hasNonEditableState={false}
+          hasNonEditableState={true}
           newRevs={newRevsInfo}
           isBaseSearch={true}
           expandBaseComponent={() => null}

--- a/src/components/Search/CompareOverTime.tsx
+++ b/src/components/Search/CompareOverTime.tsx
@@ -48,6 +48,8 @@ function CompareOverTime({
 
   const [timeRangeValue, setTimeRangeValue] = useState(intervalValue);
   const [frameworkId, setframeWorkValue] = useState(frameworkIdVal);
+  // see notes in compare with base
+  const [stagingRevs, setStagingRevs] = useState<Changeset[]>(newRevs);
   const [inProgressRevs, setInProgressRevs] = useState<Changeset[] | []>(
     newRevs,
   );
@@ -144,6 +146,10 @@ function CompareOverTime({
     setInProgressRevs(newNewRevs);
   };
 
+  const handleEdit = () => {
+    setInProgressRevs(stagingRevs);
+  };
+
   return (
     <Grid className={`wrapper--overtime ${wrapperStyles.wrapper}`}>
       <div
@@ -186,6 +192,7 @@ function CompareOverTime({
             onRepositoryChange={(repo: Repository['name']) =>
               setRepository(repo)
             }
+            onEdit={handleEdit}
           />
 
           <Grid

--- a/src/components/Search/EditButton.tsx
+++ b/src/components/Search/EditButton.tsx
@@ -9,6 +9,7 @@ interface EditButtonProps {
 
 const baseComp = Strings.components.searchDefault.base;
 const editImgUrl = baseComp.editIcon;
+const editText = Strings.components.searchDefault.sharedCollasped.edit;
 
 export default function EditButton({ isBase, onEditAction }: EditButtonProps) {
   const searchType = isBase ? 'base' : 'new';
@@ -27,6 +28,7 @@ export default function EditButton({ isBase, onEditAction }: EditButtonProps) {
         src={editImgUrl}
         alt='edit-icon'
       />
+      {editText}
     </Button>
   );
 }

--- a/src/components/Search/SearchOverTime.tsx
+++ b/src/components/Search/SearchOverTime.tsx
@@ -17,6 +17,7 @@ import {
   SearchStyles,
 } from '../../styles';
 import { Changeset, Repository } from '../../types/state';
+import EditButton from './EditButton';
 import SearchDropdown from './SearchDropdown';
 import SearchInputAndResults from './SearchInputAndResults';
 import SelectedRevisions from './SelectedRevisions';
@@ -31,6 +32,7 @@ interface SearchProps {
   onRemoveRevision: (item: Changeset) => void;
   onSearchResultsToggle: (item: Changeset) => void;
   onRepositoryChange: (repo: Repository['name']) => unknown;
+  onEdit: () => void;
 }
 
 export default function SearchOverTime({
@@ -43,6 +45,7 @@ export default function SearchOverTime({
   onRemoveRevision,
   onSearchResultsToggle,
   onRepositoryChange,
+  onEdit,
 }: SearchProps) {
   const mode = useAppSelector((state) => state.theme.mode);
   const styles = SearchStyles(mode);
@@ -87,13 +90,25 @@ export default function SearchOverTime({
             <InfoIcon fontSize='small' className='dropdown-info-icon' />
           </Tooltip>
         </InputLabel>
+        {/**** Edit Button ****/}
+        {hasNonEditableState && !formIsDisplayed && (
+          <EditButton
+            isBase={false}
+            onEditAction={() => {
+              onEdit();
+              setFormIsDisplayed(true);
+            }}
+          />
+        )}
       </Grid>
       {/**** Search - DropDown Section ****/}
       <Grid
         container
         alignItems='flex-start'
         id='new-search-container--time'
-        className={`${styles.container}`}
+        className={`${styles.container} ${
+          formIsDisplayed ? 'show-container' : 'hide-container'
+        } `}
       >
         <Grid
           item

--- a/src/resources/Strings.tsx
+++ b/src/resources/Strings.tsx
@@ -39,6 +39,7 @@ export const Strings = {
             'The framework or test harness containing the test you want to examine.',
         },
         button: 'Compare',
+        edit: 'Edit entry',
       },
       base: {
         title: 'Compare with a base',

--- a/src/styles/CompareCards.ts
+++ b/src/styles/CompareCards.ts
@@ -158,10 +158,13 @@ export const SearchStyles = (mode: string) => {
               visibility: 'hidden',
             },
             '.edit-button': {
-              padding: '0px',
-              justifyContent: 'flex-end',
+              padding: `${Spacing.xSmall}px ${Spacing.Small}px`,
+              alignItems: 'center',
+              justifyContent: 'center',
               marginLeft: `${Spacing.Medium}px`,
               bottom: `${Spacing.Small}px`,
+              gap: `${Spacing.xSmall}px`,
+              fontFamily: FontsRaw.BodyDefault.fontFamily,
               $nest: {
                 '&:hover': {
                   backgroundColor: 'transparent',


### PR DESCRIPTION
This PR adds the edit feature to the CompareOverTime component in the Results View. The commits are split to help with review:

- [ ] [add the new global edit button to the results page and related config](https://github.com/mozilla/perfcompare/pull/660/commits/e641dd7d0ed16cf0786fc40d26c79b5fa7d1e595)