### PR TITLE
Filter columns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "@swc/jest": "^0.2.21",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
-        "@testing-library/user-event": "^14.2.1",
+        "@testing-library/user-event": "^14.5.2",
         "@types/jest": "^28.1.4",
         "@types/jest-axe": "^3.5.4",
         "@types/material-ui": "^0.21.12",
@@ -4579,9 +4579,9 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.3.0.tgz",
-      "integrity": "sha512-P02xtBBa8yMaLhK8CzJCIns8rqwnF6FxhR9zs810flHOBXUYCFjLd8Io1rQrAkQRWEmW2PGdZIEdMxf/KLsqFA==",
+      "version": "14.5.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
       "dev": true,
       "engines": {
         "node": ">=12",
@@ -20447,9 +20447,9 @@
       }
     },
     "@testing-library/user-event": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.3.0.tgz",
-      "integrity": "sha512-P02xtBBa8yMaLhK8CzJCIns8rqwnF6FxhR9zs810flHOBXUYCFjLd8Io1rQrAkQRWEmW2PGdZIEdMxf/KLsqFA==",
+      "version": "14.5.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
       "dev": true,
       "requires": {}
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "express": "^4.19.2",
         "fast-kde": "^0.2.1",
         "format": "^0.2.2",
+        "material-ui-popup-state": "^5.1.2",
         "notistack": "^2.0.5",
         "react": "^18.2.0",
         "react-chartjs-2": "^5.2.0",
@@ -4915,12 +4916,11 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.0.15",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.15.tgz",
-      "integrity": "sha512-iz3BtLuIYH1uWdsv6wXYdhozhqj20oD4/Hk2DNXIn1kFsmp9x8d9QB6FnPhfkbhd2PgEONt9Q1x/ebkwjfFLow==",
+      "version": "18.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
+      "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
       "dependencies": {
         "@types/prop-types": "*",
-        "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
     },
@@ -4962,11 +4962,6 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "node_modules/@types/semver": {
       "version": "7.5.6",
@@ -6430,6 +6425,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "node_modules/clean-css": {
       "version": "5.3.1",
@@ -13174,6 +13174,25 @@
       "dev": true,
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/material-ui-popup-state": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/material-ui-popup-state/-/material-ui-popup-state-5.1.2.tgz",
+      "integrity": "sha512-+MPpydg2a/NqSbF4vNKbsHeEktiH6j0OPtNud0ZbhElKRc915XdyNH3Z7N+lL/l1erHcsCHB85izHC+zc6GgmQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.6",
+        "@types/prop-types": "^15.7.3",
+        "@types/react": "^18.0.26",
+        "classnames": "^2.2.6",
+        "prop-types": "^15.7.2"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/media-typer": {
@@ -20774,12 +20793,11 @@
       "dev": true
     },
     "@types/react": {
-      "version": "18.0.15",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.15.tgz",
-      "integrity": "sha512-iz3BtLuIYH1uWdsv6wXYdhozhqj20oD4/Hk2DNXIn1kFsmp9x8d9QB6FnPhfkbhd2PgEONt9Q1x/ebkwjfFLow==",
+      "version": "18.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
+      "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
       "requires": {
         "@types/prop-types": "*",
-        "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
     },
@@ -20821,11 +20839,6 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
-    },
-    "@types/scheduler": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "@types/semver": {
       "version": "7.5.6",
@@ -21928,6 +21941,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
+    },
+    "classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "clean-css": {
       "version": "5.3.1",
@@ -26853,6 +26871,18 @@
       "dev": true,
       "requires": {
         "tmpl": "1.0.5"
+      }
+    },
+    "material-ui-popup-state": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/material-ui-popup-state/-/material-ui-popup-state-5.1.2.tgz",
+      "integrity": "sha512-+MPpydg2a/NqSbF4vNKbsHeEktiH6j0OPtNud0ZbhElKRc915XdyNH3Z7N+lL/l1erHcsCHB85izHC+zc6GgmQ==",
+      "requires": {
+        "@babel/runtime": "^7.20.6",
+        "@types/prop-types": "^15.7.3",
+        "@types/react": "^18.0.26",
+        "classnames": "^2.2.6",
+        "prop-types": "^15.7.2"
       }
     },
     "media-typer": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@swc/jest": "^0.2.21",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
-    "@testing-library/user-event": "^14.2.1",
+    "@testing-library/user-event": "^14.5.2",
     "@types/jest": "^28.1.4",
     "@types/jest-axe": "^3.5.4",
     "@types/material-ui": "^0.21.12",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "express": "^4.19.2",
     "fast-kde": "^0.2.1",
     "format": "^0.2.2",
+    "material-ui-popup-state": "^5.1.2",
     "notistack": "^2.0.5",
     "react": "^18.2.0",
     "react-chartjs-2": "^5.2.0",

--- a/src/__tests__/CompareResults/ResultsTable.test.tsx
+++ b/src/__tests__/CompareResults/ResultsTable.test.tsx
@@ -1,11 +1,15 @@
 import type { ReactElement } from 'react';
 
+import userEvent, { type UserEvent } from '@testing-library/user-event';
+
 import { loader } from '../../components/CompareResults/loader';
 import ResultsTable from '../../components/CompareResults/ResultsTable';
+import type { CompareResultsItem } from '../../types/state';
 import getTestData from '../utils/fixtures';
 import {
   renderWithRouter,
   screen,
+  within,
   FetchMockSandbox,
 } from '../utils/test-utils';
 
@@ -17,39 +21,242 @@ function renderWithRoute(component: ReactElement) {
   });
 }
 
