### PR TITLE
change the prop name to make it less confusing

### DIFF
--- a/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
     class="MuiGrid-root component_f14z0jsa css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1qectas label-edit-wrapper css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag label-edit-wrapper css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -38,7 +38,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1qectas  -new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag  -new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -150,7 +150,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1qectas fx35f8m css-13eijkh-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fl6uoag fx35f8m css-13eijkh-MuiGrid-root"
   >
     <div
       class="bottom-dropdowns"
@@ -273,7 +273,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
       </div>
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-w3l8dt-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium compare-button fr4s9wi css-1rgi3bk-MuiButtonBase-root-MuiButton-root"
       id="compare-button"
       tabindex="0"
       type="submit"
@@ -298,7 +298,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
     class="MuiGrid-root component_f14z0jsa css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1qectas label-edit-wrapper css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag label-edit-wrapper css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -325,7 +325,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1qectas  -new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag small compare-over-time-results-new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -366,7 +366,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_fctyy2s   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_fctyy2s big  css-17gmabg-MuiGrid-root"
         id="new_search-input--time"
       >
         <div
@@ -379,10 +379,10 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-193b4t-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart css-193b4t-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <div
-                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1laqsz7-MuiInputAdornment-root"
                 >
                   <svg
                     aria-hidden="true"
@@ -398,7 +398,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
                 </div>
                 <input
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1rgu65m-MuiInputBase-input-MuiOutlinedInput-input"
+                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart css-jrmsot-MuiInputBase-input-MuiOutlinedInput-input"
                   id="search-new-input"
                   placeholder="Search revision by ID number or author email"
                   type="text"
@@ -455,7 +455,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
               </div>
             </div>
             <div
-              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters listItemButton_fj5g6dj css-1g1bko9-MuiButtonBase-root-MuiListItemButton-root"
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters listItemButton_f5s7lzh css-1g1bko9-MuiButtonBase-root-MuiListItemButton-root"
               role="button"
               tabindex="0"
             >
@@ -523,7 +523,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
                 </p>
               </div>
               <button
-                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium icon-close-show revision-action close-button css-1qlpk5e-MuiButtonBase-root-MuiIconButton-root"
+                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium icon-close-hidden revision-action close-button css-13h131f-MuiButtonBase-root-MuiButton-root"
                 name="close-button"
                 tabindex="0"
                 title="remove revision"
@@ -554,7 +554,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1qectas fx35f8m css-13eijkh-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fl6uoag fx35f8m css-13eijkh-MuiGrid-root"
   >
     <div
       class="bottom-dropdowns"
@@ -677,7 +677,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
       </div>
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-w3l8dt-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium compare-button fr4s9wi css-1rgi3bk-MuiButtonBase-root-MuiButton-root"
       id="compare-button"
       tabindex="0"
       type="submit"
@@ -808,7 +808,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
     class="MuiGrid-root component_f14z0jsa css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1qectas label-edit-wrapper css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag label-edit-wrapper css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -835,7 +835,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1qectas  -new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag  -new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -947,7 +947,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1qectas fx35f8m css-13eijkh-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fl6uoag fx35f8m css-13eijkh-MuiGrid-root"
   >
     <div
       class="bottom-dropdowns"
@@ -1070,7 +1070,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
       </div>
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-w3l8dt-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium compare-button fr4s9wi css-1rgi3bk-MuiButtonBase-root-MuiButton-root"
       id="compare-button"
       tabindex="0"
       type="submit"

--- a/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
     class="MuiGrid-root component_f14z0jsa css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag label-edit-wrapper css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1qectas label-edit-wrapper css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -38,7 +38,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag  -new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1qectas  -new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -150,7 +150,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fl6uoag fx35f8m css-13eijkh-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1qectas fx35f8m css-13eijkh-MuiGrid-root"
   >
     <div
       class="bottom-dropdowns"
@@ -273,7 +273,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
       </div>
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium compare-button fr4s9wi css-1rgi3bk-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-w3l8dt-MuiButtonBase-root-MuiButton-root"
       id="compare-button"
       tabindex="0"
       type="submit"
@@ -298,7 +298,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
     class="MuiGrid-root component_f14z0jsa css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag label-edit-wrapper css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1qectas label-edit-wrapper css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -325,7 +325,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag small compare-over-time-results-new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1qectas small compare-over-time-results-new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -455,7 +455,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
               </div>
             </div>
             <div
