### PR TITLE
PCF-432 Subtask Create RetriggerButton component, add storage event

### DIFF
--- a/src/components/CompareResults/RetriggerButton.tsx
+++ b/src/components/CompareResults/RetriggerButton.tsx
@@ -1,0 +1,49 @@
+import RefreshOutlinedIcon from '@mui/icons-material/RefreshOutlined';
+import { IconButton } from '@mui/material';
+
+import { checkTaskclusterCredentials } from '../../logic/taskcluster';
+import { Strings } from '../../resources/Strings';
+
+function waitForStorageEvent(): Promise<void> {
+  return new Promise((resolve) => {
+    window.addEventListener(
+      'storage',
+      function storageListener(event: StorageEvent) {
+        // TODO change userCredentials with userTokens
+        // when the userCredentials fetch is moved here
+        if (event.key === 'userCredentials') {
+          resolve();
+          window.removeEventListener('storage', storageListener);
+        }
+      },
+    );
+  });
+}
+
+async function checkLocalStorage() {
+  await waitForStorageEvent();
+}
+
+function RetriggerButton() {
+  const onOpenModal = async () => {
+    checkTaskclusterCredentials();
+    await checkLocalStorage();
+  };
+
+  // TODO implement modal
+
+  return (
+    <>
+      <IconButton
+        title={Strings.components.revisionRow.title.retriggerJobs}
+        color='primary'
+        size='small'
+        onClick={() => void onOpenModal()}
+      >
+        <RefreshOutlinedIcon />
+      </IconButton>
+    </>
+  );
+}
+
+export default RetriggerButton;

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -4,19 +4,18 @@ import AppleIcon from '@mui/icons-material/Apple';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import FileDownloadOutlinedIcon from '@mui/icons-material/FileDownloadOutlined';
-import RefreshOutlinedIcon from '@mui/icons-material/RefreshOutlined';
 import TimelineIcon from '@mui/icons-material/Timeline';
 import { IconButton } from '@mui/material';
 import { style } from 'typestyle';
 
 import { useAppSelector } from '../../hooks/app';
-import { checkTaskclusterCredentials } from '../../logic/taskcluster';
 import { Strings } from '../../resources/Strings';
 import { Colors, Spacing, ExpandableRowStyles } from '../../styles';
 import type { CompareResultsItem, PlatformInfo } from '../../types/state';
 import AndroidIcon from '../Shared/Icons/AndroidIcon';
 import LinuxIcon from '../Shared/Icons/LinuxIcon';
 import WindowsIcon from '../Shared/Icons/WindowsIcon';
+import RetriggerButton from './RetriggerButton';
 import RevisionRowExpandable from './RevisionRowExpandable';
 
 function determineStatus(improvement: boolean, regression: boolean) {
@@ -235,14 +234,7 @@ function RevisionRow(props: RevisionRowProps) {
             data-testid='retrigger-jobs-button'
           >
             <div className='retrigger-button-container'>
-              <IconButton
-                title={Strings.components.revisionRow.title.retriggerJobs}
-                color='primary'
-                size='small'
-                onClick={() => checkTaskclusterCredentials()}
-              >
-                <RefreshOutlinedIcon />
-              </IconButton>
+              <RetriggerButton />
             </div>
           </div>
         </div>


### PR DESCRIPTION
This PR fullfills a part of [PCF-432 Implement the "login" intermediate popup if credentials are not available](https://mozilla-hub.atlassian.net/browse/PCF-432)
It adds the storage event that will later be used to trigger some action after the localStorage saved the userToken/userCredentials.