### PR TITLE
pass down repo info and adjusted tests

### DIFF
--- a/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
@@ -157,6 +157,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
     </div>
     <div
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
+      data-testid="base-selected-revision"
     >
       <div
         class="box_f65ycfw base-box MuiBox-root css-0"
@@ -183,6 +184,26 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
             >
               <div>
                 try
+              </div>
+              <div
+                class="warning-icon"
+              >
+                <svg
+                  aria-label="Comparing “try” repository to any repository aside from “try” is not recommended."
+                  class="MuiSvgIcon-root MuiSvgIcon-colorWarning MuiSvgIcon-fontSizeSmall css-1jwhf5x-MuiSvgIcon-root"
+                  data-mui-internal-clone-element="true"
+                  data-testid="WarningIcon"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
+                  />
+                  <title>
+                    Comparing “try” repository to any repository aside from “try” is not recommended.
+                  </title>
+                </svg>
               </div>
             </div>
             <div
@@ -351,13 +372,13 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
               role="button"
               tabindex="0"
             >
-              try
+              mozilla-central
             </div>
             <input
               aria-hidden="true"
               class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
               tabindex="-1"
-              value="try"
+              value="mozilla-central"
             />
             <svg
               aria-hidden="true"
@@ -434,6 +455,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
     </div>
     <div
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
+      data-testid="new-selected-revision"
     >
       <div
         class="box_f65ycfw new-box MuiBox-root css-0"
@@ -448,18 +470,38 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
             <input
               name="newRev"
               type="hidden"
-              value="spam"
+              value="coconut"
             />
             <input
               name="newRepo"
               type="hidden"
-              value="mozilla-central"
+              value="try"
             />
             <div
               class="repo_f1bx8by5"
             >
               <div>
-                mozilla-central
+                try
+              </div>
+              <div
+                class="warning-icon"
+              >
+                <svg
+                  aria-label="Comparing “try” repository to any repository aside from “try” is not recommended."
+                  class="MuiSvgIcon-root MuiSvgIcon-colorWarning MuiSvgIcon-fontSizeSmall css-1jwhf5x-MuiSvgIcon-root"
+                  data-mui-internal-clone-element="true"
+                  data-testid="WarningIcon"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
+                  />
+                  <title>
+                    Comparing “try” repository to any repository aside from “try” is not recommended.
+                  </title>
+                </svg>
               </div>
             </div>
             <div
@@ -478,11 +520,11 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
-                      href="https://treeherder.mozilla.org/jobs?repo=mozilla-central&revision=spam"
+                      href="https://treeherder.mozilla.org/jobs?repo=try&revision=coconut"
                       target="_blank"
-                      title="open treeherder view for spam"
+                      title="open treeherder view for coconut"
                     >
-                      spam
+                      coconut
                     </a>
                   </span>
                   <div
@@ -504,7 +546,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
                         />
                       </svg>
                        
-                      ericidle@python.com
+                      johncleese@python.com
                     </div>
                     <div
                       class="info-caption-item item-time"
@@ -520,14 +562,14 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
                           d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"
                         />
                       </svg>
-                      02/22/58 00:00
+                      03/29/51 00:00
                     </div>
                   </div>
                 </span>
                 <p
                   class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-163o6oo-MuiTypography-root"
                 >
-                  it's just a flesh wound 
+                  you've got no arms left! 
                 </p>
               </div>
               <button
@@ -934,6 +976,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
     </div>
     <div
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
+      data-testid="base-selected-revision"
     >
       <div
         class="box_f65ycfw base-box MuiBox-root css-0"