-              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters listItemButton_f5s7lzh css-1g1bko9-MuiButtonBase-root-MuiListItemButton-root"
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters listItemButton_fj5g6dj css-1g1bko9-MuiButtonBase-root-MuiListItemButton-root"
               role="button"
               tabindex="0"
             >
@@ -523,7 +523,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
                 </p>
               </div>
               <button
-                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium icon-close-hidden revision-action close-button css-13h131f-MuiButtonBase-root-MuiButton-root"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium icon-close-hidden revision-action close-button css-1qlpk5e-MuiButtonBase-root-MuiIconButton-root"
                 name="close-button"
                 tabindex="0"
                 title="remove revision"
@@ -554,7 +554,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fl6uoag fx35f8m css-13eijkh-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1qectas fx35f8m css-13eijkh-MuiGrid-root"
   >
     <div
       class="bottom-dropdowns"
@@ -677,7 +677,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
       </div>
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium compare-button fr4s9wi css-1rgi3bk-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-w3l8dt-MuiButtonBase-root-MuiButton-root"
       id="compare-button"
       tabindex="0"
       type="submit"
@@ -808,7 +808,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
     class="MuiGrid-root component_f14z0jsa css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag label-edit-wrapper css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1qectas label-edit-wrapper css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -835,7 +835,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag  -new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1qectas  -new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -947,7 +947,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fl6uoag fx35f8m css-13eijkh-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1qectas fx35f8m css-13eijkh-MuiGrid-root"
   >
     <div
       class="bottom-dropdowns"
@@ -1070,7 +1070,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
       </div>
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium compare-button fr4s9wi css-1rgi3bk-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-w3l8dt-MuiButtonBase-root-MuiButton-root"
       id="compare-button"
       tabindex="0"
       type="submit"

