### PR TITLE
Properly debounce the search function, and increment the ID

### DIFF
--- a/src/components/Search/SearchInputAndResults.tsx
+++ b/src/components/Search/SearchInputAndResults.tsx
@@ -58,11 +58,11 @@ export default function SearchInputAndResults({
     [displayDropdown],
   );
 
-  const handleEscKeypress = (e: KeyboardEvent) => {
+  const handleEscKeypress = useCallback((e: KeyboardEvent) => {
     if (e.key === 'Escape') {
       setDisplayDropdown(false);
     }
-  };
+  }, []);
 
   const searchRecentRevisions = useCallback(
     async (searchTerm: string) => {
@@ -156,7 +156,7 @@ export default function SearchInputAndResults({
     return () => {
       document.removeEventListener('keydown', handleEscKeypress);
     };
-  }, []);
+  }, [handleEscKeypress]);
 
   return (
     <Box ref={containerRef}>


### PR DESCRIPTION
There was 2 issues:
1. The search function and its debounce version were being recreated at
   each render. As a result it wasn't debounced and a new request was
   being sent for each keystroke, albeit after half a second.
2. The ID used to know if the received response is for latest search
   wasn't incremented at the right place. As a result some reponses
   weren't ignored where they should have been.

This first commit fixes both issues, by using useCallback and incrementing the search id in the right place.

The second commit is a small correctness issue where `handleEscKeypress` wasn't memoized. I think it wasn't doing any problem but it's more consistent with the other function `handleDocumentMousedown`.

Finally the 3rd commit fixes a bunch of issues with the existing test for the SearchView. The biggest issue (IMO) is that the mock was always returning all the data, because it wasn't configured in the correct order. I thought the library would order it by specificity but it's not doing it.