@@ -960,6 +1003,26 @@ exports[`Compare With Base should have an edit mode in Results View: After click
             >
               <div>
                 try
+              </div>
+              <div
+                class="warning-icon"
+              >
+                <svg
+                  aria-label="Comparing “try” repository to any repository aside from “try” is not recommended."
+                  class="MuiSvgIcon-root MuiSvgIcon-colorWarning MuiSvgIcon-fontSizeSmall css-1jwhf5x-MuiSvgIcon-root"
+                  data-mui-internal-clone-element="true"
+                  data-testid="WarningIcon"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
+                  />
+                  <title>
+                    Comparing “try” repository to any repository aside from “try” is not recommended.
+                  </title>
+                </svg>
               </div>
             </div>
             <div
@@ -1128,13 +1191,13 @@ exports[`Compare With Base should have an edit mode in Results View: After click
               role="button"
               tabindex="0"
             >
-              try
+              mozilla-central
             </div>
             <input
               aria-hidden="true"
               class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
               tabindex="-1"
-              value="try"
+              value="mozilla-central"
             />
             <svg
               aria-hidden="true"
@@ -1211,6 +1274,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
     </div>
     <div
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
+      data-testid="new-selected-revision"
     >
       <div
         class="box_f65ycfw new-box MuiBox-root css-0"
@@ -1225,18 +1289,38 @@ exports[`Compare With Base should have an edit mode in Results View: After click
             <input
               name="newRev"
               type="hidden"
-              value="spam"
+              value="coconut"
             />
             <input
               name="newRepo"
               type="hidden"
-              value="mozilla-central"
+              value="try"
             />
             <div
               class="repo_f1bx8by5"
             >
               <div>
-                mozilla-central
+                try
+              </div>
+              <div
+                class="warning-icon"
+              >
+                <svg
+                  aria-label="Comparing “try” repository to any repository aside from “try” is not recommended."
+                  class="MuiSvgIcon-root MuiSvgIcon-colorWarning MuiSvgIcon-fontSizeSmall css-1jwhf5x-MuiSvgIcon-root"
+                  data-mui-internal-clone-element="true"
+                  data-testid="WarningIcon"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
+                  />
+                  <title>
+                    Comparing “try” repository to any repository aside from “try” is not recommended.
+                  </title>
+                </svg>
               </div>
             </div>
             <div
@@ -1255,11 +1339,11 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
-                      href="https://treeherder.mozilla.org/jobs?repo=mozilla-central&revision=spam"
+                      href="https://treeherder.mozilla.org/jobs?repo=try&revision=coconut"
                       target="_blank"
-                      title="open treeherder view for spam"
+                      title="open treeherder view for coconut"
                     >
-                      spam
+                      coconut
                     </a>
                   </span>
                   <div
@@ -1281,7 +1365,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                         />
                       </svg>
                        
-                      ericidle@python.com
+                      johncleese@python.com
                     </div>
                     <div
                       class="info-caption-item item-time"
@@ -1297,14 +1381,14 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                           d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"
                         />
                       </svg>
-                      02/22/58 00:00
+                      03/29/51 00:00
                     </div>
                   </div>
                 </span>
                 <p
                   class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-163o6oo-MuiTypography-root"
                 >
-                  it's just a flesh wound 
+                  you've got no arms left! 
                 </p>
               </div>
               <button
@@ -1571,6 +1655,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
     </div>
     <div
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
+      data-testid="base-selected-revision"
     >
       <div
         class="box_f65ycfw base-box MuiBox-root css-0"
@@ -1630,13 +1715,13 @@ exports[`Compare With Base should have an edit mode in Results View: After click
               role="button"
               tabindex="0"
             >
-              try
+              mozilla-central
             </div>
             <input
               aria-hidden="true"
               class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
               tabindex="-1"
-              value="try"
+              value="mozilla-central"
             />
             <svg
               aria-hidden="true"
@@ -1741,6 +1826,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
     </div>
     <div
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
+      data-testid="new-selected-revision"
     >
       <div
         class="box_f65ycfw new-box MuiBox-root css-0"
@@ -1755,18 +1841,38 @@ exports[`Compare With Base should have an edit mode in Results View: After click
             <input
               name="newRev"
               type="hidden"
-              value="spam"
+              value="coconut"
             />
             <input
               name="newRepo"
               type="hidden"
-              value="mozilla-central"
+              value="try"
             />
             <div
               class="repo_f1bx8by5"
             >
               <div>
-                mozilla-central
+                try
+              </div>
+              <div
+                class="warning-icon"
+              >
+                <svg
+                  aria-label="Comparing “try” repository to any repository aside from “try” is not recommended."
+                  class="MuiSvgIcon-root MuiSvgIcon-colorWarning MuiSvgIcon-fontSizeSmall css-1jwhf5x-MuiSvgIcon-root"
+                  data-mui-internal-clone-element="true"
+                  data-testid="WarningIcon"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
+                  />
+                  <title>
+                    Comparing “try” repository to any repository aside from “try” is not recommended.
+                  </title>
+                </svg>
               </div>
             </div>
             <div
@@ -1785,11 +1891,11 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
-                      href="https://treeherder.mozilla.org/jobs?repo=mozilla-central&revision=spam"
+                      href="https://treeherder.mozilla.org/jobs?repo=try&revision=coconut"
                       target="_blank"
-                      title="open treeherder view for spam"
+                      title="open treeherder view for coconut"
                     >
-                      spam
+                      coconut
                     </a>
                   </span>
                   <div
@@ -1811,7 +1917,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                         />
                       </svg>
                        
-                      ericidle@python.com
+                      johncleese@python.com
                     </div>
                     <div
                       class="info-caption-item item-time"
@@ -1827,14 +1933,14 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                           d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"
                         />
                       </svg>
-                      02/22/58 00:00
+                      03/29/51 00:00
                     </div>
                   </div>
                 </span>
                 <p
                   class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-163o6oo-MuiTypography-root"
                 >
-                  it's just a flesh wound 
+                  you've got no arms left! 
                 </p>
               </div>
               <button
@@ -2101,6 +2207,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
     </div>
     <div
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
+      data-testid="base-selected-revision"
     >
       <div
         class="box_f65ycfw base-box MuiBox-root css-0"
@@ -2127,6 +2234,26 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
             >
               <div>
                 try
+              </div>
+              <div
+                class="warning-icon"
+              >
+                <svg
+                  aria-label="Comparing “try” repository to any repository aside from “try” is not recommended."
+                  class="MuiSvgIcon-root MuiSvgIcon-colorWarning MuiSvgIcon-fontSizeSmall css-1jwhf5x-MuiSvgIcon-root"
+                  data-mui-internal-clone-element="true"
+                  data-testid="WarningIcon"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
+                  />
+                  <title>
+                    Comparing “try” repository to any repository aside from “try” is not recommended.
+                  </title>
+                </svg>
               </div>
             </div>
             <div
@@ -2295,13 +2422,13 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
               role="button"
               tabindex="0"
             >
-              try
+              mozilla-central
             </div>
             <input
               aria-hidden="true"
               class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
               tabindex="-1"
-              value="try"
+              value="mozilla-central"
             />
             <svg
               aria-hidden="true"
@@ -2378,6 +2505,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
     </div>
     <div
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
+      data-testid="new-selected-revision"
     >
       <div
         class="box_f65ycfw new-box MuiBox-root css-0"
@@ -2392,18 +2520,38 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
             <input
               name="newRev"
               type="hidden"
-              value="spam"
+              value="coconut"
             />
             <input
               name="newRepo"
               type="hidden"
-              value="mozilla-central"
+              value="try"
             />
             <div
               class="repo_f1bx8by5"
             >
               <div>
-                mozilla-central
+                try
+              </div>
+              <div
+                class="warning-icon"
+              >
+                <svg
+                  aria-label="Comparing “try” repository to any repository aside from “try” is not recommended."
+                  class="MuiSvgIcon-root MuiSvgIcon-colorWarning MuiSvgIcon-fontSizeSmall css-1jwhf5x-MuiSvgIcon-root"
+                  data-mui-internal-clone-element="true"
+                  data-testid="WarningIcon"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
+                  />
+                  <title>
+                    Comparing “try” repository to any repository aside from “try” is not recommended.
+                  </title>
+                </svg>
               </div>
             </div>
             <div
@@ -2422,11 +2570,11 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
-                      href="https://treeherder.mozilla.org/jobs?repo=mozilla-central&revision=spam"
+                      href="https://treeherder.mozilla.org/jobs?repo=try&revision=coconut"
                       target="_blank"
-                      title="open treeherder view for spam"
+                      title="open treeherder view for coconut"
                     >
-                      spam
+                      coconut
                     </a>
                   </span>
                   <div
@@ -2448,7 +2596,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
                         />
                       </svg>
                        
-                      ericidle@python.com
+                      johncleese@python.com
                     </div>
                     <div
                       class="info-caption-item item-time"
@@ -2464,14 +2612,566 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
                           d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"
                         />
                       </svg>
-                      02/22/58 00:00
+                      03/29/51 00:00
                     </div>
                   </div>
                 </span>
                 <p
                   class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-163o6oo-MuiTypography-root"
                 >
-                  it's just a flesh wound 
+                  you've got no arms left! 
+                </p>
+              </div>
+              <button
+                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium icon-close-hidden revision-action close-button css-13h131f-MuiButtonBase-root-MuiButton-root"
+                name="close-button"
+                tabindex="0"
+                title="remove revision"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-1mecf1h-MuiSvgIcon-root"
+                  data-testid="close-icon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"
+                  />
+                </svg>
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fl6uoag fjuaqdk css-13eijkh-MuiGrid-root"
+  >
+    <div
+      class="MuiFormControl-root framework-dropdown f1pm9d4y css-1nrlq1o-MuiFormControl-root"
+    >
+      <label
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined dropdown-select-label css-11mbixr-MuiFormLabel-root-MuiInputLabel-root"
+        data-shrink="true"
+        id="select-framework-label"
+      >
+        Framework
+        <svg
+          aria-hidden="true"
+          aria-label="The framework or test harness containing the test you want to examine."
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+          data-mui-internal-clone-element="true"
+          data-testid="InfoOutlinedIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+          />
+        </svg>
+      </label>
+      <div
+        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl dropdown-select css-1nwv3h7-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+        data-testid="dropdown-select-framework"
+      >
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-labelledby="select-framework-label mui-component-select-framework"
+          class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-edng3m-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+          id="mui-component-select-framework"
+          role="button"
+          tabindex="0"
+        >
+          build_metrics
+        </div>
+        <input
+          aria-hidden="true"
+          class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+          name="framework"
+          tabindex="-1"
+          value="2"
+        />
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-ll500r-MuiSvgIcon-root-MuiSelect-icon"
+          data-testid="ArrowDropDownIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M7 10l5 5 5-5z"
+          />
+        </svg>
+      </div>
+    </div>
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium compare-button fr4s9wi css-1rgi3bk-MuiButtonBase-root-MuiButton-root"
+      id="compare-button"
+      tabindex="0"
+      type="submit"
+    >
+      Compare
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</form>
+`;
+
+exports[`Compare With Base should have an edit mode in Results View: after removal of base revision 1`] = `
+<form
+  action="/compare-results"
+  aria-label="Compare with base form"
+  class="form-wrapper"
+  method="get"
+>
+  <div
+    class="MuiGrid-root component_f14z0jsa css-plh9qo-MuiGrid-root"
+  >
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fl6uoag label-edit-wrapper css-13eijkh-MuiGrid-root"
+    >
+      <label
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
+        id="repo-dropdown--base"
+      >
+        Base
+        <svg
+          aria-hidden="true"
+          aria-label="The baseline revision (no changes) your revision will be compared against."
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+          data-mui-internal-clone-element="true"
+          data-testid="InfoOutlinedIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+          />
+        </svg>
+      </label>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-container container_f1psuwcf show-container  css-1ljzhs0-MuiGrid-root"
+      id="base-search-container"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fl6uoag small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        id="base_search-dropdown"
+      >
+        <div
+          class="MuiFormControl-root search-dropdown f1o9jg5h css-1nrlq1o-MuiFormControl-root"
+        >
+          <div
+            class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall dropdown-select css-1nwv3h7-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+            data-testid="dropdown-select-repo-dropdown--base"
+          >
+            <div
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-labelledby="repo-dropdown--base"
+              class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input MuiInputBase-inputSizeSmall css-v8lh20-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+              role="button"
+              tabindex="0"
+            >
+              try
+            </div>
+            <input
+              aria-hidden="true"
+              class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+              tabindex="-1"
+              value="try"
+            />
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-ll500r-MuiSvgIcon-root-MuiSelect-icon"
+              data-testid="ArrowDropDownIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7 10l5 5 5-5z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_fctyy2s big  css-17gmabg-MuiGrid-root"
+        id="base_search-input"
+      >
+        <div
+          class="MuiBox-root css-0"
+        >
+          <div
+            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+          >
+            <div
+              class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+            >
+              <div
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart css-193b4t-MuiInputBase-root-MuiOutlinedInput-root"
+              >
+                <div
+                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1laqsz7-MuiInputAdornment-root"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                    data-testid="SearchIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                    />
+                  </svg>
+                </div>
+                <input
+                  aria-invalid="false"
+                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart css-jrmsot-MuiInputBase-input-MuiOutlinedInput-input"
+                  id="search-base-input"
+                  placeholder="Search base by ID number or author email"
+                  type="text"
+                  value=""
+                />
+                <fieldset
+                  aria-hidden="true"
+                  class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+                >
+                  <legend
+                    class="css-ihdtdm"
+                  >
+                    <span
+                      class="notranslate"
+                    >
+                      ​
+                    </span>
+                  </legend>
+                </fieldset>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="cancel-save-btns"
+        id="cancel-save_btns"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium cancel-save cancel-button f9oipqi cancel-button-base css-2uznlz-MuiButtonBase-root-MuiButton-root"
+          name="cancel-button"
+          tabindex="0"
+          type="button"
+        >
+          Cancel
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium cancel-save save-button save-button-base 
+        } css-2uznlz-MuiButtonBase-root-MuiButton-root"
+          name="save-button"
+          tabindex="0"
+          type="button"
+        >
+          Save
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
+      data-testid="base-selected-revision"
+    >
+      <div
+        class="box_f65ycfw base-box MuiBox-root css-0"
+      >
+        <ul
+          class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    class="MuiGrid-root component_f14z0jsa css-plh9qo-MuiGrid-root"
+  >
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag label-edit-wrapper css-13eijkh-MuiGrid-root"
+    >
+      <label
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
+        id="repo-dropdown--new"
+      >
+        Revisions
+        <svg
+          aria-hidden="true"
+          aria-label="Revisions (typically including your changes) to compare against the selected base revision."
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+          data-mui-internal-clone-element="true"
+          data-testid="InfoOutlinedIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+          />
+        </svg>
+      </label>
+      <button
+        aria-label="edit revision"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium edit-button edit-button-new show-edit-btn css-13h131f-MuiButtonBase-root-MuiButton-root"
+        id="new-edit-button"
+        name="edit-button"
+        tabindex="0"
+        type="button"
+      >
+        <img
+          alt="edit-icon"
+          class="icon icon-edit"
+          id="new-edit-button-icon"
+          src="https://user-images.githubusercontent.com/88336547/259900252-462ac221-f4ff-4b1c-bb6b-5df906e8007d.svg"
+        />
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+        />
+      </button>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-container container_f1psuwcf hide-container  css-1ljzhs0-MuiGrid-root"
+      id="new-search-container"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        id="new_search-dropdown"
+      >
+        <div
+          class="MuiFormControl-root search-dropdown f1o9jg5h css-1nrlq1o-MuiFormControl-root"
+        >
+          <div
+            class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall dropdown-select css-1nwv3h7-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+            data-testid="dropdown-select-repo-dropdown--new"
+          >
+            <div
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-labelledby="repo-dropdown--new"
+              class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input MuiInputBase-inputSizeSmall css-v8lh20-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+              role="button"
+              tabindex="0"
+            >
+              mozilla-central
+            </div>
+            <input
+              aria-hidden="true"
+              class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+              tabindex="-1"
+              value="mozilla-central"
+            />
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-ll500r-MuiSvgIcon-root-MuiSelect-icon"
+              data-testid="ArrowDropDownIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7 10l5 5 5-5z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_fctyy2s big  css-17gmabg-MuiGrid-root"
+        id="new_search-input"
+      >
+        <div
+          class="MuiBox-root css-0"
+        >
+          <div
+            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+          >
+            <div
+              class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+            >
+              <div
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart css-193b4t-MuiInputBase-root-MuiOutlinedInput-root"
+              >
+                <div
+                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1laqsz7-MuiInputAdornment-root"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                    data-testid="SearchIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                    />
+                  </svg>
+                </div>
+                <input
+                  aria-invalid="false"
+                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart css-jrmsot-MuiInputBase-input-MuiOutlinedInput-input"
+                  id="search-new-input"
+                  placeholder="Search revision by ID number or author email"
+                  type="text"
+                  value=""
+                />
+                <fieldset
+                  aria-hidden="true"
+                  class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+                >
+                  <legend
+                    class="css-ihdtdm"
+                  >
+                    <span
+                      class="notranslate"
+                    >
+                      ​
+                    </span>
+                  </legend>
+                </fieldset>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
+      data-testid="new-selected-revision"
+    >
+      <div
+        class="box_f65ycfw new-box MuiBox-root css-0"
+      >
+        <ul
+          class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
+        >
+          <li
+            class="MuiListItem-root MuiListItem-gutters MuiListItem-padding item-container item-0 item-new css-vtiz8x-MuiListItem-root"
+            data-testid="selected-rev-item"
+          >
+            <input
+              name="newRev"
+              type="hidden"
+              value="coconut"
+            />
+            <input
+              name="newRepo"
+              type="hidden"
+              value="try"
+            />
+            <div
+              class="repo_f1bx8by5"
+            >
+              <div>
+                try
+              </div>
+              <div
+                class="warning-icon"
+              >
+                <svg
+                  aria-label="Comparing “try” repository to any repository aside from “try” is not recommended."
+                  class="MuiSvgIcon-root MuiSvgIcon-colorWarning MuiSvgIcon-fontSizeSmall css-1jwhf5x-MuiSvgIcon-root"
+                  data-mui-internal-clone-element="true"
+                  data-testid="WarningIcon"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
+                  />
+                  <title>
+                    Comparing “try” repository to any repository aside from “try” is not recommended.
+                  </title>
+                </svg>
+              </div>
+            </div>
+            <div
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters listItemButton_f5s7lzh css-1g1bko9-MuiButtonBase-root-MuiListItemButton-root"
+              role="button"
+              tabindex="0"
+            >
+              <div
+                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
+              >
+                <span
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-hrbm3k-MuiTypography-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
+                      href="https://treeherder.mozilla.org/jobs?repo=try&revision=coconut"
+                      target="_blank"
+                      title="open treeherder view for coconut"
+                    >
+                      coconut
+                    </a>
+                  </span>
+                  <div
+                    class="info-caption"
+                  >
+                    <div
+                      class="info-caption-item item-author"
+                    >
+                       
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
+                        data-testid="MailOutlineOutlinedIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
+                        />
+                      </svg>
+                       
+                      johncleese@python.com
+                    </div>
+                    <div
+                      class="info-caption-item item-time"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall time-icon css-1mecf1h-MuiSvgIcon-root"
+                        data-testid="AccessTimeOutlinedIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"
+                        />
+                      </svg>
+                      03/29/51 00:00
+                    </div>
+                  </div>
+                </span>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-163o6oo-MuiTypography-root"
+                >
+                  you've got no arms left! 
                 </p>
               </div>
               <button
@@ -2844,6 +3544,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                 </div>
                 <div
                   class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
+                  data-testid="base-selected-revision"
                 >
                   <div
                     class="box_f65ycfw base-box MuiBox-root css-0"
@@ -2986,6 +3687,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                 </div>
                 <div
                   class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
+                  data-testid="new-selected-revision"
                 >
                   <div
                     class="box_f65ycfw new-box MuiBox-root css-0"
@@ -3394,4 +4096,1382 @@ exports[`Compare With Base should remove the checked revision once X button is c
     </div>
   </div>
 </body>
+`;
+
+exports[`Compare With Base should save the updated BASE revision when Save is clicked: After clicking edit for the base revision 1`] = `
+<form
+  action="/compare-results"
+  aria-label="Compare with base form"
+  class="form-wrapper"
+  method="get"
+>
+  <div
+    class="MuiGrid-root component_f14z0jsa css-plh9qo-MuiGrid-root"
+  >
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fl6uoag label-edit-wrapper css-13eijkh-MuiGrid-root"
+    >
+      <label
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
+        id="repo-dropdown--base"
+      >
+        Base
+        <svg
+          aria-hidden="true"
+          aria-label="The baseline revision (no changes) your revision will be compared against."
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+          data-mui-internal-clone-element="true"
+          data-testid="InfoOutlinedIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+          />
+        </svg>
+      </label>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-container container_f1psuwcf show-container  css-1ljzhs0-MuiGrid-root"
+      id="base-search-container"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fl6uoag small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        id="base_search-dropdown"
+      >
+        <div
+          class="MuiFormControl-root search-dropdown f1o9jg5h css-1nrlq1o-MuiFormControl-root"
+        >
+          <div
+            class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall dropdown-select css-1nwv3h7-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+            data-testid="dropdown-select-repo-dropdown--base"
+          >
+            <div
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-labelledby="repo-dropdown--base"
+              class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input MuiInputBase-inputSizeSmall css-v8lh20-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+              role="button"
+              tabindex="0"
+            >
+              try
+            </div>
+            <input
+              aria-hidden="true"
+              class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+              tabindex="-1"
+              value="try"
+            />
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-ll500r-MuiSvgIcon-root-MuiSelect-icon"
+              data-testid="ArrowDropDownIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7 10l5 5 5-5z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_fctyy2s big  css-17gmabg-MuiGrid-root"
+        id="base_search-input"
+      >
+        <div
+          class="MuiBox-root css-0"
+        >
+          <div
+            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+          >
+            <div
+              class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+            >
+              <div
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart css-193b4t-MuiInputBase-root-MuiOutlinedInput-root"
+              >
+                <div
+                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1laqsz7-MuiInputAdornment-root"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                    data-testid="SearchIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                    />
+                  </svg>
+                </div>
+                <input
+                  aria-invalid="false"
+                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart css-jrmsot-MuiInputBase-input-MuiOutlinedInput-input"
+                  id="search-base-input"
+                  placeholder="Search base by ID number or author email"
+                  type="text"
+                  value=""
+                />
+                <fieldset
+                  aria-hidden="true"
+                  class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+                >
+                  <legend
+                    class="css-ihdtdm"
+                  >
+                    <span
+                      class="notranslate"
+                    >
+                      ​
+                    </span>
+                  </legend>
+                </fieldset>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="cancel-save-btns"
+        id="cancel-save_btns"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium cancel-save cancel-button f9oipqi cancel-button-base css-2uznlz-MuiButtonBase-root-MuiButton-root"
+          name="cancel-button"
+          tabindex="0"
+          type="button"
+        >
+          Cancel
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium cancel-save save-button save-button-base 
+        } css-2uznlz-MuiButtonBase-root-MuiButton-root"
+          name="save-button"
+          tabindex="0"
+          type="button"
+        >
+          Save
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
+      data-testid="base-selected-revision"
+    >
+      <div
+        class="box_f65ycfw base-box MuiBox-root css-0"
+      >
+        <ul
+          class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
+        >
+          <li
+            class="MuiListItem-root MuiListItem-gutters MuiListItem-padding item-container item-0 item-base css-vtiz8x-MuiListItem-root"
+            data-testid="selected-rev-item"
+          >
+            <input
+              name="baseRev"
+              type="hidden"
+              value="coconut"
+            />
+            <input
+              name="baseRepo"
+              type="hidden"
+              value="try"
+            />
+            <div
+              class="repo_f1bx8by5"
+            >
+              <div>
+                try
+              </div>
+              <div
+                class="warning-icon"
+              >
+                <svg
+                  aria-label="Comparing “try” repository to any repository aside from “try” is not recommended."
+                  class="MuiSvgIcon-root MuiSvgIcon-colorWarning MuiSvgIcon-fontSizeSmall css-1jwhf5x-MuiSvgIcon-root"
+                  data-mui-internal-clone-element="true"
+                  data-testid="WarningIcon"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
+                  />
+                  <title>
+                    Comparing “try” repository to any repository aside from “try” is not recommended.
+                  </title>
+                </svg>
+              </div>
+            </div>
+            <div
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters listItemButton_f5s7lzh css-1g1bko9-MuiButtonBase-root-MuiListItemButton-root"
+              role="button"
+              tabindex="0"
+            >
+              <div
+                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
+              >
+                <span
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-hrbm3k-MuiTypography-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
+                      href="https://treeherder.mozilla.org/jobs?repo=try&revision=coconut"
+                      target="_blank"
+                      title="open treeherder view for coconut"
+                    >
+                      coconut
+                    </a>
+                  </span>
+                  <div
+                    class="info-caption"
+                  >
+                    <div
+                      class="info-caption-item item-author"
+                    >
+                       
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
+                        data-testid="MailOutlineOutlinedIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
+                        />
+                      </svg>
+                       
+                      johncleese@python.com
+                    </div>
+                    <div
+                      class="info-caption-item item-time"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall time-icon css-1mecf1h-MuiSvgIcon-root"
+                        data-testid="AccessTimeOutlinedIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"
+                        />
+                      </svg>
+                      03/29/51 00:00
+                    </div>
+                  </div>
+                </span>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-163o6oo-MuiTypography-root"
+                >
+                  you've got no arms left! 
+                </p>
+              </div>
+              <button
+                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium icon-close-show revision-action close-button css-13h131f-MuiButtonBase-root-MuiButton-root"
+                name="close-button"
+                tabindex="0"
+                title="remove revision"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-1mecf1h-MuiSvgIcon-root"
+                  data-testid="close-icon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"
+                  />
+                </svg>
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div
+    class="MuiGrid-root component_f14z0jsa css-plh9qo-MuiGrid-root"
+  >
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag label-edit-wrapper css-13eijkh-MuiGrid-root"
+    >
+      <label
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
+        id="repo-dropdown--new"
+      >
+        Revisions
+        <svg
+          aria-hidden="true"
+          aria-label="Revisions (typically including your changes) to compare against the selected base revision."
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+          data-mui-internal-clone-element="true"
+          data-testid="InfoOutlinedIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+          />
+        </svg>
+      </label>
+      <button
+        aria-label="edit revision"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium edit-button edit-button-new show-edit-btn css-13h131f-MuiButtonBase-root-MuiButton-root"
+        id="new-edit-button"
+        name="edit-button"
+        tabindex="0"
+        type="button"
+      >
+        <img
+          alt="edit-icon"
+          class="icon icon-edit"
+          id="new-edit-button-icon"
+          src="https://user-images.githubusercontent.com/88336547/259900252-462ac221-f4ff-4b1c-bb6b-5df906e8007d.svg"
+        />
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+        />
+      </button>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-container container_f1psuwcf hide-container  css-1ljzhs0-MuiGrid-root"
+      id="new-search-container"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        id="new_search-dropdown"
+      >
+        <div
+          class="MuiFormControl-root search-dropdown f1o9jg5h css-1nrlq1o-MuiFormControl-root"
+        >
+          <div
+            class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall dropdown-select css-1nwv3h7-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+            data-testid="dropdown-select-repo-dropdown--new"
+          >
+            <div
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-labelledby="repo-dropdown--new"
+              class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input MuiInputBase-inputSizeSmall css-v8lh20-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+              role="button"
+              tabindex="0"
+            >
+              mozilla-central
+            </div>
+            <input
+              aria-hidden="true"
+              class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+              tabindex="-1"
+              value="mozilla-central"
+            />
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-ll500r-MuiSvgIcon-root-MuiSelect-icon"
+              data-testid="ArrowDropDownIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7 10l5 5 5-5z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_fctyy2s big  css-17gmabg-MuiGrid-root"
+        id="new_search-input"
+      >
+        <div
+          class="MuiBox-root css-0"
+        >
+          <div
+            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+          >
+            <div
+              class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+            >
+              <div
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart css-193b4t-MuiInputBase-root-MuiOutlinedInput-root"
+              >
+                <div
+                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1laqsz7-MuiInputAdornment-root"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                    data-testid="SearchIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                    />
+                  </svg>
+                </div>
+                <input
+                  aria-invalid="false"
+                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart css-jrmsot-MuiInputBase-input-MuiOutlinedInput-input"
+                  id="search-new-input"
+                  placeholder="Search revision by ID number or author email"
+                  type="text"
+                  value=""
+                />
+                <fieldset
+                  aria-hidden="true"
+                  class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+                >
+                  <legend
+                    class="css-ihdtdm"
+                  >
+                    <span
+                      class="notranslate"
+                    >
+                      ​
+                    </span>
+                  </legend>
+                </fieldset>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
+      data-testid="new-selected-revision"
+    >
+      <div
+        class="box_f65ycfw new-box MuiBox-root css-0"
+      >
+        <ul
+          class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
+        >
+          <li
+            class="MuiListItem-root MuiListItem-gutters MuiListItem-padding item-container item-0 item-new css-vtiz8x-MuiListItem-root"
+            data-testid="selected-rev-item"
+          >
+            <input
+              name="newRev"
+              type="hidden"
+              value="coconut"
+            />
+            <input
+              name="newRepo"
+              type="hidden"
+              value="try"
+            />
+            <div
+              class="repo_f1bx8by5"
+            >
+              <div>
+                try
+              </div>
+              <div
+                class="warning-icon"
+              >
+                <svg
+                  aria-label="Comparing “try” repository to any repository aside from “try” is not recommended."
+                  class="MuiSvgIcon-root MuiSvgIcon-colorWarning MuiSvgIcon-fontSizeSmall css-1jwhf5x-MuiSvgIcon-root"
+                  data-mui-internal-clone-element="true"
+                  data-testid="WarningIcon"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
+                  />
+                  <title>
+                    Comparing “try” repository to any repository aside from “try” is not recommended.
+                  </title>
+                </svg>
+              </div>
+            </div>
+            <div
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters listItemButton_f5s7lzh css-1g1bko9-MuiButtonBase-root-MuiListItemButton-root"
+              role="button"
+              tabindex="0"
+            >
+              <div
+                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
+              >
+                <span
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-hrbm3k-MuiTypography-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
+                      href="https://treeherder.mozilla.org/jobs?repo=try&revision=coconut"
+                      target="_blank"
+                      title="open treeherder view for coconut"
+                    >
+                      coconut
+                    </a>
+                  </span>
+                  <div
+                    class="info-caption"
+                  >
+                    <div
+                      class="info-caption-item item-author"
+                    >
+                       
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
+                        data-testid="MailOutlineOutlinedIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
+                        />
+                      </svg>
+                       
+                      johncleese@python.com
+                    </div>
+                    <div
+                      class="info-caption-item item-time"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall time-icon css-1mecf1h-MuiSvgIcon-root"
+                        data-testid="AccessTimeOutlinedIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"
+                        />
+                      </svg>
+                      03/29/51 00:00
+                    </div>
+                  </div>
+                </span>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-163o6oo-MuiTypography-root"
+                >
+                  you've got no arms left! 
+                </p>
+              </div>
+              <button
+                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium icon-close-hidden revision-action close-button css-13h131f-MuiButtonBase-root-MuiButton-root"
+                name="close-button"
+                tabindex="0"
+                title="remove revision"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-1mecf1h-MuiSvgIcon-root"
+                  data-testid="close-icon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"
+                  />
+                </svg>
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fl6uoag fjuaqdk css-13eijkh-MuiGrid-root"
+  >
+    <div
+      class="MuiFormControl-root framework-dropdown f1pm9d4y css-1nrlq1o-MuiFormControl-root"
+    >
+      <label
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined dropdown-select-label css-11mbixr-MuiFormLabel-root-MuiInputLabel-root"
+        data-shrink="true"
+        id="select-framework-label"
+      >
+        Framework
+        <svg
+          aria-hidden="true"
+          aria-label="The framework or test harness containing the test you want to examine."
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+          data-mui-internal-clone-element="true"
+          data-testid="InfoOutlinedIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+          />
+        </svg>
+      </label>
+      <div
+        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl dropdown-select css-1nwv3h7-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+        data-testid="dropdown-select-framework"
+      >
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-labelledby="select-framework-label mui-component-select-framework"
+          class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-edng3m-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+          id="mui-component-select-framework"
+          role="button"
+          tabindex="0"
+        >
+          build_metrics
+        </div>
+        <input
+          aria-hidden="true"
+          class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+          name="framework"
+          tabindex="-1"
+          value="2"
+        />
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-ll500r-MuiSvgIcon-root-MuiSelect-icon"
+          data-testid="ArrowDropDownIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M7 10l5 5 5-5z"
+          />
+        </svg>
+      </div>
+    </div>
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium compare-button fr4s9wi css-1rgi3bk-MuiButtonBase-root-MuiButton-root"
+      id="compare-button"
+      tabindex="0"
+      type="submit"
+    >
+      Compare
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</form>
+`;
+
+exports[`Compare With Base should save the updated NEW revision when Save is clicked: After clicking edit for the new revision 1`] = `
+<form
+  action="/compare-results"
+  aria-label="Compare with base form"
+  class="form-wrapper"
+  method="get"
+>
+  <div
+    class="MuiGrid-root component_f14z0jsa css-plh9qo-MuiGrid-root"
+  >
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fl6uoag label-edit-wrapper css-13eijkh-MuiGrid-root"
+    >
+      <label
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
+        id="repo-dropdown--base"
+      >
+        Base
+        <svg
+          aria-hidden="true"
+          aria-label="The baseline revision (no changes) your revision will be compared against."
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+          data-mui-internal-clone-element="true"
+          data-testid="InfoOutlinedIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+          />
+        </svg>
+      </label>
+      <button
+        aria-label="edit revision"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium edit-button edit-button-base show-edit-btn css-13h131f-MuiButtonBase-root-MuiButton-root"
+        id="base-edit-button"
+        name="edit-button"
+        tabindex="0"
+        type="button"
+      >
+        <img
+          alt="edit-icon"
+          class="icon icon-edit"
+          id="base-edit-button-icon"
+          src="https://user-images.githubusercontent.com/88336547/259900252-462ac221-f4ff-4b1c-bb6b-5df906e8007d.svg"
+        />
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+        />
+      </button>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-container container_f1psuwcf hide-container  css-1ljzhs0-MuiGrid-root"
+      id="base-search-container"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fl6uoag small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        id="base_search-dropdown"
+      >
+        <div
+          class="MuiFormControl-root search-dropdown f1o9jg5h css-1nrlq1o-MuiFormControl-root"
+        >
+          <div
+            class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall dropdown-select css-1nwv3h7-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+            data-testid="dropdown-select-repo-dropdown--base"
+          >
+            <div
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-labelledby="repo-dropdown--base"
+              class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input MuiInputBase-inputSizeSmall css-v8lh20-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+              role="button"
+              tabindex="0"
+            >
+              try
+            </div>
+            <input
+              aria-hidden="true"
+              class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+              tabindex="-1"
+              value="try"
+            />
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-ll500r-MuiSvgIcon-root-MuiSelect-icon"
+              data-testid="ArrowDropDownIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7 10l5 5 5-5z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_fctyy2s big  css-17gmabg-MuiGrid-root"
+        id="base_search-input"
+      >
+        <div
+          class="MuiBox-root css-0"
+        >
+          <div
+            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+          >
+            <div
+              class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+            >
+              <div
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart css-193b4t-MuiInputBase-root-MuiOutlinedInput-root"
+              >
+                <div
+                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1laqsz7-MuiInputAdornment-root"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                    data-testid="SearchIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                    />
+                  </svg>
+                </div>
+                <input
+                  aria-invalid="false"
+                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart css-jrmsot-MuiInputBase-input-MuiOutlinedInput-input"
+                  id="search-base-input"
+                  placeholder="Search base by ID number or author email"
+                  type="text"
+                  value=""
+                />
+                <fieldset
+                  aria-hidden="true"
+                  class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+                >
+                  <legend
+                    class="css-ihdtdm"
+                  >
+                    <span
+                      class="notranslate"
+                    >
+                      ​
+                    </span>
+                  </legend>
+                </fieldset>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
+      data-testid="base-selected-revision"
+    >
+      <div
+        class="box_f65ycfw base-box MuiBox-root css-0"
+      >
+        <ul
+          class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
+        >
+          <li
+            class="MuiListItem-root MuiListItem-gutters MuiListItem-padding item-container item-0 item-base css-vtiz8x-MuiListItem-root"
+            data-testid="selected-rev-item"
+          >
+            <input
+              name="baseRev"
+              type="hidden"
+              value="coconut"
+            />
+            <input
+              name="baseRepo"
+              type="hidden"
+              value="try"
+            />
+            <div
+              class="repo_f1bx8by5"
+            >
+              <div>
+                try
+              </div>
+              <div
+                class="warning-icon"
+              >
+                <svg
+                  aria-label="Comparing “try” repository to any repository aside from “try” is not recommended."
+                  class="MuiSvgIcon-root MuiSvgIcon-colorWarning MuiSvgIcon-fontSizeSmall css-1jwhf5x-MuiSvgIcon-root"
+                  data-mui-internal-clone-element="true"
+                  data-testid="WarningIcon"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
+                  />
+                  <title>
+                    Comparing “try” repository to any repository aside from “try” is not recommended.
+                  </title>
+                </svg>
+              </div>
+            </div>
+            <div
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters listItemButton_f5s7lzh css-1g1bko9-MuiButtonBase-root-MuiListItemButton-root"
+              role="button"
+              tabindex="0"
+            >
+              <div
+                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
+              >
+                <span
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-hrbm3k-MuiTypography-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
+                      href="https://treeherder.mozilla.org/jobs?repo=try&revision=coconut"
+                      target="_blank"
+                      title="open treeherder view for coconut"
+                    >
+                      coconut
+                    </a>
+                  </span>
+                  <div
+                    class="info-caption"
+                  >
+                    <div
+                      class="info-caption-item item-author"
+                    >
+                       
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
+                        data-testid="MailOutlineOutlinedIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
+                        />
+                      </svg>
+                       
+                      johncleese@python.com
+                    </div>
+                    <div
+                      class="info-caption-item item-time"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall time-icon css-1mecf1h-MuiSvgIcon-root"
+                        data-testid="AccessTimeOutlinedIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"
+                        />
+                      </svg>
+                      03/29/51 00:00
+                    </div>
+                  </div>
+                </span>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-163o6oo-MuiTypography-root"
+                >
+                  you've got no arms left! 
+                </p>
+              </div>
+              <button
+                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium icon-close-hidden revision-action close-button css-13h131f-MuiButtonBase-root-MuiButton-root"
+                name="close-button"
+                tabindex="0"
+                title="remove revision"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-1mecf1h-MuiSvgIcon-root"
+                  data-testid="close-icon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"
+                  />
+                </svg>
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div
+    class="MuiGrid-root component_f14z0jsa css-plh9qo-MuiGrid-root"
+  >
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag label-edit-wrapper css-13eijkh-MuiGrid-root"
+    >
+      <label
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
+        id="repo-dropdown--new"
+      >
+        Revisions
+        <svg
+          aria-hidden="true"
+          aria-label="Revisions (typically including your changes) to compare against the selected base revision."
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+          data-mui-internal-clone-element="true"
+          data-testid="InfoOutlinedIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+          />
+        </svg>
+      </label>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-container container_f1psuwcf show-container  css-1ljzhs0-MuiGrid-root"
+      id="new-search-container"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fl6uoag small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        id="new_search-dropdown"
+      >
+        <div
+          class="MuiFormControl-root search-dropdown f1o9jg5h css-1nrlq1o-MuiFormControl-root"
+        >
+          <div
+            class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall dropdown-select css-1nwv3h7-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+            data-testid="dropdown-select-repo-dropdown--new"
+          >
+            <div
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-labelledby="repo-dropdown--new"
+              class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input MuiInputBase-inputSizeSmall css-v8lh20-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+              role="button"
+              tabindex="0"
+            >
+              mozilla-central
+            </div>
+            <input
+              aria-hidden="true"
+              class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+              tabindex="-1"
+              value="mozilla-central"
+            />
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-ll500r-MuiSvgIcon-root-MuiSelect-icon"
+              data-testid="ArrowDropDownIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7 10l5 5 5-5z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_fctyy2s big  css-17gmabg-MuiGrid-root"
+        id="new_search-input"
+      >
+        <div
+          class="MuiBox-root css-0"
+        >
+          <div
+            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+          >
+            <div
+              class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+            >
+              <div
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart css-193b4t-MuiInputBase-root-MuiOutlinedInput-root"
+              >
+                <div
+                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1laqsz7-MuiInputAdornment-root"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                    data-testid="SearchIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                    />
+                  </svg>
+                </div>
+                <input
+                  aria-invalid="false"
+                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart css-jrmsot-MuiInputBase-input-MuiOutlinedInput-input"
+                  id="search-new-input"
+                  placeholder="Search revision by ID number or author email"
+                  type="text"
+                  value=""
+                />
+                <fieldset
+                  aria-hidden="true"
+                  class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+                >
+                  <legend
+                    class="css-ihdtdm"
+                  >
+                    <span
+                      class="notranslate"
+                    >
+                      ​
+                    </span>
+                  </legend>
+                </fieldset>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="cancel-save-btns"
+        id="cancel-save_btns"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium cancel-save cancel-button f9oipqi cancel-button-new css-2uznlz-MuiButtonBase-root-MuiButton-root"
+          name="cancel-button"
+          tabindex="0"
+          type="button"
+        >
+          Cancel
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium cancel-save save-button save-button-new 
+        } css-2uznlz-MuiButtonBase-root-MuiButton-root"
+          name="save-button"
+          tabindex="0"
+          type="button"
+        >
+          Save
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
+      data-testid="new-selected-revision"
+    >
+      <div
+        class="box_f65ycfw new-box MuiBox-root css-0"
+      >
+        <ul
+          class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
+        >
+          <li
+            class="MuiListItem-root MuiListItem-gutters MuiListItem-padding item-container item-0 item-new css-vtiz8x-MuiListItem-root"
+            data-testid="selected-rev-item"
+          >
+            <input
+              name="newRev"
+              type="hidden"
+              value="coconut"
+            />
+            <input
+              name="newRepo"
+              type="hidden"
+              value="try"
+            />
+            <div
+              class="repo_f1bx8by5"
+            >
+              <div>
+                try
+              </div>
+              <div
+                class="warning-icon"
+              >
+                <svg
+                  aria-label="Comparing “try” repository to any repository aside from “try” is not recommended."
+                  class="MuiSvgIcon-root MuiSvgIcon-colorWarning MuiSvgIcon-fontSizeSmall css-1jwhf5x-MuiSvgIcon-root"
+                  data-mui-internal-clone-element="true"
+                  data-testid="WarningIcon"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
+                  />
+                  <title>
+                    Comparing “try” repository to any repository aside from “try” is not recommended.
+                  </title>
+                </svg>
+              </div>
+            </div>
+            <div
+              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters listItemButton_f5s7lzh css-1g1bko9-MuiButtonBase-root-MuiListItemButton-root"
+              role="button"
+              tabindex="0"
+            >
+              <div
+                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
+              >
+                <span
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-hrbm3k-MuiTypography-root"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
+                      href="https://treeherder.mozilla.org/jobs?repo=try&revision=coconut"
+                      target="_blank"
+                      title="open treeherder view for coconut"
+                    >
+                      coconut
+                    </a>
+                  </span>
+                  <div
+                    class="info-caption"
+                  >
+                    <div
+                      class="info-caption-item item-author"
+                    >
+                       
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
+                        data-testid="MailOutlineOutlinedIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
+                        />
+                      </svg>
+                       
+                      johncleese@python.com
+                    </div>
+                    <div
+                      class="info-caption-item item-time"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall time-icon css-1mecf1h-MuiSvgIcon-root"
+                        data-testid="AccessTimeOutlinedIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"
+                        />
+                      </svg>
+                      03/29/51 00:00
+                    </div>
+                  </div>
+                </span>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-163o6oo-MuiTypography-root"
+                >
+                  you've got no arms left! 
+                </p>
+              </div>
+              <button
+                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium icon-close-show revision-action close-button css-13h131f-MuiButtonBase-root-MuiButton-root"
+                name="close-button"
+                tabindex="0"
+                title="remove revision"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-1mecf1h-MuiSvgIcon-root"
+                  data-testid="close-icon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"
+                  />
+                </svg>
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fl6uoag fjuaqdk css-13eijkh-MuiGrid-root"
+  >
+    <div
+      class="MuiFormControl-root framework-dropdown f1pm9d4y css-1nrlq1o-MuiFormControl-root"
+    >
+      <label
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined dropdown-select-label css-11mbixr-MuiFormLabel-root-MuiInputLabel-root"
+        data-shrink="true"
+        id="select-framework-label"
+      >
+        Framework
+        <svg
+          aria-hidden="true"
+          aria-label="The framework or test harness containing the test you want to examine."
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+          data-mui-internal-clone-element="true"
+          data-testid="InfoOutlinedIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+          />
+        </svg>
+      </label>
+      <div
+        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl dropdown-select css-1nwv3h7-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+        data-testid="dropdown-select-framework"
+      >
+        <div
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-labelledby="select-framework-label mui-component-select-framework"
+          class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-edng3m-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+          id="mui-component-select-framework"
+          role="button"
+          tabindex="0"
+        >
+          build_metrics
+        </div>
+        <input
+          aria-hidden="true"
+          class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+          name="framework"
+          tabindex="-1"
+          value="2"
+        />
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-ll500r-MuiSvgIcon-root-MuiSelect-icon"
+          data-testid="ArrowDropDownIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M7 10l5 5 5-5z"
+          />
+        </svg>
+      </div>
+    </div>
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium compare-button fr4s9wi css-1rgi3bk-MuiButtonBase-root-MuiButton-root"
+      id="compare-button"
+      tabindex="0"
+      type="submit"
+    >
+      Compare
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</form>
 `;

--- a/src/__tests__/Search/__snapshots__/SearchContainer.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchContainer.test.tsx.snap
@@ -182,6 +182,7 @@ exports[`Search Containter should match snapshot 1`] = `
               </div>
               <div
                 class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
+                data-testid="base-selected-revision"
               >
                 <div
                   class="box_f65ycfw base-box MuiBox-root css-0"
@@ -324,6 +325,7 @@ exports[`Search Containter should match snapshot 1`] = `
               </div>
               <div
                 class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
+                data-testid="new-selected-revision"
               >
                 <div
                   class="box_f65ycfw new-box MuiBox-root css-0"

--- a/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
@@ -746,6 +746,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                 </div>
                 <div
                   class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
+                  data-testid="base-selected-revision"
                 >
                   <div
                     class="box_f65ycfw base-box MuiBox-root css-0"
@@ -888,6 +889,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                 </div>
                 <div
                   class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
+                  data-testid="new-selected-revision"
                 >
                   <div
                     class="box_f65ycfw new-box MuiBox-root css-0"

--- a/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
@@ -261,6 +261,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                 </div>
                 <div
                   class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
+                  data-testid="base-selected-revision"
                 >
                   <div
                     class="box_f65ycfw base-box MuiBox-root css-0"
@@ -403,6 +404,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                 </div>
                 <div
                   class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
+                  data-testid="new-selected-revision"
                 >
                   <div
                     class="box_f65ycfw new-box MuiBox-root css-0"

--- a/src/components/CompareResults/ResultsView.tsx
+++ b/src/components/CompareResults/ResultsView.tsx
@@ -16,9 +16,10 @@ interface ResultsViewProps {
   title: string;
 }
 function ResultsView(props: ResultsViewProps) {
-  const { baseRevInfo, newRevsInfo, frameworkId, results } =
+  const { baseRevInfo, newRevsInfo, frameworkId, results, baseRepo, newRepos } =
     useLoaderData() as LoaderReturnValue;
 
+  const newRepo = newRepos[0];
   const { title } = props;
   const themeMode = useAppSelector((state) => state.theme.mode);
   const styles = {
@@ -49,6 +50,8 @@ function ResultsView(props: ResultsViewProps) {
           frameworkIdVal={frameworkId}
           isBaseSearch={null}
           expandBaseComponent={() => null}
+          baseRepo={baseRepo}
+          newRepo={newRepo}
         />
       </section>
       <Grid container alignItems='center' justifyContent='center'>

--- a/src/components/CompareResults/loader.ts
+++ b/src/components/CompareResults/loader.ts
@@ -65,7 +65,6 @@ function checkValues({
       `The parameter framework isn't a valid value: "${framework}".`,
     );
   }