--- a/src/components/CompareResults/OverTimeResultsView.tsx
+++ b/src/components/CompareResults/OverTimeResultsView.tsx
@@ -43,7 +43,7 @@ function ResultsView(props: ResultsViewProps) {
         <LinkToHome />
 
         <CompareOverTime
-          hasEditableState={true}
+          hasEditButton={true}
           newRevs={newRevsInfo}
           isBaseSearch={true}
           expandBaseComponent={() => null}

--- a/src/components/CompareResults/OverTimeResultsView.tsx
+++ b/src/components/CompareResults/OverTimeResultsView.tsx
@@ -43,7 +43,7 @@ function ResultsView(props: ResultsViewProps) {
         <LinkToHome />
 
         <CompareOverTime
-          hasNonEditableState={false}
+          hasEditableState={true}
           newRevs={newRevsInfo}
           isBaseSearch={true}
           expandBaseComponent={() => null}

--- a/src/components/CompareResults/ResultsView.tsx
+++ b/src/components/CompareResults/ResultsView.tsx
@@ -44,7 +44,7 @@ function ResultsView(props: ResultsViewProps) {
         <LinkToHome />
 
         <CompareWithBase
-          hasNonEditableState={true}
+          hasEditableState={true}
           baseRev={baseRevInfo ?? null}
           newRevs={newRevsInfo ?? []}
           frameworkIdVal={frameworkId}

--- a/src/components/CompareResults/ResultsView.tsx
+++ b/src/components/CompareResults/ResultsView.tsx
@@ -44,7 +44,7 @@ function ResultsView(props: ResultsViewProps) {
         <LinkToHome />
 
         <CompareWithBase
-          hasEditableState={true}
+          hasEditButton={true}
           baseRev={baseRevInfo ?? null}
           newRevs={newRevsInfo ?? []}
           frameworkIdVal={frameworkId}

--- a/src/components/Search/CompareOverTime.tsx
+++ b/src/components/Search/CompareOverTime.tsx
@@ -24,7 +24,7 @@ const stringsNew =
   Strings.components.searchDefault.overTime.collapsed.revisions;
 
 interface CompareWithTimeProps {
-  hasEditableState: boolean;
+  hasEditButton: boolean;
   newRevs: Changeset[] | [];
   frameworkIdVal: Framework['id'];
   intervalValue: TimeRange['value'];
@@ -33,7 +33,7 @@ interface CompareWithTimeProps {
 }
 
 function CompareOverTime({
-  hasEditableState,
+  hasEditButton,
   newRevs,
   frameworkIdVal,
   intervalValue,
@@ -178,7 +178,7 @@ function CompareOverTime({
         >
           <SearchOverTime
             {...stringsNew}
-            hasEditableState={hasEditableState}
+            hasEditButton={hasEditButton}
             repository={repository}
             displayedRevisions={inProgressRevs}
             onRemoveRevision={handleRemoveRevision}

--- a/src/components/Search/CompareOverTime.tsx
+++ b/src/components/Search/CompareOverTime.tsx
@@ -24,7 +24,7 @@ const stringsNew =
   Strings.components.searchDefault.overTime.collapsed.revisions;
 
 interface CompareWithTimeProps {
-  hasNonEditableState: boolean;
+  hasEditableState: boolean;
   newRevs: Changeset[] | [];
   frameworkIdVal: Framework['id'];
   intervalValue: TimeRange['value'];
@@ -33,7 +33,7 @@ interface CompareWithTimeProps {
 }
 
 function CompareOverTime({
-  hasNonEditableState,
+  hasEditableState,
   newRevs,
   frameworkIdVal,
   intervalValue,
@@ -178,7 +178,7 @@ function CompareOverTime({
         >
           <SearchOverTime
             {...stringsNew}
-            hasNonEditableState={hasNonEditableState}
+            hasEditableState={hasEditableState}
             repository={repository}
             displayedRevisions={inProgressRevs}
             onRemoveRevision={handleRemoveRevision}

--- a/src/components/Search/CompareWithBase.tsx
+++ b/src/components/Search/CompareWithBase.tsx
@@ -21,7 +21,7 @@ const stringsBase = Strings.components.searchDefault.base.collapsed.base;
 const stringsNew = Strings.components.searchDefault.base.collapsed.revision;
 
 interface CompareWithBaseProps {
-  hasEditableState: boolean;
+  hasEditButton: boolean;
   baseRev: Changeset | null;
   newRevs: Changeset[];
   baseRepo: Repository['name'];
@@ -68,7 +68,7 @@ interface CompareWithBaseProps {
  *   recalled.
  */
 function CompareWithBase({
-  hasEditableState,
+  hasEditButton,
   baseRev,
   newRevs,
   isBaseSearch,
@@ -278,7 +278,7 @@ function CompareWithBase({
             {...stringsBase}
             isBaseComp={true}
             isWarning={isWarning}
-            hasEditableState={hasEditableState}
+            hasEditButton={hasEditButton}
             displayedRevisions={baseInProgressRev ? [baseInProgressRev] : []}
             onSave={handleSaveBase}
             onCancel={handleCancelBase}
@@ -294,7 +294,7 @@ function CompareWithBase({
           <SearchComponent
             {...stringsNew}
             isBaseComp={false}
-            hasEditableState={hasEditableState}
+            hasEditButton={hasEditButton}
             isWarning={isWarning}
             displayedRevisions={newInProgressRevs}
             onSave={handleSaveNew}

--- a/src/components/Search/CompareWithBase.tsx
+++ b/src/components/Search/CompareWithBase.tsx
@@ -21,7 +21,7 @@ const stringsBase = Strings.components.searchDefault.base.collapsed.base;
 const stringsNew = Strings.components.searchDefault.base.collapsed.revision;
 
 interface CompareWithBaseProps {
-  hasNonEditableState: boolean;
+  hasEditableState: boolean;
   baseRev: Changeset | null;
   newRevs: Changeset[];
   baseRepo: Repository['name'];
@@ -68,7 +68,7 @@ interface CompareWithBaseProps {
  *   recalled.
  */
 function CompareWithBase({
-  hasNonEditableState,
+  hasEditableState,
   baseRev,
   newRevs,
   isBaseSearch,
@@ -278,7 +278,7 @@ function CompareWithBase({
             {...stringsBase}
             isBaseComp={true}
             isWarning={isWarning}
-            hasNonEditableState={hasNonEditableState}
+            hasEditableState={hasEditableState}
             displayedRevisions={baseInProgressRev ? [baseInProgressRev] : []}
             onSave={handleSaveBase}
             onCancel={handleCancelBase}
@@ -294,7 +294,7 @@ function CompareWithBase({
           <SearchComponent
             {...stringsNew}
             isBaseComp={false}
-            hasNonEditableState={hasNonEditableState}
+            hasEditableState={hasEditableState}
             isWarning={isWarning}
             displayedRevisions={newInProgressRevs}
             onSave={handleSaveNew}

--- a/src/components/Search/SearchComponent.tsx
+++ b/src/components/Search/SearchComponent.tsx
@@ -23,7 +23,7 @@ import SearchInputAndResults from './SearchInputAndResults';
 import SelectedRevisions from './SelectedRevisions';
 
 interface SearchProps {
-  hasNonEditableState: boolean;
+  hasEditableState: boolean;
   isWarning: boolean;
   isBaseComp: boolean;
   displayedRevisions: Changeset[];
@@ -41,7 +41,7 @@ interface SearchProps {
 }
 
 function SearchComponent({
-  hasNonEditableState,
+  hasEditableState,
   isBaseComp,
   displayedRevisions,
   onCancel,
@@ -83,7 +83,7 @@ function SearchComponent({
     },
   });
 
-  const [formIsDisplayed, setFormIsDisplayed] = useState(!hasNonEditableState);
+  const [formIsDisplayed, setFormIsDisplayed] = useState(!hasEditableState);
 
   return (
     <Grid className={styles.component}>
@@ -101,7 +101,7 @@ function SearchComponent({
           </Tooltip>
         </InputLabel>
         {/**** Edit Button ****/}
-        {hasNonEditableState && !formIsDisplayed && (
+        {hasEditableState && !formIsDisplayed && (
           <EditButton
             isBase={isBaseComp}
             onEditAction={() => {
@@ -125,11 +125,11 @@ function SearchComponent({
           xs={2}
           id={`${searchType}_search-dropdown`}
           className={`${searchType}-search-dropdown ${styles.dropDown} ${
-            hasNonEditableState ? 'small' : ''
-          } ${hasNonEditableState ? compareView : ''}-base-dropdown`}
+            hasEditableState ? 'small' : ''
+          } ${hasEditableState ? compareView : ''}-base-dropdown`}
         >
           <SearchDropdown
-            compact={hasNonEditableState}
+            compact={hasEditableState}
             selectLabel={selectLabel}
             searchType={searchType}
             repository={repository}
@@ -142,11 +142,11 @@ function SearchComponent({
           xs={7}
           id={`${searchType}_search-input`}
           className={`${searchType}-search-input  ${styles.baseSearchInput} ${
-            hasNonEditableState ? 'big' : ''
+            hasEditableState ? 'big' : ''
           } `}
         >
           <SearchInputAndResults
-            compact={hasNonEditableState}
+            compact={hasEditableState}
             inputPlaceholder={inputPlaceholder}
             displayedRevisions={displayedRevisions}
             searchType={searchType}
@@ -155,7 +155,7 @@ function SearchComponent({
           />
         </Grid>
         {/****** Cancel Save Buttons ******/}
-        {hasNonEditableState && formIsDisplayed && (
+        {hasEditableState && formIsDisplayed && (
           <SaveCancelButtons
             searchType={searchType}
             onSave={() => {
@@ -177,7 +177,7 @@ function SearchComponent({
         >
           <SelectedRevisions
             isBase={isBaseComp}
-            canRemoveRevision={!hasNonEditableState || formIsDisplayed}
+            canRemoveRevision={!hasEditableState || formIsDisplayed}
             isWarning={isWarning}
             displayedRevisions={displayedRevisions}
             onRemoveRevision={onRemoveRevision}

--- a/src/components/Search/SearchComponent.tsx
+++ b/src/components/Search/SearchComponent.tsx
@@ -23,7 +23,7 @@ import SearchInputAndResults from './SearchInputAndResults';
 import SelectedRevisions from './SelectedRevisions';
 
 interface SearchProps {
-  hasEditableState: boolean;
+  hasEditButton: boolean;
   isWarning: boolean;
   isBaseComp: boolean;
   displayedRevisions: Changeset[];
@@ -41,7 +41,7 @@ interface SearchProps {
 }
 
 function SearchComponent({
-  hasEditableState,
+  hasEditButton,
   isBaseComp,
   displayedRevisions,
   onCancel,
@@ -83,7 +83,7 @@ function SearchComponent({
     },
   });
 
-  const [formIsDisplayed, setFormIsDisplayed] = useState(!hasEditableState);
+  const [formIsDisplayed, setFormIsDisplayed] = useState(!hasEditButton);
 
   return (
     <Grid className={styles.component}>
@@ -101,7 +101,7 @@ function SearchComponent({
           </Tooltip>
         </InputLabel>
         {/**** Edit Button ****/}
-        {hasEditableState && !formIsDisplayed && (
+        {hasEditButton && !formIsDisplayed && (
           <EditButton
             isBase={isBaseComp}
             onEditAction={() => {
@@ -125,11 +125,11 @@ function SearchComponent({
           xs={2}
           id={`${searchType}_search-dropdown`}
           className={`${searchType}-search-dropdown ${styles.dropDown} ${
-            hasEditableState ? 'small' : ''
-          } ${hasEditableState ? compareView : ''}-base-dropdown`}
+            hasEditButton ? 'small' : ''
+          } ${hasEditButton ? compareView : ''}-base-dropdown`}
         >
           <SearchDropdown
-            compact={hasEditableState}
+            compact={hasEditButton}
             selectLabel={selectLabel}
             searchType={searchType}
             repository={repository}
@@ -142,11 +142,11 @@ function SearchComponent({
           xs={7}
           id={`${searchType}_search-input`}
           className={`${searchType}-search-input  ${styles.baseSearchInput} ${
-            hasEditableState ? 'big' : ''
+            hasEditButton ? 'big' : ''
           } `}
         >
           <SearchInputAndResults
-            compact={hasEditableState}
+            compact={hasEditButton}
             inputPlaceholder={inputPlaceholder}
             displayedRevisions={displayedRevisions}
             searchType={searchType}
@@ -155,7 +155,7 @@ function SearchComponent({
           />
         </Grid>
         {/****** Cancel Save Buttons ******/}
-        {hasEditableState && formIsDisplayed && (
+        {hasEditButton && formIsDisplayed && (
           <SaveCancelButtons
             searchType={searchType}
             onSave={() => {
@@ -177,7 +177,7 @@ function SearchComponent({
         >
           <SelectedRevisions
             isBase={isBaseComp}
-            canRemoveRevision={!hasEditableState || formIsDisplayed}
+            canRemoveRevision={!hasEditButton || formIsDisplayed}
             isWarning={isWarning}
             displayedRevisions={displayedRevisions}
             onRemoveRevision={onRemoveRevision}

--- a/src/components/Search/SearchContainer.tsx
+++ b/src/components/Search/SearchContainer.tsx
@@ -27,7 +27,7 @@ function SearchContainer(props: SearchViewProps) {
        default framework; refer to frameworkMap in constants.ts */}
       <CompareWithBase
         frameworkIdVal={1 as Framework['id']}
-        hasNonEditableState={false}
+        hasEditableState={false}
         baseRev={null}
         newRevs={[]}
         isBaseSearch={isBaseSearch}
@@ -36,7 +36,7 @@ function SearchContainer(props: SearchViewProps) {
         newRepo='try'
       />
       <CompareOverTime
-        hasNonEditableState={false}
+        hasEditableState={false}
         newRevs={[]}
         isBaseSearch={isBaseSearch}
         expandBaseComponent={expandBaseComponent}

--- a/src/components/Search/SearchContainer.tsx
+++ b/src/components/Search/SearchContainer.tsx
@@ -27,7 +27,7 @@ function SearchContainer(props: SearchViewProps) {
        default framework; refer to frameworkMap in constants.ts */}
       <CompareWithBase
         frameworkIdVal={1 as Framework['id']}
-        hasEditableState={false}
+        hasEditButton={false}
         baseRev={null}
         newRevs={[]}
         isBaseSearch={isBaseSearch}
@@ -36,7 +36,7 @@ function SearchContainer(props: SearchViewProps) {
         newRepo='try'
       />
       <CompareOverTime
-        hasEditableState={false}
+        hasEditButton={false}
         newRevs={[]}
         isBaseSearch={isBaseSearch}
         expandBaseComponent={expandBaseComponent}

--- a/src/components/Search/SearchOverTime.tsx
+++ b/src/components/Search/SearchOverTime.tsx
@@ -25,7 +25,7 @@ interface SearchProps {
   selectLabel: string;
   tooltip: string;
   inputPlaceholder: string;
-  hasNonEditableState: boolean;
+  hasEditableState: boolean;
   displayedRevisions: Changeset[];
   repository: Repository['name'];
   onRemoveRevision: (item: Changeset) => void;
@@ -37,7 +37,7 @@ export default function SearchOverTime({
   selectLabel,
   tooltip,
   inputPlaceholder,
-  hasNonEditableState,
+  hasEditableState,
   repository,
   displayedRevisions,
   onRemoveRevision,
@@ -47,7 +47,7 @@ export default function SearchOverTime({
   const mode = useAppSelector((state) => state.theme.mode);
   const styles = SearchStyles(mode);
 
-  const [formIsDisplayed, setFormIsDisplayed] = useState(!hasNonEditableState);
+  const [formIsDisplayed, setFormIsDisplayed] = useState(!hasEditableState);
 
   /* These overriding rules update the theme mode by accessing the otherwise inaccessible MUI tooltip styles */
   cssRule('.MuiPopover-root', {
@@ -100,8 +100,8 @@ export default function SearchOverTime({
           xs={2}
           id='new_search-dropdown--time'
           className={`new-search-dropdown ${styles.dropDown} ${
-            hasNonEditableState ? 'small' : ''
-          } ${hasNonEditableState ? compareOverTimeView : ''}-new-dropdown`}
+            hasEditableState ? 'small' : ''
+          } ${hasEditableState ? compareOverTimeView : ''}-new-dropdown`}
         >
           <SearchDropdown
             compact={false}
@@ -117,11 +117,11 @@ export default function SearchOverTime({
           xs={7}
           id='new_search-input--time'
           className={`new-search-input--time  ${styles.baseSearchInput} ${
-            hasNonEditableState ? 'big' : ''
+            hasEditableState ? 'big' : ''
           } `}
         >
           <SearchInputAndResults
-            compact={hasNonEditableState}
+            compact={hasEditableState}
             inputPlaceholder={inputPlaceholder}
             displayedRevisions={displayedRevisions}
             searchType='new'
@@ -135,7 +135,7 @@ export default function SearchOverTime({
         <Grid className='d-flex'>
           <SelectedRevisions
             isBase={false}
-            canRemoveRevision={!hasNonEditableState || formIsDisplayed}
+            canRemoveRevision={!hasEditableState || formIsDisplayed}
             isWarning={false}
             displayedRevisions={displayedRevisions}
             onRemoveRevision={onRemoveRevision}

--- a/src/components/Search/SearchOverTime.tsx
+++ b/src/components/Search/SearchOverTime.tsx
@@ -25,7 +25,7 @@ interface SearchProps {
   selectLabel: string;
   tooltip: string;
   inputPlaceholder: string;
-  hasEditableState: boolean;
+  hasEditButton: boolean;
   displayedRevisions: Changeset[];
   repository: Repository['name'];
   onRemoveRevision: (item: Changeset) => void;
@@ -37,7 +37,7 @@ export default function SearchOverTime({
   selectLabel,
   tooltip,
   inputPlaceholder,
-  hasEditableState,
+  hasEditButton,
   repository,
   displayedRevisions,
   onRemoveRevision,
@@ -47,7 +47,7 @@ export default function SearchOverTime({
   const mode = useAppSelector((state) => state.theme.mode);
   const styles = SearchStyles(mode);
 
-  const [formIsDisplayed, setFormIsDisplayed] = useState(!hasEditableState);
+  const [formIsDisplayed, setFormIsDisplayed] = useState(!hasEditButton);
 
   /* These overriding rules update the theme mode by accessing the otherwise inaccessible MUI tooltip styles */
   cssRule('.MuiPopover-root', {
@@ -100,8 +100,8 @@ export default function SearchOverTime({
           xs={2}
           id='new_search-dropdown--time'
           className={`new-search-dropdown ${styles.dropDown} ${
-            hasEditableState ? 'small' : ''
-          } ${hasEditableState ? compareOverTimeView : ''}-new-dropdown`}
+            hasEditButton ? 'small' : ''
+          } ${hasEditButton ? compareOverTimeView : ''}-new-dropdown`}
         >
           <SearchDropdown
             compact={false}
@@ -117,11 +117,11 @@ export default function SearchOverTime({
           xs={7}
           id='new_search-input--time'
           className={`new-search-input--time  ${styles.baseSearchInput} ${
-            hasEditableState ? 'big' : ''
+            hasEditButton ? 'big' : ''
           } `}
         >
           <SearchInputAndResults
-            compact={hasEditableState}
+            compact={hasEditButton}
             inputPlaceholder={inputPlaceholder}
             displayedRevisions={displayedRevisions}
             searchType='new'
@@ -135,7 +135,7 @@ export default function SearchOverTime({
         <Grid className='d-flex'>
           <SelectedRevisions
             isBase={false}
-            canRemoveRevision={!hasEditableState || formIsDisplayed}
+            canRemoveRevision={!hasEditButton || formIsDisplayed}
             isWarning={false}
             displayedRevisions={displayedRevisions}
             onRemoveRevision={onRemoveRevision}


### PR DESCRIPTION
The prop `hasNonEditableState` is confusing because of the double negative when using the false boolean. Let's make it positive, `hasEditableState`, so there's less cognitive load.