### PR TITLE
reset view post submit

### DIFF
--- a/src/components/Search/CompareWithBase.tsx
+++ b/src/components/Search/CompareWithBase.tsx
@@ -104,9 +104,11 @@ function CompareWithBase({
     (baseRepository === 'try' && newRepository !== 'try') ||
     (baseRepository !== 'try' && newRepository === 'try');
 
-  const possiblyPreventFormSubmission = (e: React.FormEvent) => {
+  const onFormSubmit = (e: React.FormEvent) => {
     const isFormReadyToBeSubmitted = baseInProgressRev !== null;
+    setFormIsDisplayed(false);
     if (!isFormReadyToBeSubmitted) {
+      setFormIsDisplayed(true);
       e.preventDefault();
       enqueueSnackbar(strings.base.collapsed.errors.notEnoughRevisions, {
         variant: 'error',
@@ -257,7 +259,7 @@ function CompareWithBase({
         <Form
           action='/compare-results'
           className='form-wrapper'
-          onSubmit={possiblyPreventFormSubmission}
+          onSubmit={onFormSubmit}
           aria-label='Compare with base form'
         >
           {/**** Edit Button ****/}

--- a/src/components/Search/CompareWithBase.tsx
+++ b/src/components/Search/CompareWithBase.tsx
@@ -106,9 +106,8 @@ function CompareWithBase({
 
   const onFormSubmit = (e: React.FormEvent) => {
     const isFormReadyToBeSubmitted = baseInProgressRev !== null;
-    setFormIsDisplayed(false);
+    setFormIsDisplayed(!isFormReadyToBeSubmitted);
     if (!isFormReadyToBeSubmitted) {
-      setFormIsDisplayed(true);
       e.preventDefault();
       enqueueSnackbar(strings.base.collapsed.errors.notEnoughRevisions, {
         variant: 'error',


### PR DESCRIPTION
This PR sets the view back to read-only post click of the Compare button in the Results View edit mode. Closes https://mozilla-hub.atlassian.net/browse/PCF-443