+function setupAndRender(testCompareData: CompareResultsItem[]) {
+  (window.fetch as FetchMockSandbox)
+    .get(
+      'begin:https://treeherder.mozilla.org/api/perfcompare/results/',
+      testCompareData,
+    )
+    .get('begin:https://treeherder.mozilla.org/api/project/', {
+      results: [],
+    });
+  renderWithRoute(
+    <ResultsTable results={[testCompareData]} filteringSearchTerm='' />,
+  );
+}
+
 describe('Results Table', () => {
   it('Should match snapshot', async () => {
     const { testCompareData } = getTestData();
+
     const compareDataToChange = testCompareData.at(-1)!;
     Object.assign(compareDataToChange, {
       extra_options: '',
       header_name: `${compareDataToChange.suite} ${compareDataToChange.test} ${compareDataToChange.option_name}`,
     });
 
-    (window.fetch as FetchMockSandbox)
-      .get(
-        'begin:https://treeherder.mozilla.org/api/perfcompare/results/',
-        testCompareData,
-      )
-      .get('begin:https://treeherder.mozilla.org/api/project/', {
-        results: [],
-      });
-    renderWithRoute(
-      <ResultsTable results={[testCompareData]} filteringSearchTerm='' />,
-    );
+    setupAndRender(testCompareData);
 
-    expect(await screen.findByTestId('results-table')).toBeInTheDocument();
+    expect(await screen.findByRole('table')).toBeInTheDocument();
     expect(document.body).toMatchSnapshot();
   });
 
   it('Display message for not finding results', async () => {
-    (window.fetch as FetchMockSandbox)
-      .get('begin:https://treeherder.mozilla.org/api/perfcompare/results/', [])
-      .get('begin:https://treeherder.mozilla.org/api/project/', {
-        results: [],
-      });
-    renderWithRoute(<ResultsTable results={[]} filteringSearchTerm='' />);
-
+    setupAndRender([]);
     expect(await screen.findByText(/No results found/)).toBeInTheDocument();
+  });
+
+  // This handy function parses the results page and returns an array of visible
+  // rows. It makes it easy to assert visible rows when filtering them in a
+  // user-friendly way without using snapshots.
+  function summarizeVisibleRows() {
+    const rowGroups = screen.getAllByRole('rowgroup');
+    const result = [];
+
+    for (const group of rowGroups) {
+      const titleElement = group.firstElementChild!.firstElementChild!;
+      const optionsElements = Array.from(
+        titleElement.nextElementSibling!.children,
+      );
+      const title = [
+        titleElement.textContent,
+        ...optionsElements.map((element) => element.textContent),
+      ].join(' ');
+      result.push(title);
+      const rows = within(group).getAllByRole('row');
+      for (const row of rows) {
+        const rowString = ['.platform span', '.status', '.confidence']
+          .map((selector) => row.querySelector(selector)!.textContent!.trim())
+          .join(', ');
+
+        result.push('  - ' + rowString);
+      }
+    }
+
+    return result;
+  }
+
+  async function clickMenuItem(
+    user: UserEvent,
+    menuMatcher: string | RegExp,
+    itemMatcher: string | RegExp,
+  ) {
+    const platformColumnButton = screen.getByRole('button', {
+      name: menuMatcher,
+    });
+    await user.click(platformColumnButton);
+
+    const menu = screen.getByRole('menu');
+    let menuItem = within(menu).queryByRole('menuitemcheckbox', {
+      name: itemMatcher,
+    });
+    if (!menuItem) {
+      menuItem = within(menu).getByRole('menuitem', {
+        name: itemMatcher,
+      });
+    }
+    await user.click(menuItem);
+    await user.keyboard('[Escape]');
+  }
+
+  it('should filter on the Platform column', async () => {
+    const { testCompareData } = getTestData();
+    testCompareData.push({
+      ...testCompareData[0],
+      platform: 'android-em-7-0-x86_64-lite-qr',
+    });
+    setupAndRender(testCompareData);
+
+    await screen.findByText('a11yr');
+    expect(summarizeVisibleRows()).toEqual([
+      'a11yr dhtml.html spam opt e10s fission stylo webrender',
+      '  - OSX, Improvement, Low',
+      '  - Linux, Regression, Medium',
+      '  - Windows, -, High',
+      '  - Windows, -, ',
+      '  - Android, Improvement, Low',
+    ]);
+
+    const user = userEvent.setup({ delay: null });
+    await clickMenuItem(user, /Platform/, /Windows/);
+    expect(summarizeVisibleRows()).toEqual([
+      'a11yr dhtml.html spam opt e10s fission stylo webrender',
+      '  - OSX, Improvement, Low',
+      '  - Linux, Regression, Medium',
+      '  - Android, Improvement, Low',
+    ]);
+
+    await clickMenuItem(user, /Platform/, /Linux/);
+    expect(summarizeVisibleRows()).toEqual([
+      'a11yr dhtml.html spam opt e10s fission stylo webrender',
+      '  - OSX, Improvement, Low',
+      '  - Android, Improvement, Low',
+    ]);
+    await clickMenuItem(user, /Platform/, /Linux/);
+    expect(summarizeVisibleRows()).toEqual([
+      'a11yr dhtml.html spam opt e10s fission stylo webrender',
+      '  - OSX, Improvement, Low',
+      '  - Linux, Regression, Medium',
+      '  - Android, Improvement, Low',
+    ]);
+
+    await clickMenuItem(user, /Platform/, 'Clear filters');
+    expect(summarizeVisibleRows()).toEqual([
+      'a11yr dhtml.html spam opt e10s fission stylo webrender',
+      '  - OSX, Improvement, Low',
+      '  - Linux, Regression, Medium',
+      '  - Windows, -, High',
+      '  - Windows, -, ',
+      '  - Android, Improvement, Low',
+    ]);
+
+    await clickMenuItem(user, /Platform/, /OSX/);
+    expect(summarizeVisibleRows()).toEqual([
+      'a11yr dhtml.html spam opt e10s fission stylo webrender',
+      '  - Linux, Regression, Medium',
+      '  - Windows, -, High',
+      '  - Windows, -, ',
+      '  - Android, Improvement, Low',
+    ]);
+
+    await clickMenuItem(user, /Platform/, /Android/);
+    expect(summarizeVisibleRows()).toEqual([
+      'a11yr dhtml.html spam opt e10s fission stylo webrender',
+      '  - Linux, Regression, Medium',
+      '  - Windows, -, High',
+      '  - Windows, -, ',
+    ]);
+  });
+
+  it('should filter on the Status column', async () => {
+    const { testCompareData } = getTestData();
+    setupAndRender(testCompareData);
+
+    await screen.findByText('a11yr');
+    expect(summarizeVisibleRows()).toEqual([
+      'a11yr dhtml.html spam opt e10s fission stylo webrender',
+      '  - OSX, Improvement, Low',
+      '  - Linux, Regression, Medium',
+      '  - Windows, -, High',
+      '  - Windows, -, ',
+    ]);
+
+    const user = userEvent.setup({ delay: null });
+    await clickMenuItem(user, /Status/, /No changes/);
+    expect(summarizeVisibleRows()).toEqual([
+      'a11yr dhtml.html spam opt e10s fission stylo webrender',
+      '  - OSX, Improvement, Low',
+      '  - Linux, Regression, Medium',
+    ]);
+
+    await clickMenuItem(user, /Status/, /Clear filters/);
+    await clickMenuItem(user, /Status/, /Improvement/);
+    expect(summarizeVisibleRows()).toEqual([
+      'a11yr dhtml.html spam opt e10s fission stylo webrender',
+      '  - Linux, Regression, Medium',
+      '  - Windows, -, High',
+      '  - Windows, -, ',
+    ]);
+    await clickMenuItem(user, /Status/, /Regression/);
+    expect(summarizeVisibleRows()).toEqual([
+      'a11yr dhtml.html spam opt e10s fission stylo webrender',
+      '  - Windows, -, High',
+      '  - Windows, -, ',
+    ]);
+  });
+
+  it('should filter on the Confidence column', async () => {
+    const { testCompareData } = getTestData();
+    setupAndRender(testCompareData);
+
+    await screen.findByText('a11yr');
+    expect(summarizeVisibleRows()).toEqual([
+      'a11yr dhtml.html spam opt e10s fission stylo webrender',
+      '  - OSX, Improvement, Low',
+      '  - Linux, Regression, Medium',
+      '  - Windows, -, High',
+      '  - Windows, -, ',
+    ]);
+
+    const user = userEvent.setup({ delay: null });
+    await clickMenuItem(user, /Confidence/, /Low/);
+    expect(summarizeVisibleRows()).toEqual([
+      'a11yr dhtml.html spam opt e10s fission stylo webrender',
+      '  - Linux, Regression, Medium',
+      '  - Windows, -, High',
+      '  - Windows, -, ',
+    ]);
+
+    await clickMenuItem(user, /Confidence/, /High/);
+    expect(summarizeVisibleRows()).toEqual([
+      'a11yr dhtml.html spam opt e10s fission stylo webrender',
+      '  - Linux, Regression, Medium',
+      '  - Windows, -, ',
+    ]);
+
+    await clickMenuItem(user, /Confidence/, /Medium/);
+    expect(summarizeVisibleRows()).toEqual([
+      'a11yr dhtml.html spam opt e10s fission stylo webrender',
+      '  - Windows, -, ',
+    ]);
+
+    await clickMenuItem(user, /Confidence/, /Clear filters/);
+    expect(summarizeVisibleRows()).toEqual([
+      'a11yr dhtml.html spam opt e10s fission stylo webrender',
+      '  - OSX, Improvement, Low',
+      '  - Linux, Regression, Medium',
+      '  - Windows, -, High',
+      '  - Windows, -, ',
+    ]);
   });
 });