-
   if (!newRevs.length) {
     return {
       baseRev,

--- a/src/components/Search/CompareWithBase.tsx
+++ b/src/components/Search/CompareWithBase.tsx
@@ -24,6 +24,8 @@ interface CompareWithBaseProps {
   hasNonEditableState: boolean;
   baseRev: Changeset | null;
   newRevs: Changeset[];
+  baseRepo: Repository['name'];
+  newRepo: Repository['name'];
   frameworkIdVal: Framework['id'];
   isBaseSearch: null | boolean;
   expandBaseComponent: (expanded: boolean) => void | null;
@@ -72,6 +74,8 @@ function CompareWithBase({
   isBaseSearch,
   expandBaseComponent,
   frameworkIdVal,
+  baseRepo,
+  newRepo,
 }: CompareWithBaseProps) {
   const { enqueueSnackbar } = useSnackbar();
   const [frameWorkId, setframeWorkValue] = useState(frameworkIdVal);
@@ -93,12 +97,8 @@ function CompareWithBase({
   );
   const [newInProgressRevs, setInProgressNewRevs] =
     useState<Changeset[]>(newRevs);
-  const [baseRepository, setBaseRepository] = useState(
-    'try' as Repository['name'],
-  );
-  const [newRepository, setNewRepository] = useState(
-    'try' as Repository['name'],
-  );
+  const [baseRepository, setBaseRepository] = useState(baseRepo);
+  const [newRepository, setNewRepository] = useState(newRepo);
 
   const mode = useAppSelector((state) => state.theme.mode);
 

--- a/src/components/Search/SearchComponent.tsx
+++ b/src/components/Search/SearchComponent.tsx
@@ -173,7 +173,7 @@ function SearchComponent({
       {displayedRevisions && (
         <Grid
           className='d-flex'
-          data-testid={`${isBaseComp ? 'base' : 'new'}-selected-revision`}
+          data-testid={`${searchType}-selected-revision`}
         >
           <SelectedRevisions
             isBase={isBaseComp}

--- a/src/components/Search/SearchComponent.tsx
+++ b/src/components/Search/SearchComponent.tsx
@@ -171,7 +171,10 @@ function SearchComponent({
       </Grid>
       {/***** Selected Revisions Section *****/}
       {displayedRevisions && (
-        <Grid className='d-flex'>
+        <Grid
+          className='d-flex'
+          data-testid={`${isBaseComp ? 'base' : 'new'}-selected-revision`}
+        >
           <SelectedRevisions
             isBase={isBaseComp}
             canRemoveRevision={!hasNonEditableState || formIsDisplayed}

--- a/src/components/Search/SearchContainer.tsx
+++ b/src/components/Search/SearchContainer.tsx
@@ -32,6 +32,8 @@ function SearchContainer(props: SearchViewProps) {
         newRevs={[]}
         isBaseSearch={isBaseSearch}
         expandBaseComponent={expandBaseComponent}
+        baseRepo='try'
+        newRepo='try'
       />
       <CompareOverTime
         hasNonEditableState={false}


### PR DESCRIPTION
In the same way that we pass down the rev information for the selected revs in the results list, it makes sense to pass down the repo info so the repo drop-down is already set to the committed repo in the Results view edit section