--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -12,165 +12,134 @@ exports[`Results View The table should match snapshot and other elements should 
     role="row"
   >
     <div
-      class="cell platform-header fcno249"
+      class="cell platform-header"
       role="columnheader"
     >
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-        data-testid="SortIcon"
-        focusable="false"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M3 18h6v-2H3v2zM3 6v2h18V6H3zm0 7h12v-2H3v2z"
-        />
-      </svg>
-      <div
-        role="cell"
+      <button
+        aria-haspopup="true"
+        aria-label="Platform (Click to filter values)"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-12n6w6k-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="button"
       >
         Platform
-      </div>
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-        data-testid="ExpandMoreIcon"
-        focusable="false"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+        <svg
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-reqpbo-MuiSvgIcon-root"
+          data-testid="FilterListIcon"
+          focusable="false"
+          role="img"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+          />
+          <title>
+            No active filters
+          </title>
+        </svg>
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
         />
-      </svg>
+      </button>
     </div>
     <div
-      class="cell base-header "
+      class="cell base-header"
       role="columnheader"
     >
-      <div
-        role="cell"
-      >
-        Base
-      </div>
+      Base
     </div>
     <div
-      class="cell comparisonSign-header "
+      class="cell comparisonSign-header"
+      role="columnheader"
+    />
+    <div
+      class="cell new-header"
       role="columnheader"
     >
-      <div
-        role="cell"
-      />
+      New
     </div>
     <div
-      class="cell new-header "
+      class="cell status-header"
       role="columnheader"
     >
-      <div
-        role="cell"
-      >
-        New
-      </div>
-    </div>
-    <div
-      class="cell status-header fcno249"
-      role="columnheader"
-    >
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-        data-testid="SortIcon"
-        focusable="false"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M3 18h6v-2H3v2zM3 6v2h18V6H3zm0 7h12v-2H3v2z"
-        />
-      </svg>
-      <div
-        role="cell"
+      <button
+        aria-haspopup="true"
+        aria-label="Status (Click to filter values)"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-12n6w6k-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="button"
       >
         Status
-      </div>
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-        data-testid="ExpandMoreIcon"
-        focusable="false"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+        <svg
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-reqpbo-MuiSvgIcon-root"
+          data-testid="FilterListIcon"
+          focusable="false"
+          role="img"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+          />
+          <title>
+            No active filters
+          </title>
+        </svg>
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
         />
-      </svg>
+      </button>
     </div>
     <div
-      class="cell delta-header "
+      class="cell delta-header"
       role="columnheader"
     >
-      <div
-        role="cell"
-      >
-        Delta(%)
-      </div>
+      Delta(%)
     </div>
     <div
-      class="cell confidence-header fcno249"
+      class="cell confidence-header"
       role="columnheader"
     >
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-        data-testid="SortIcon"
-        focusable="false"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M3 18h6v-2H3v2zM3 6v2h18V6H3zm0 7h12v-2H3v2z"
-        />
-      </svg>
-      <div
-        role="cell"
+      <button
+        aria-haspopup="true"
+        aria-label="Confidence (Click to filter values)"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-12n6w6k-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="button"
       >
         Confidence
-      </div>
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-        data-testid="ExpandMoreIcon"
-        focusable="false"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+        <svg
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-reqpbo-MuiSvgIcon-root"
+          data-testid="FilterListIcon"
+          focusable="false"
+          role="img"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+          />
+          <title>
+            No active filters
+          </title>
+        </svg>
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
         />
-      </svg>
+      </button>
     </div>
     <div
-      class="cell runs-header "
+      class="cell runs-header"
       role="columnheader"
     >
-      <div
-        role="cell"
-      >
-        Total Runs
-      </div>
+      Total Runs
     </div>
     <div
-      class="cell buttons-header "
+      class="cell buttons-header"
       role="columnheader"
-    >
-      <div
-        role="cell"
-      />
-    </div>
+    />
     <div
-      class="cell expand-header "
+      class="cell expand-header"
       role="columnheader"
-    >
-      <div
-        role="cell"
-      />
-    </div>
+    />
   </div>
   <div
     class="f1otqxop"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -14,165 +14,134 @@ exports[`Results Table Should match snapshot 1`] = `
         role="row"
       >
         <div
-          class="cell platform-header fcno249"
+          class="cell platform-header"
           role="columnheader"
         >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-            data-testid="SortIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M3 18h6v-2H3v2zM3 6v2h18V6H3zm0 7h12v-2H3v2z"
-            />
-          </svg>
-          <div
-            role="cell"
+          <button
+            aria-haspopup="true"
+            aria-label="Platform (Click to filter values)"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-12n6w6k-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
           >
             Platform
-          </div>
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-            data-testid="ExpandMoreIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+            <svg
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-reqpbo-MuiSvgIcon-root"
+              data-testid="FilterListIcon"
+              focusable="false"
+              role="img"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+              />
+              <title>
+                No active filters
+              </title>
+            </svg>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
             />
-          </svg>
+          </button>
         </div>
         <div
-          class="cell base-header "
+          class="cell base-header"
           role="columnheader"
         >
-          <div
-            role="cell"
-          >
-            Base
-          </div>
+          Base
         </div>
         <div
-          class="cell comparisonSign-header "
+          class="cell comparisonSign-header"
+          role="columnheader"
+        />
+        <div
+          class="cell new-header"
           role="columnheader"
         >
-          <div
-            role="cell"
-          />
+          New
         </div>
         <div
-          class="cell new-header "
+          class="cell status-header"
           role="columnheader"
         >
-          <div
-            role="cell"
-          >
-            New
-          </div>
-        </div>
-        <div
-          class="cell status-header fcno249"
-          role="columnheader"
-        >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-            data-testid="SortIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M3 18h6v-2H3v2zM3 6v2h18V6H3zm0 7h12v-2H3v2z"
-            />
-          </svg>
-          <div
-            role="cell"
+          <button
+            aria-haspopup="true"
+            aria-label="Status (Click to filter values)"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-12n6w6k-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
           >
             Status
-          </div>
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-            data-testid="ExpandMoreIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+            <svg
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-reqpbo-MuiSvgIcon-root"
+              data-testid="FilterListIcon"
+              focusable="false"
+              role="img"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+              />
+              <title>
+                No active filters
+              </title>
+            </svg>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
             />
-          </svg>
+          </button>
         </div>
         <div
-          class="cell delta-header "
+          class="cell delta-header"
           role="columnheader"
         >
-          <div
-            role="cell"
-          >
-            Delta(%)
-          </div>
+          Delta(%)
         </div>
         <div
-          class="cell confidence-header fcno249"
+          class="cell confidence-header"
           role="columnheader"
         >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-            data-testid="SortIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M3 18h6v-2H3v2zM3 6v2h18V6H3zm0 7h12v-2H3v2z"
-            />
-          </svg>
-          <div
-            role="cell"
+          <button
+            aria-haspopup="true"
+            aria-label="Confidence (Click to filter values)"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-12n6w6k-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
           >
             Confidence
-          </div>
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-            data-testid="ExpandMoreIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+            <svg
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-reqpbo-MuiSvgIcon-root"
+              data-testid="FilterListIcon"
+              focusable="false"
+              role="img"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+              />
+              <title>
+                No active filters
+              </title>
+            </svg>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
             />
-          </svg>
+          </button>
         </div>
         <div
-          class="cell runs-header "
+          class="cell runs-header"
           role="columnheader"
         >
-          <div
-            role="cell"
-          >
-            Total Runs
-          </div>
+          Total Runs
         </div>
         <div
-          class="cell buttons-header "
+          class="cell buttons-header"
           role="columnheader"
-        >
-          <div
-            role="cell"
-          />
-        </div>
+        />
         <div
-          class="cell expand-header "
+          class="cell expand-header"
           role="columnheader"
-        >
-          <div
-            role="cell"
-          />
-        </div>
+        />
       </div>
       <div
         class="f1otqxop"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -210,165 +210,134 @@ exports[`Results View The table should match snapshot and other elements should 
     role="row"
   >
     <div
-      class="cell platform-header fcno249"
+      class="cell platform-header"
       role="columnheader"
     >
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-        data-testid="SortIcon"
-        focusable="false"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M3 18h6v-2H3v2zM3 6v2h18V6H3zm0 7h12v-2H3v2z"
-        />
-      </svg>
-      <div
-        role="cell"
+      <button
+        aria-haspopup="true"
+        aria-label="Platform (Click to filter values)"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-12n6w6k-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="button"
       >
         Platform
-      </div>
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-        data-testid="ExpandMoreIcon"
-        focusable="false"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+        <svg
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-reqpbo-MuiSvgIcon-root"
+          data-testid="FilterListIcon"
+          focusable="false"
+          role="img"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+          />
+          <title>
+            No active filters
+          </title>
+        </svg>
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
         />
-      </svg>
+      </button>
     </div>
     <div
-      class="cell base-header "
+      class="cell base-header"
       role="columnheader"
     >
-      <div
-        role="cell"
-      >
-        Base
-      </div>
+      Base
     </div>
     <div
-      class="cell comparisonSign-header "
+      class="cell comparisonSign-header"
+      role="columnheader"
+    />
+    <div
+      class="cell new-header"
       role="columnheader"
     >
-      <div
-        role="cell"
-      />
+      New
     </div>
     <div
-      class="cell new-header "
+      class="cell status-header"
       role="columnheader"
     >
-      <div
-        role="cell"
-      >
-        New
-      </div>
-    </div>
-    <div
-      class="cell status-header fcno249"
-      role="columnheader"
-    >
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-        data-testid="SortIcon"
-        focusable="false"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M3 18h6v-2H3v2zM3 6v2h18V6H3zm0 7h12v-2H3v2z"
-        />
-      </svg>
-      <div
-        role="cell"
+      <button
+        aria-haspopup="true"
+        aria-label="Status (Click to filter values)"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-12n6w6k-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="button"
       >
         Status
-      </div>
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-        data-testid="ExpandMoreIcon"
-        focusable="false"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+        <svg
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-reqpbo-MuiSvgIcon-root"
+          data-testid="FilterListIcon"
+          focusable="false"
+          role="img"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+          />
+          <title>
+            No active filters
+          </title>
+        </svg>
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
         />
-      </svg>
+      </button>
     </div>
     <div
-      class="cell delta-header "
+      class="cell delta-header"
       role="columnheader"
     >
-      <div
-        role="cell"
-      >
-        Delta(%)
-      </div>
+      Delta(%)
     </div>
     <div
-      class="cell confidence-header fcno249"
+      class="cell confidence-header"
       role="columnheader"
     >
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-        data-testid="SortIcon"
-        focusable="false"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M3 18h6v-2H3v2zM3 6v2h18V6H3zm0 7h12v-2H3v2z"
-        />
-      </svg>
-      <div
-        role="cell"
+      <button
+        aria-haspopup="true"
+        aria-label="Confidence (Click to filter values)"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-12n6w6k-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="button"
       >
         Confidence
-      </div>
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-        data-testid="ExpandMoreIcon"
-        focusable="false"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+        <svg
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-reqpbo-MuiSvgIcon-root"
+          data-testid="FilterListIcon"
+          focusable="false"
+          role="img"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+          />
+          <title>
+            No active filters
+          </title>
+        </svg>
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
         />
-      </svg>
+      </button>
     </div>
     <div
-      class="cell runs-header "
+      class="cell runs-header"
       role="columnheader"
     >
-      <div
-        role="cell"
-      >
-        Total Runs
-      </div>
+      Total Runs
     </div>
     <div
-      class="cell buttons-header "
+      class="cell buttons-header"
       role="columnheader"
-    >
-      <div
-        role="cell"
-      />
-    </div>
+    />
     <div
-      class="cell expand-header "
+      class="cell expand-header"
       role="columnheader"
-    >
-      <div
-        role="cell"
-      />
-    </div>
+    />
   </div>
   <div
     class="f1otqxop"

--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -8,6 +8,8 @@ import { useAppSelector } from '../../hooks/app';
 import { Strings } from '../../resources/Strings';
 import { Spacing } from '../../styles';
 import type { CompareResultsItem, RevisionsHeader } from '../../types/state';
+import type { CompareResultsTableConfig } from '../../types/types';
+import { getPlatformShortName } from '../../utils/platform';
 import NoResultsFound from './NoResultsFound';
 import TableContent from './TableContent';
 import TableHeader from './TableHeader';
@@ -56,29 +58,17 @@ function processResults(results: CompareResultsItem[]) {
   return restructuredResults;
 }
 
-function filterBySearchTerm(results: CompareResultsItem[], searchTerm: string) {
-  if (!searchTerm) {
-    return results;
-  }
-
-  return results.filter(
-    (result) =>
-      result.suite.includes(searchTerm) ||
-      result.extra_options.includes(searchTerm) ||
-      result.option_name.includes(searchTerm) ||
-      result.test.includes(searchTerm) ||
-      result.new_rev.includes(searchTerm) ||
-      result.platform.includes(searchTerm),
-  );
-}
-
-const headerCellsConfiguration = [
+const cellsConfiguration: CompareResultsTableConfig[] = [
   {
     name: 'Platform',
     disable: true,
     filter: true,
     key: 'platform',
-    sort: true,
+    possibleValues: ['Windows', 'OSX', 'Linux', 'Android'],
+    matchesFunction: (result: CompareResultsItem, value: string) => {
+      const platformName = getPlatformShortName(result.platform);
+      return platformName === value;
+    },
   },
   {
     name: 'Base',
@@ -91,7 +81,17 @@ const headerCellsConfiguration = [
     disable: true,
     filter: true,
     key: 'status',
-    sort: true,
+    possibleValues: ['No changes', 'Improvement', 'Regression'],
+    matchesFunction: (result: CompareResultsItem, value: string) => {
+      switch (value) {
+        case 'Improvement':
+          return result.is_improvement;
+        case 'Regression':
+          return result.is_regression;
+        default:
+          return !result.is_improvement && !result.is_regression;
+      }
+    },
   },
   {
     name: 'Delta(%)',
@@ -102,12 +102,75 @@ const headerCellsConfiguration = [
     disable: true,
     filter: true,
     key: 'confidence',
-    sort: true,
+    possibleValues: ['Low', 'Medium', 'High'],
+    matchesFunction: (result: CompareResultsItem, value: string) =>
+      result.confidence_text === value,
   },
   { name: 'Total Runs', key: 'runs' },
   { key: 'buttons' },
   { key: 'expand' },
 ];
+
+function resultMatchesSearchTerm(
+  result: CompareResultsItem,
+  searchTerm: string,
+) {
+  return (
+    result.suite.includes(searchTerm) ||
+    result.extra_options.includes(searchTerm) ||
+    result.option_name.includes(searchTerm) ||
+    result.test.includes(searchTerm) ||
+    result.new_rev.includes(searchTerm) ||
+    result.platform.includes(searchTerm)
+  );
+}
+
+function resultMatchesColumnFilter(
+  result: CompareResultsItem,
+  columnId: string,
+  uncheckedValues: Set<string>,
+): boolean {
+  const cellConfiguration = cellsConfiguration.find(
+    (cell) => cell.key === columnId,
+  );
+  if (!cellConfiguration || !cellConfiguration.filter) {
+    return true;
+  }
+
+  const { matchesFunction } = cellConfiguration;
+  for (const filterValue of uncheckedValues) {
+    if (matchesFunction(result, filterValue)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// This function filters the results array using both the searchTerm and the
+// tableFilters. The tableFilters is a map ColumnID -> Set of values to remove.
+function filterResults(
+  results: CompareResultsItem[],
+  searchTerm: string,
+  tableFilters: Map<string, Set<string>>,
+) {
+  if (!searchTerm && !tableFilters.size) {
+    return results;
+  }
+
+  return results.filter((result) => {
+    if (!resultMatchesSearchTerm(result, searchTerm)) {
+      return false;
+    }
+
+    for (const [columnId, uncheckedValues] of tableFilters) {
+      if (resultMatchesColumnFilter(result, columnId, uncheckedValues)) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+}
 
 const allRevisionsOption =
   Strings.components.comparisonRevisionDropdown.allRevisions.key;
@@ -122,6 +185,10 @@ function ResultsTable({ results, filteringSearchTerm }: ResultsTableProps) {
     (state) => state.comparison.activeComparison,
   );
 
+  const [tableFilters, setTableFilters] = useState(
+    new Map() as Map<string, Set<string>>, // ColumnID -> Set<Values to remove>
+  );
+
   const processedResults = useMemo(() => {
     const resultsForCurrentComparison =
       activeComparison === allRevisionsOption
@@ -129,12 +196,29 @@ function ResultsTable({ results, filteringSearchTerm }: ResultsTableProps) {
         : results.find((result) => result[0].new_rev === activeComparison) ??
           [];
 
-    const filteredResults = filterBySearchTerm(
+    const filteredResults = filterResults(
       resultsForCurrentComparison,
       filteringSearchTerm,
+      tableFilters,
     );
     return processResults(filteredResults);
-  }, [results, activeComparison, filteringSearchTerm]);
+  }, [results, activeComparison, filteringSearchTerm, tableFilters]);
+
+  const onClearFilter = (columnId: string) => {
+    setTableFilters((oldFilters) => {
+      const newFilters = new Map(oldFilters);
+      newFilters.delete(columnId);
+      return newFilters;
+    });
+  };
+
+  const onToggleFilter = (columnId: string, filters: Set<string>) => {
+    setTableFilters((oldFilters) => {
+      const newFilters = new Map(oldFilters);
+      newFilters.set(columnId, filters);
+      return newFilters;
+    });
+  };
 
   // TODO Implement a loading UI through the react-router defer mechanism
   const loading = false;
@@ -158,7 +242,12 @@ function ResultsTable({ results, filteringSearchTerm }: ResultsTableProps) {
         </Box>
       ) : (
         <>
-          <TableHeader headerCellsConfiguration={headerCellsConfiguration} />
+          <TableHeader
+            cellsConfiguration={cellsConfiguration}
+            filters={tableFilters}
+            onToggleFilter={onToggleFilter}
+            onClearFilter={onClearFilter}
+          />
           {processedResults.map((res) => (
             <TableContent
               key={res.key}

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 
 import AppleIcon from '@mui/icons-material/Apple';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
@@ -11,7 +11,8 @@ import { style } from 'typestyle';
 import { useAppSelector } from '../../hooks/app';
 import { Strings } from '../../resources/Strings';
 import { Colors, Spacing, ExpandableRowStyles } from '../../styles';
-import type { CompareResultsItem, PlatformInfo } from '../../types/state';
+import type { CompareResultsItem, PlatformShortName } from '../../types/state';
+import { getPlatformShortName } from '../../utils/platform';
 import AndroidIcon from '../Shared/Icons/AndroidIcon';
 import LinuxIcon from '../Shared/Icons/LinuxIcon';
 import WindowsIcon from '../Shared/Icons/WindowsIcon';
@@ -30,23 +31,12 @@ function determineSign(baseMedianValue: number, newMedianValue: number) {
   return '';
 }
 
-const getPlatformInfo = (platformName: string): PlatformInfo => {
-  if (platformName.toLowerCase().includes('linux'))
-    return { shortName: 'Linux', icon: <LinuxIcon /> };
-  else if (
-    platformName.toLowerCase().includes('osx') ||
-    platformName.toLowerCase().includes('os x')
-  )
-    return { shortName: 'OSX', icon: <AppleIcon /> };
-  else if (platformName.toLowerCase().includes('windows'))
-    return { shortName: 'Windows', icon: <WindowsIcon /> };
-  else if (platformName.toLowerCase().includes('android'))
-    return { shortName: 'Android', icon: <AndroidIcon /> };
-  else
-    return {
-      shortName: Strings.components.revisionRow.platformUndefinedText,
-      icon: '',
-    };
+const platformIcons: Record<PlatformShortName, ReactNode> = {
+  Linux: <LinuxIcon />,
+  OSX: <AppleIcon />,
+  Windows: <WindowsIcon />,
+  Android: <AndroidIcon />,
+  Unspecified: '',
 };
 
 function RevisionRow(props: RevisionRowProps) {
@@ -66,7 +56,8 @@ function RevisionRow(props: RevisionRowProps) {
     graphs_link: graphLink,
   } = result;
 
-  const platformInfo = getPlatformInfo(platform);
+  const platformShortName = getPlatformShortName(platform);
+  const platformIcon = platformIcons[platformShortName];
 
   const [expanded, setExpanded] = useState(false);
 
@@ -170,8 +161,8 @@ function RevisionRow(props: RevisionRowProps) {
       >
         <div className='platform cell' role='cell'>
           <div className='platform-container'>
-            {platformInfo.icon}
-            <span>{platformInfo.shortName}</span>
+            {platformIcon}
+            <span>{platformShortName}</span>
           </div>
         </div>
         <div className='base-value cell' role='cell'>

--- a/src/components/CompareResults/TableHeader.tsx
+++ b/src/components/CompareResults/TableHeader.tsx
@@ -1,16 +1,104 @@
+import CheckIcon from '@mui/icons-material/Check';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import SortIcon from '@mui/icons-material/Sort';
+import Button from '@mui/material/Button';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import {
+  usePopupState,
+  bindTrigger,
+  bindMenu,
+} from 'material-ui-popup-state/hooks';
 import { style } from 'typestyle';
 
 import { useAppSelector } from '../../hooks/app';
 import { Colors, Spacing } from '../../styles';
 import type { CompareResultsTableConfig } from '../../types/types';
 
-type TableHeaderProps = {
-  headerCellsConfiguration: CompareResultsTableConfig[];
+type FilterableColumnProps = {
+  name: string;
+  columnId: string;
+  possibleValues: string[];
+  uncheckedValues?: Set<string>;
+  onToggle: (checkedValues: Set<string>) => unknown;
+  onClear: () => unknown;
 };
 
-function TableHeader({ headerCellsConfiguration }: TableHeaderProps) {
+function FilterableColumn({
+  name,
+  columnId,
+  possibleValues,
+  uncheckedValues,
+  onToggle,
+  onClear,
+}: FilterableColumnProps) {
+  const popupState = usePopupState({ variant: 'popover', popupId: columnId });
+
+  const onClickFilter = (value: string) => {
+    const newUncheckedValues = new Set(uncheckedValues);
+    if (newUncheckedValues.has(value)) {
+      newUncheckedValues.delete(value);
+    } else {
+      newUncheckedValues.add(value);
+    }
+    onToggle(newUncheckedValues);
+  };
+
+  return (
+    <>
+      <Button
+        color='secondary'
+        {...bindTrigger(popupState)}
+        sx={(theme) => ({
+          background:
+            theme.palette.mode == 'light'
+              ? Colors.Background200
+              : Colors.Background200Dark,
+          borderRadius: '4px',
+          fontSize: 'inherit',
+        })}
+      >
+        {name}
+        <ExpandMoreIcon />
+      </Button>
+      <Menu {...bindMenu(popupState)}>
+        <MenuItem dense={true} onClick={onClear}>
+          Clear filters
+        </MenuItem>
+        {possibleValues.map((possibleValue) => {
+          const isChecked =
+            !uncheckedValues || !uncheckedValues.has(possibleValue);
+          return (
+            <MenuItem
+              dense={true}
+              key={possibleValue}
+              role='menuitemcheckbox'
+              aria-checked={isChecked ? 'true' : 'false'}
+              aria-label={`${possibleValue}${isChecked ? ' (selected)' : ''}`}
+              onClick={() => onClickFilter(possibleValue)}
+            >
+              {isChecked ? <CheckIcon fontSize='small' /> : null}
+              {possibleValue}
+            </MenuItem>
+          );
+        })}
+      </Menu>
+    </>
+  );
+}
+
+type TableHeaderProps = {
+  cellsConfiguration: CompareResultsTableConfig[];
+  filters: Map<string, Set<string>>;
+  onToggleFilter: (columnId: string, filters: Set<string>) => unknown;
+  onClearFilter: (columnId: string) => unknown;
+};
+
+function TableHeader({
+  cellsConfiguration,
+  filters,
+  onToggleFilter,
+  onClearFilter,
+}: TableHeaderProps) {
   const themeMode = useAppSelector((state) => state.theme.mode);
   const styles = {
     tableHeader: style({
@@ -48,13 +136,6 @@ function TableHeader({ headerCellsConfiguration }: TableHeaderProps) {
       },
     }),
 
-    filter: style({
-      background:
-        themeMode == 'light' ? Colors.Background200 : Colors.Background200Dark,
-      borderRadius: '4px',
-      cursor: 'not-allowed',
-    }),
-
     typography: style({
       fontFamily: 'SF Pro',
       fontStyle: 'normal',
@@ -70,17 +151,26 @@ function TableHeader({ headerCellsConfiguration }: TableHeaderProps) {
       data-testid='table-header'
       role='row'
     >
-      {headerCellsConfiguration.map((header) => (
+      {cellsConfiguration.map((header) => (
         <div
           key={`${header.key}`}
-          className={`cell ${header.key}-header ${
-            header.filter ? styles.filter : ''
-          }`}
+          className={`cell ${header.key}-header`}
           role='columnheader'
         >
-          {header.sort ? <SortIcon /> : null}
-          <div role='cell'>{header.name}</div>
-          {header.filter ? <ExpandMoreIcon /> : null}
+          {header.filter ? (
+            <FilterableColumn
+              possibleValues={header.possibleValues}
+              name={header.name}
+              columnId={header.key}
+              uncheckedValues={filters.get(header.key)}
+              onClear={() => onClearFilter(header.key)}
+              onToggle={(checkedValues) =>
+                onToggleFilter(header.key, checkedValues)
+              }
+            />
+          ) : (
+            header.name
+          )}
         </div>
       ))}
     </div>

--- a/src/components/CompareResults/TableHeader.tsx
+++ b/src/components/CompareResults/TableHeader.tsx
@@ -1,5 +1,5 @@
 import CheckIcon from '@mui/icons-material/Check';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import FilterListIcon from '@mui/icons-material/FilterList';
 import Button from '@mui/material/Button';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
@@ -43,11 +43,17 @@ function FilterableColumn({
     onToggle(newUncheckedValues);
   };
 
+  const hasFilteredValues = uncheckedValues && uncheckedValues.size;
+  const buttonAriaLabel = hasFilteredValues
+    ? `${name} (Click to filter values. Some filters are active.)`
+    : `${name} (Click to filter values)`;
+
   return (
     <>
       <Button
         color='secondary'
         {...bindTrigger(popupState)}
+        aria-label={buttonAriaLabel}
         sx={(theme) => ({
           background:
             theme.palette.mode == 'light'
@@ -58,7 +64,14 @@ function FilterableColumn({
         })}
       >
         {name}
-        <ExpandMoreIcon />
+        <FilterListIcon
+          fontSize='small'
+          color={hasFilteredValues ? 'primary' : 'inherit'}
+          sx={{ marginInlineStart: 1 }}
+          titleAccess={
+            hasFilteredValues ? 'Some filters are active' : 'No active filters'
+          }
+        />
       </Button>
       <Menu {...bindMenu(popupState)}>
         <MenuItem dense={true} onClick={onClear}>

--- a/src/components/CompareResults/TableHeader.tsx
+++ b/src/components/CompareResults/TableHeader.tsx
@@ -4,17 +4,10 @@ import { style } from 'typestyle';
 
 import { useAppSelector } from '../../hooks/app';
 import { Colors, Spacing } from '../../styles';
-
-type HeaderCell = {
-  name?: string;
-  key: string;
-  disable?: boolean;
-  filter?: boolean;
-  sort?: boolean;
-};
+import type { CompareResultsTableConfig } from '../../types/types';
 
 type TableHeaderProps = {
-  headerCellsConfiguration: HeaderCell[];
+  headerCellsConfiguration: CompareResultsTableConfig[];
 };
 
 function TableHeader({ headerCellsConfiguration }: TableHeaderProps) {

--- a/src/resources/Strings.tsx
+++ b/src/resources/Strings.tsx
@@ -102,7 +102,6 @@ export const Strings = {
       },
     },
     revisionRow: {
-      platformUndefinedText: 'Unspecified',
       title: {
         graphLink: 'open the evolution graph for this job in treeherder',
         downloadProfilers: 'open the performance profile for this job',

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -110,7 +110,9 @@ export type SelectedRevisionsState = {
   newCommittedRevisions: Changeset[];
 };
 
-export type PlatformInfo = {
-  shortName: string;
-  icon: React.ReactNode;
-};
+export type PlatformShortName =
+  | 'Linux'
+  | 'OSX'
+  | 'Windows'
+  | 'Android'
+  | 'Unspecified';

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,30 +1,12 @@
 import { CompareResultsItem } from './state';
 
-export type SelectedRevisionsTableHeaders =
-  | 'Project'
-  | 'Revision'
-  | 'Author'
-  | 'Commit Message'
-  | 'Timestamp';
-
-export type CompareResultsTableHeader = {
-  id: string;
-  label: CompareResultsTableHeaderName;
+export type CompareResultsTableConfig = {
+  name?: string;
   key: string;
-  align: 'left' | 'center' | 'right';
+  disable?: boolean;
+  filter?: boolean;
+  sort?: boolean;
 };
-
-export type CompareResultsTableHeaderName =
-  | 'Platform'
-  | 'Graph'
-  | 'Suite'
-  | 'Test Name'
-  | 'Base'
-  | 'New'
-  | 'Delta'
-  | 'Status'
-  | 'Confidence'
-  | 'Total Runs';
 
 export type ConfidenceText = 'High' | 'Medium' | 'Low';
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,12 +1,21 @@
 import { CompareResultsItem } from './state';
 
-export type CompareResultsTableConfig = {
-  name?: string;
-  key: string;
-  disable?: boolean;
-  filter?: boolean;
-  sort?: boolean;
-};
+export type CompareResultsTableConfig =
+  | {
+      name?: string;
+      filter?: false;
+      key: string;
+      disable?: boolean;
+    }
+  | {
+      name: string;
+      key: string;
+      disable?: boolean;
+      filter: true;
+      possibleValues: string[];
+      // This function returns whether this result matches the value for this column.
+      matchesFunction: (result: CompareResultsItem, value: string) => boolean;
+    };
 
 export type ConfidenceText = 'High' | 'Medium' | 'Low';
 

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -1,0 +1,15 @@
+import type { PlatformShortName } from '../types/state';
+
+export const getPlatformShortName = (
+  platformName: string,
+): PlatformShortName => {
+  if (platformName.toLowerCase().includes('linux')) return 'Linux';
+  if (
+    platformName.toLowerCase().includes('osx') ||
+    platformName.toLowerCase().includes('os x')
+  )
+    return 'OSX';
+  if (platformName.toLowerCase().includes('windows')) return 'Windows';
+  if (platformName.toLowerCase().includes('android')) return 'Android';
+  return 'Unspecified';
+};


### PR DESCRIPTION
This implements filtering by column.

The initial commits in the PR are #678 so please don't look at them here.
Then the commits are:
1. update the user-event library: indeed the new version expose a type that I'd like to use in the tests
2. Some moving around of types. This also removes some types that are not used.
3. Some more refactoring around how the short platform name and icon are computed. Indeed I want to reuse this in the filtering.
4. This is the meat of the PR, where the implementation for filtering happens. I tried to implement this so that we'd loop over the results only once for filtering. Ideally we'd do the "processResults" in the same loop too, but decided to leave this for future work, also to keep the code cleaner.
5. This changes the "expand icon" to a "filter icon". Indeed I wanted to provide an indicator when a filter is active on a column. It's only conveyed by the color so it's not perfect, but I still added some title and aria-label to try to provide a good accessibility.
6. and 7. are about tests.

It's not 100% perfect, especially the style for the filtering menu should be polished. Indeed some other styles are conflicting with that and I'd like to work on that in another PR.

[deploy preview](https://deploy-preview-673--mozilla-perfcompare.netlify.app/compare-results?baseRev=ddaa8beed4f649a50d0d6b8b67b373487e46dd56&baseRepo=mozilla-central&newRev=55142668d01174ee804cdee8c877f6d0212fd421&newRepo=mozilla-central&framework=1)