### PR TITLE
Do not add extra options flags if there are no extra options

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -111,4 +111,10 @@ module.exports = {
       },
     },
   ],
+  // This property is specified both here in addition to the command line in
+  // package.json.
+  // The reason is that the property only warns but the command line option
+  // outputs errors, but the property is useful so that we have the information
+  // directly in editors.
+  reportUnusedDisableDirectives: true,
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -86,6 +86,8 @@ module.exports = {
         // TODO: update tests to not use store directly and remove these overrides
         // https://github.com/mozilla/perfcompare/issues/115
         '@typescript-eslint/no-unsafe-member-access': 'off',
+        // We can be less strict in tests about non-null assertions, to make it easier.
+        '@typescript-eslint/no-non-null-assertion': 'off',
 
         // This disallows using direct Node properties (eg: firstChild), but we have
         // legitimate uses:

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dev": "webpack serve --config webpack/webpack.config.js --env env=development --open",
     "start": "node server.js",
     "build": "webpack --config webpack/webpack.config.js --env env=production",
-    "lint": "eslint \"src/**/*.{js,ts,tsx}\" \"*.js\"",
+    "lint": "eslint \"src/**/*.{js,ts,tsx}\" \"*.js\" --report-unused-disable-directives",
     "lint:fix": "npm run lint -- --fix",
     "format": "prettier --write . --config ./.prettierrc.js",
     "format:check": "prettier --check . --config ./.prettierrc.js",

--- a/src/__tests__/CompareResults/OverTimeResultsView.test.tsx
+++ b/src/__tests__/CompareResults/OverTimeResultsView.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-disabled-tests */
 import type { ReactElement } from 'react';
 
 import { loader } from '../../components/CompareResults/overTimeLoader';

--- a/src/__tests__/CompareResults/ResultsTable.test.tsx
+++ b/src/__tests__/CompareResults/ResultsTable.test.tsx
@@ -20,6 +20,11 @@ function renderWithRoute(component: ReactElement) {
 describe('Results Table', () => {
   it('Should match snapshot', async () => {
     const { testCompareData } = getTestData();
+    const compareDataToChange = testCompareData.at(-1)!;
+    Object.assign(compareDataToChange, {
+      extra_options: '',
+      header_name: `${compareDataToChange.suite} ${compareDataToChange.test} ${compareDataToChange.option_name}`,
+    });
 
     (window.fetch as FetchMockSandbox)
       .get(

--- a/src/__tests__/CompareResults/ResultsTable.test.tsx
+++ b/src/__tests__/CompareResults/ResultsTable.test.tsx
@@ -29,7 +29,9 @@ describe('Results Table', () => {
       .get('begin:https://treeherder.mozilla.org/api/project/', {
         results: [],
       });
-    renderWithRoute(<ResultsTable results={[]} filteringSearchTerm='' />);
+    renderWithRoute(
+      <ResultsTable results={[testCompareData]} filteringSearchTerm='' />,
+    );
 
     expect(await screen.findByTestId('results-table')).toBeInTheDocument();
     expect(document.body).toMatchSnapshot();

--- a/src/__tests__/CompareResults/ResultsView.test.tsx
+++ b/src/__tests__/CompareResults/ResultsView.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-disabled-tests */
 import type { ReactElement } from 'react';
 
 import userEvent from '@testing-library/user-event';

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -175,34 +175,1021 @@ exports[`Results Table Should match snapshot 1`] = `
         </div>
       </div>
       <div
-        class="MuiContainer-root MuiContainer-maxWidthLg css-1oqqzyl-MuiContainer-root"
+        class="f1otqxop"
+        role="rowgroup"
       >
         <div
-          class="MuiGrid-root MuiGrid-container css-3s5eoc-MuiGrid-root"
+          class="fx9q187"
         >
           <div
-            class="foa7wva"
+            class="f897l9y"
           >
-            <div>
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge css-8lii5d-MuiSvgIcon-root"
-                data-testid="SearchIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
+            <strong>
+              <a
+                aria-label="link to suite documentation"
+                class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-g8z9fn-MuiTypography-root-MuiLink-root"
+                href="https://firefox-source-docs.mozilla.org/testing/perfdocs/talos.html#a11yr"
+                target="_blank"
               >
-                <path
-                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-                />
-              </svg>
-              <br />
+                a11yr
+              </a>
+               dhtml.html
+            </strong>
+             
+            <a
+              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
+              href="https://treeherder.mozilla.org/jobs?repo=mozilla-central&revision=spam"
+              target="_blank"
+              title="open treeherder view for spam"
+            >
+              spam
+            </a>
+          </div>
+          <div
+            class="f1oxa67k"
+          >
+            <span
+              class="f1rpr1m5"
+            >
+              opt
+            </span>
+            <span
+              class="f1rpr1m5"
+            >
+              e10s
+            </span>
+            <span
+              class="f1rpr1m5"
+            >
+              fission
+            </span>
+            <span
+              class="f1rpr1m5"
+            >
+              stylo
+            </span>
+            <span
+              class="f1rpr1m5"
+            >
+              webrender
+            </span>
+          </div>
+        </div>
+        <div>
+          <div
+            class="revisionRow f1x1c13s fp4ugv1"
+            role="row"
+          >
+            <div
+              class="platform cell"
+              role="cell"
+            >
+              <div
+                class="platform-container"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                  data-testid="AppleIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"
+                  />
+                </svg>
+                <span>
+                  OSX
+                </span>
+              </div>
             </div>
-            <b>
-              No results found
-            </b>
-            <br />
-            For the selected revision(s), no results when compared to the base revision.
-            <br />
+            <div
+              class="base-value cell"
+              role="cell"
+            >
+               
+              704.84
+               
+              ms
+               
+            </div>
+            <div
+              class="comparison-sign cell"
+              role="cell"
+            >
+              &lt;
+            </div>
+            <div
+              class="new-value cell"
+              role="cell"
+            >
+               
+              712.44
+               
+              ms
+            </div>
+            <div
+              class="status cell"
+              role="cell"
+            >
+               
+              Improvement
+               
+            </div>
+            <div
+              class="delta cell"
+              role="cell"
+            >
+               
+              1.08
+               %
+               
+            </div>
+            <div
+              class="confidence cell"
+              role="cell"
+            >
+               
+              Low
+               
+            </div>
+            <div
+              class="total-runs cell"
+              role="cell"
+            >
+              <span>
+                B:
+              </span>
+              <strong>
+                 
+                1
+                 
+              </strong>
+               
+              <span>
+                 N: 
+              </span>
+              <strong>
+                 
+                1
+                 
+              </strong>
+            </div>
+            <div
+              class="row-buttons cell"
+            >
+              <div
+                class="graph"
+                role="cell"
+              >
+                <div
+                  class="graph-link-button-container"
+                >
+                  <a
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
+                    href="https://treeherder.mozilla.org/perfherder/graphs?highlightedRevisions=1e32960788ea&highlightedRevisions=6a1f133815a1&series=mozilla-central%2C9daea6258ae244039eb2390f3eab7935994cbb0e%2C1%2C1&timerange=5184000"
+                    tabindex="0"
+                    target="_blank"
+                    title="open the evolution graph for this job in treeherder"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                      data-testid="TimelineIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
+                      />
+                    </svg>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </div>
+              </div>
+              <div
+                class="download"
+                role="cell"
+              >
+                <div
+                  class="download-button-container"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
+                    tabindex="0"
+                    title="open the performance profile for this job"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                      data-testid="FileDownloadOutlinedIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
+                      />
+                    </svg>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
+              </div>
+              <div
+                class="retrigger-button"
+                data-testid="retrigger-jobs-button"
+                role="cell"
+              >
+                <div
+                  class="retrigger-button-container"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
+                    tabindex="0"
+                    title="retrigger jobs"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                      data-testid="RefreshOutlinedIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                      />
+                    </svg>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div
+              class="expand-button cell"
+              role="cell"
+            >
+              <div
+                class="expand-button-container"
+                data-testid="expand-revision-button"
+              >
+                <button
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  title="expand this row"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                    data-testid="ExpandMoreIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="revisionRow f1x1c13s fp4ugv1"
+            role="row"
+          >
+            <div
+              class="platform cell"
+              role="cell"
+            >
+              <div
+                class="platform-container"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 34 34"
+                >
+                  <g
+                    id="SVGRepo_bgCarrier"
+                    stroke-width="0"
+                  />
+                  <g
+                    id="SVGRepo_tracerCarrier"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <g
+                    id="SVGRepo_iconCarrier"
+                  >
+                    <path
+                      d="M15.6 8.1c0 .1-.1.1-.1.1h-.1c-.1 0-.1-.1-.2-.2 0 0-.1-.1-.1-.2s0-.1.1-.1l.2.1c.1.1.2.2.2.3m-1.9-1c0-.5-.2-.8-.5-.8 0 0 0 .1-.1.1v.2h.3c0 .2.1.3.1.5h.2m3.6-.5c.2 0 .3.2.4.5h.2c-.1-.1-.1-.2-.1-.3 0-.1 0-.2-.1-.3-.1-.1-.2-.2-.3-.2 0 0-.1.1-.2.1 0 .1.1.1.1.2m-3.1 1.6c-.1 0-.1 0-.1-.1s0-.2.1-.3c.2 0 .3-.1.3-.1.1 0 .1.1.1.1 0 .1-.1.2-.3.4h-.1m-1.1-.1c-.4-.2-.5-.5-.5-1 0-.3 0-.5.2-.7.1-.2.3-.3.5-.3s.3.1.5.3c.1.3.2.6.2.9v.2h.1v-.1c.1 0 .1-.2.1-.6 0-.3 0-.6-.2-.9-.2-.3-.4-.5-.8-.5-.3 0-.6.2-.7.5-.2.4-.2.7-.2 1.2 0 .4.1.8.6 1.2 0-.1.1-.1.2-.2m12.8 14.5c.1 0 .1 0 .1-.1 0-.2-.1-.5-.4-.8-.3-.3-.8-.5-1.4-.6h-.4c-.1 0-.3 0-.4-.1.3-1 .4-1.8.4-2.5 0-1-.2-1.7-.6-2.4-.4-.6-.8-.9-1.3-1-.1.1-.1.1-.1.2.5.2 1 .6 1.3 1.2.3.7.4 1.3.4 2.1 0 .6-.1 1.4-.5 2.5-.4.2-.8.5-1.1 1.1 0 .1 0 .1.1.1 0 0 .1-.1.2-.3l.5-.5c.3-.2.5-.3.8-.3.5 0 1 .1 1.3.2.4.1.6.3.7.4.1.2.2.3.3.4 0 .3.1.4.1.4M16.5 7.7c-.1-.1-.1-.3-.1-.5 0-.4 0-.6.2-.9.2-.2.4-.3.6-.3.3 0 .5.2.7.4.1.3.2.5.2.8 0 .5-.2.8-.6.9 0 0 .1.1.2.1.2 0 .3.1.5.2.1-.6.2-1 .2-1.5 0-.6-.1-1-.3-1.3-.3-.3-.6-.4-1-.4-.3 0-.6.1-.9.3-.2.3-.3.5-.3.8 0 .5.1.9.3 1.3.1 0 .2.1.3.1m1.2 1.7c-1.3.9-2.4 1.3-3.2 1.3-.7 0-1.4-.3-2.1-.8.1.2.2.4.3.5l.6.6c.4.4.9.6 1.4.6.7 0 1.5-.4 2.6-1.1l.9-.6c.2-.2.4-.4.4-.7 0-.1 0-.2-.1-.2 0-.3-.5-.6-1.5-.9-.9-.4-1.6-.6-2.1-.6-.3 0-.8.2-1.5.6-.6.4-1 .8-1 1.2 0 0 .1.1.2.3.6.5 1.2.8 1.8.8.8 0 1.8-.4 3.2-1.4v.2c.1.1.1.2.1.2m2.4 20.7c.4.8 1.1 1.2 1.9 1.2.2 0 .4 0 .6-.1.2 0 .4-.1.5-.2.1-.1.2-.1.3-.2.2-.1.2-.1.3-.2l1.7-1.5c.4-.3.8-.6 1.3-.9l1-.5c.3-.1.5-.2.7-.4.1-.2.2-.3.2-.6s-.2-.5-.4-.7c-.2-.2-.4-.3-.6-.3-.2-.1-.4-.2-.7-.5-.2-.3-.4-.6-.5-1.1l-.1-.6c-.1-.3-.1-.5-.2-.6H26c-.1 0-.3.1-.4.3l-.6.6c-.1.2-.4.4-.6.6-.3.2-.6.3-.8.3-.8 0-1.2-.2-1.5-.7-.2-.3-.3-.7-.4-1.1-.2-.2-.3-.3-.5-.3-.5 0-.7.5-.7 1.6V27.3c0 .1-.1.3-.1.6-.1.3-.1.7-.1 1.1l-.2 1.1m-14.9-.6c1 .1 2.1.4 3.3.9 1.2.5 2 .7 2.3.7.7 0 1.3-.3 1.8-.9.1-.2.1-.4.1-.7 0-1-.6-2.2-1.8-3.7l-.7-.9c-.1-.2-.3-.5-.5-.9s-.4-.7-.6-.9c-.1-.2-.3-.5-.6-.7-.3-.2-.6-.4-.9-.5-.4.1-.7.2-.9.4s-.2.4-.2.6c0 .2-.1.4-.2.4-.1.1-.3.1-.5.2h-.6c-.5 0-.9.1-1.1.2-.3.3-.4.6-.4 1 0 .2 0 .4.1.8s.1.7.1.9c0 .4-.1.8-.4 1.3-.3.4-.4.8-.4 1 .2.4.9.7 2.1.8m3.4-9.3c0-.7.2-1.5.6-2.4.4-.9.7-1.5 1.1-1.9 0-.1-.1-.1-.2-.1l-.1-.2c-.3.3-.7 1-1.1 2.1-.4.9-.7 1.8-.7 2.4 0 .5.1.9.3 1.2.2.3.8.8 1.6 1.5l1.1.7c1.2 1 1.8 1.7 1.8 2.1 0 .2-.1.4-.4.7-.2.2-.5.4-.7.4v.1l.3.6c.4.6 1.4.9 2.6.9 2.3 0 4-.9 5.3-2.8 0-.5 0-.8-.1-1v-.4c0-.7.1-1.2.3-1.5.2-.3.4-.5.7-.5.2 0 .4.1.6.2.1-.8.1-1.5.1-2.1 0-.9 0-1.7-.2-2.4-.1-.6-.3-1.1-.5-1.5l-.6-.9c-.2-.3-.3-.6-.5-.9-.1-.4-.2-.7-.2-1.2-.3-.5-.5-1-.8-1.5-.2-.5-.4-1-.6-1.4l-.9.7c-1 .7-1.8 1-2.6 1-.6 0-1.1-.1-1.4-.5l-.6-.5c0 .3-.1.7-.3 1.1l-.6 1.2c-.3.7-.4 1.1-.5 1.4 0 .2-.1.4-.1.4l-.8 1.5c-.8 1.5-1.3 3-1.3 4.1 0 .2 0 .5.1.7-.5-.3-.7-.7-.7-1.3m7.4 9.7c-1.3 0-2.4.2-3.1.5-.5.6-1.1.9-1.9.9-.5 0-1.3-.2-2.4-.6-1.1-.4-2-.7-2.9-.8-.1 0-.3-.1-.6-.1s-.6-.1-.8-.1c-.2 0-.5-.1-.7-.2-.3-.1-.5-.2-.6-.3-.1-.1-.2-.3-.2-.4 0-.2 0-.3.1-.5s.2-.3.3-.4c.1-.1.1-.2.2-.3.1-.1.1-.2.1-.3 0-.1.1-.2.1-.3v-.3s0-.4-.1-1c-.1-.5-.1-.9-.1-1 0-.5.1-.8.3-1.1.2-.3.4-.4.7-.4h1.2c.1 0 .2-.1.5-.2.1-.2.1-.3.2-.4.1-.1.1-.2.1-.3 0-.1 0-.1.1-.2 0-.1.1-.2.2-.2-.1-.1-.1-.2-.1-.4v-.3c0-.4.2-.9.5-1.6l.4-.6.7-1.4c.2-.4.4-1 .6-1.8.2-.7.6-1.4 1.2-2.2l.8-.9c.5-.6.9-1.1 1.1-1.5.2-.4.3-.9.3-1.3 0-.2-.1-.8-.2-1.8s-.2-2.1-.2-3c0-.7.1-1.2.2-1.7s.4-1 .7-1.4c.3-.4.7-.8 1.3-1 .6-.2 1.3-.3 2.2-.3.3 0 .6 0 .9.1.3 0 .7.1 1.2.3.4.2.8.4 1.1.7.2.2.6.7.9 1.2.2.6.4 1.2.5 2.1.1.5.1 1 .2 1.7 0 .6.1 1 .1 1.3.1.3.1.7.2 1.2.1.4.2.8.4 1.1.2.4.4.8.7 1.2.3.5.7 1 1.1 1.6.9 1 1.6 2.2 2.1 3.3.5 1 .8 2.4.8 3.8 0 .7-.1 1.4-.3 2.1.2 0 .3.1.4.2s.2.5.3.9l.1.8c.1.2.2.4.5.6.2.2.4.3.7.5.2.1.5.2.7.4.2.2.3.4.3.6 0 .3-.1.6-.3.8-.2.2-.4.3-.7.4l-1.2.6c-.5.3-1 .7-1.5 1.1l-1 .9c-.4.4-.8.7-1.1.9-.3.2-.7.3-1.1.3l-.7-.1c-.8-.2-1.3-.6-1.6-1.3-1.8 0-3.1-.1-3.9-.1"
+                    />
+                  </g>
+                </svg>
+                <span>
+                  Linux
+                </span>
+              </div>
+            </div>
+            <div
+              class="base-value cell"
+              role="cell"
+            >
+               
+              776.97
+               
+              ms
+               
+            </div>
+            <div
+              class="comparison-sign cell"
+              role="cell"
+            >
+              &lt;
+            </div>
+            <div
+              class="new-value cell"
+              role="cell"
+            >
+               
+              791.34
+               
+              ms
+            </div>
+            <div
+              class="status cell"
+              role="cell"
+            >
+               
+              Regression
+               
+            </div>
+            <div
+              class="delta cell"
+              role="cell"
+            >
+               
+              1.85
+               %
+               
+            </div>
+            <div
+              class="confidence cell"
+              role="cell"
+            >
+               
+              Medium
+               
+            </div>
+            <div
+              class="total-runs cell"
+              role="cell"
+            >
+              <span>
+                B:
+              </span>
+              <strong>
+                 
+                1
+                 
+              </strong>
+               
+              <span>
+                 N: 
+              </span>
+              <strong>
+                 
+                1
+                 
+              </strong>
+            </div>
+            <div
+              class="row-buttons cell"
+            >
+              <div
+                class="graph"
+                role="cell"
+              >
+                <div
+                  class="graph-link-button-container"
+                >
+                  <a
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
+                    href="https://treeherder.mozilla.org/perfherder/graphs?highlightedRevisions=1e32960788ea&highlightedRevisions=6a1f133815a1&series=mozilla-central%2Cedcc6311f15bdf7924ef3f0ccfd8b47ce1892212%2C1%2C1&timerange=5184000"
+                    tabindex="0"
+                    target="_blank"
+                    title="open the evolution graph for this job in treeherder"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                      data-testid="TimelineIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
+                      />
+                    </svg>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </div>
+              </div>
+              <div
+                class="download"
+                role="cell"
+              >
+                <div
+                  class="download-button-container"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
+                    tabindex="0"
+                    title="open the performance profile for this job"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                      data-testid="FileDownloadOutlinedIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
+                      />
+                    </svg>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
+              </div>
+              <div
+                class="retrigger-button"
+                data-testid="retrigger-jobs-button"
+                role="cell"
+              >
+                <div
+                  class="retrigger-button-container"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
+                    tabindex="0"
+                    title="retrigger jobs"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                      data-testid="RefreshOutlinedIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                      />
+                    </svg>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div
+              class="expand-button cell"
+              role="cell"
+            >
+              <div
+                class="expand-button-container"
+                data-testid="expand-revision-button"
+              >
+                <button
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  title="expand this row"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                    data-testid="ExpandMoreIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="revisionRow f1x1c13s fp4ugv1"
+            role="row"
+          >
+            <div
+              class="platform cell"
+              role="cell"
+            >
+              <div
+                class="platform-container"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 30 30"
+                >
+                  <g
+                    id="SVGRepo_bgCarrier"
+                    stroke-width="0"
+                  />
+                  <g
+                    id="SVGRepo_tracerCarrier"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <g
+                    id="SVGRepo_iconCarrier"
+                  >
+                     
+                    <title>
+                      windows
+                    </title>
+                     
+                    <path
+                      d="M13.875 7.719l-2.281 7.906s-2.594-1.813-4.5-1.625c-1.875 0.188-4.406 1.125-4.406 1.125l2.313-7.969s4.781-2.563 8.875 0.563zM12.813 16.375l2.281-7.844c0.688 0.469 1.906 1.313 3.875 1.563 1.969 0.219 5.031-1.031 5.031-1.031l-2.281 7.906c-0.344 0.125-1.781 0.938-4.406 1.094-2.656 0.156-4.5-1.688-4.5-1.688zM0 24.469l2.281-7.969s2.563-1.188 4.719-1.031c2.125 0.125 3.844 1.313 4.188 1.594l-2.281 7.969s-2.625-1.719-4.438-1.563-3.406 0.469-4.469 1zM10.125 25.719l2.281-7.906s2.438 1.594 4.031 1.531c1.594-0.031 2.688-0.125 4.844-0.969h0.031c-0.156 0.406-2.281 7.844-2.281 7.844s-2.5 1.188-4.813 1.063c-2.281-0.094-3.656-1.406-4.094-1.563z"
+                    />
+                     
+                  </g>
+                </svg>
+                <span>
+                  Windows
+                </span>
+              </div>
+            </div>
+            <div
+              class="base-value cell"
+              role="cell"
+            >
+               
+              643.54
+               
+              ms
+               
+            </div>
+            <div
+              class="comparison-sign cell"
+              role="cell"
+            >
+              &gt;
+            </div>
+            <div
+              class="new-value cell"
+              role="cell"
+            >
+               
+              628.09
+               
+              ms
+            </div>
+            <div
+              class="status cell"
+              role="cell"
+            >
+               
+              -
+               
+            </div>
+            <div
+              class="delta cell"
+              role="cell"
+            >
+               
+              -2.4
+               %
+               
+            </div>
+            <div
+              class="confidence cell"
+              role="cell"
+            >
+               
+              High
+               
+            </div>
+            <div
+              class="total-runs cell"
+              role="cell"
+            >
+              <span>
+                B:
+              </span>
+              <strong>
+                 
+                1
+                 
+              </strong>
+               
+              <span>
+                 N: 
+              </span>
+              <strong>
+                 
+                1
+                 
+              </strong>
+            </div>
+            <div
+              class="row-buttons cell"
+            >
+              <div
+                class="graph"
+                role="cell"
+              >
+                <div
+                  class="graph-link-button-container"
+                >
+                  <a
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
+                    href="https://treeherder.mozilla.org/perfherder/graphs?highlightedRevisions=1e32960788ea&highlightedRevisions=6a1f133815a1&series=mozilla-central%2C3a6d4b6178678c3113c980b378bb83b2629926a0%2C1%2C1&timerange=5184000"
+                    tabindex="0"
+                    target="_blank"
+                    title="open the evolution graph for this job in treeherder"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                      data-testid="TimelineIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
+                      />
+                    </svg>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </div>
+              </div>
+              <div
+                class="download"
+                role="cell"
+              >
+                <div
+                  class="download-button-container"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
+                    tabindex="0"
+                    title="open the performance profile for this job"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                      data-testid="FileDownloadOutlinedIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
+                      />
+                    </svg>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
+              </div>
+              <div
+                class="retrigger-button"
+                data-testid="retrigger-jobs-button"
+                role="cell"
+              >
+                <div
+                  class="retrigger-button-container"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
+                    tabindex="0"
+                    title="retrigger jobs"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                      data-testid="RefreshOutlinedIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                      />
+                    </svg>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div
+              class="expand-button cell"
+              role="cell"
+            >
+              <div
+                class="expand-button-container"
+                data-testid="expand-revision-button"
+              >
+                <button
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  title="expand this row"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                    data-testid="ExpandMoreIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="revisionRow f1x1c13s fp4ugv1"
+            role="row"
+          >
+            <div
+              class="platform cell"
+              role="cell"
+            >
+              <div
+                class="platform-container"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 30 30"
+                >
+                  <g
+                    id="SVGRepo_bgCarrier"
+                    stroke-width="0"
+                  />
+                  <g
+                    id="SVGRepo_tracerCarrier"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                  <g
+                    id="SVGRepo_iconCarrier"
+                  >
+                     
+                    <title>
+                      windows
+                    </title>
+                     
+                    <path
+                      d="M13.875 7.719l-2.281 7.906s-2.594-1.813-4.5-1.625c-1.875 0.188-4.406 1.125-4.406 1.125l2.313-7.969s4.781-2.563 8.875 0.563zM12.813 16.375l2.281-7.844c0.688 0.469 1.906 1.313 3.875 1.563 1.969 0.219 5.031-1.031 5.031-1.031l-2.281 7.906c-0.344 0.125-1.781 0.938-4.406 1.094-2.656 0.156-4.5-1.688-4.5-1.688zM0 24.469l2.281-7.969s2.563-1.188 4.719-1.031c2.125 0.125 3.844 1.313 4.188 1.594l-2.281 7.969s-2.625-1.719-4.438-1.563-3.406 0.469-4.469 1zM10.125 25.719l2.281-7.906s2.438 1.594 4.031 1.531c1.594-0.031 2.688-0.125 4.844-0.969h0.031c-0.156 0.406-2.281 7.844-2.281 7.844s-2.5 1.188-4.813 1.063c-2.281-0.094-3.656-1.406-4.094-1.563z"
+                    />
+                     
+                  </g>
+                </svg>
+                <span>
+                  Windows
+                </span>
+              </div>
+            </div>
+            <div
+              class="base-value cell"
+              role="cell"
+            >
+               
+              643.54
+               
+              ms
+               
+            </div>
+            <div
+              class="comparison-sign cell"
+              role="cell"
+            >
+              &gt;
+            </div>
+            <div
+              class="new-value cell"
+              role="cell"
+            >
+               
+              628.09
+               
+              ms
+            </div>
+            <div
+              class="status cell"
+              role="cell"
+            >
+               
+              -
+               
+            </div>
+            <div
+              class="delta cell"
+              role="cell"
+            >
+               
+              -2.4
+               %
+               
+            </div>
+            <div
+              class="confidence cell"
+              role="cell"
+            >
+               
+               
+            </div>
+            <div
+              class="total-runs cell"
+              role="cell"
+            >
+              <span>
+                B:
+              </span>
+              <strong>
+                 
+                1
+                 
+              </strong>
+               
+              <span>
+                 N: 
+              </span>
+              <strong>
+                 
+                1
+                 
+              </strong>
+            </div>
+            <div
+              class="row-buttons cell"
+            >
+              <div
+                class="graph"
+                role="cell"
+              >
+                <div
+                  class="graph-link-button-container"
+                >
+                  <a
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
+                    href="https://treeherder.mozilla.org/perfherder/graphs?highlightedRevisions=1e32960788ea&highlightedRevisions=6a1f133815a1&series=mozilla-central%2C3a6d4b6178678c3113c980b378bb83b2629926a0%2C1%2C1&timerange=5184000"
+                    tabindex="0"
+                    target="_blank"
+                    title="open the evolution graph for this job in treeherder"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                      data-testid="TimelineIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
+                      />
+                    </svg>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </div>
+              </div>
+              <div
+                class="download"
+                role="cell"
+              >
+                <div
+                  class="download-button-container"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
+                    tabindex="0"
+                    title="open the performance profile for this job"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                      data-testid="FileDownloadOutlinedIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3h-2zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5 5-5z"
+                      />
+                    </svg>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
+              </div>
+              <div
+                class="retrigger-button"
+                data-testid="retrigger-jobs-button"
+                role="cell"
+              >
+                <div
+                  class="retrigger-button-container"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
+                    tabindex="0"
+                    title="retrigger jobs"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                      data-testid="RefreshOutlinedIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                      />
+                    </svg>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div
+              class="expand-button cell"
+              role="cell"
+            >
+              <div
+                class="expand-button-container"
+                data-testid="expand-revision-button"
+              >
+                <button
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  title="expand this row"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                    data-testid="ExpandMoreIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -988,9 +988,6 @@ exports[`Results Table Should match snapshot 1`] = `
             >
               opt
             </span>
-            <span
-              class="f1rpr1m5"
-            />
           </div>
         </div>
         <div>

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -947,6 +947,53 @@ exports[`Results Table Should match snapshot 1`] = `
               </div>
             </div>
           </div>
+        </div>
+      </div>
+      <div
+        class="f1otqxop"
+        role="rowgroup"
+      >
+        <div
+          class="fx9q187"
+        >
+          <div
+            class="f897l9y"
+          >
+            <strong>
+              <a
+                aria-label="link to suite documentation"
+                class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-g8z9fn-MuiTypography-root-MuiLink-root"
+                href="https://firefox-source-docs.mozilla.org/testing/perfdocs/talos.html#a11yr"
+                target="_blank"
+              >
+                a11yr
+              </a>
+               dhtml.html
+            </strong>
+             
+            <a
+              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
+              href="https://treeherder.mozilla.org/jobs?repo=mozilla-central&revision=spam"
+              target="_blank"
+              title="open treeherder view for spam"
+            >
+              spam
+            </a>
+          </div>
+          <div
+            class="f1oxa67k"
+          >
+            <span
+              class="f1rpr1m5"
+            >
+              opt
+            </span>
+            <span
+              class="f1rpr1m5"
+            />
+          </div>
+        </div>
+        <div>
           <div
             class="revisionRow f1x1c13s fp4ugv1"
             role="row"

--- a/src/__tests__/Search/SelectedRevision.test.tsx
+++ b/src/__tests__/Search/SelectedRevision.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-disabled-tests */
 import userEvent from '@testing-library/user-event';
 
 import SearchView from '../../components/Search/SearchView';

--- a/src/components/CompareResults/RevisionHeader.tsx
+++ b/src/components/CompareResults/RevisionHeader.tsx
@@ -84,7 +84,7 @@ function createTitle(
 }
 
 function getExtraOptions(extraOptions: string) {
-  return extraOptions.split(' ');
+  return extraOptions ? extraOptions.split(' ') : [];
 }
 
 function RevisionHeader(props: RevisionHeaderProps) {


### PR DESCRIPTION
The problem is that `"".split(" ")` produces an array with one empty string. As a result we were adding an empty box.

When I wanted to add a test I realized that the test for ResultsTable was incorrect and was always generating an empty table. I fixed that as well. I ordered the commits so that the changes are well visible.

I also added 2 commits to change the eslint configuration:
1. so that eslint warns us about unused "disable" directives. This is useful for cleanup.
2. so that eslint doesn't warn anymore when somebody uses the "not null assertion" (the `!`) in tests only.

I reconize that this makes a PR with several quite unrelated things in it, I hope that the fact they're separated in several commits makes it OK enough. I did it this way because I used the eslint changes in the following commits.

[Deploy preview](https://deploy-preview-678--mozilla-perfcompare.netlify.app/compare-results?baseRev=ddaa8beed4f649a50d0d6b8b67b373487e46dd56&baseRepo=mozilla-central&newRev=55142668d01174ee804cdee8c877f6d0212fd421&newRepo=mozilla-central&framework=12) / [Beta branch](https://beta--mozilla-perfcompare.netlify.app/compare-results?baseRev=ddaa8beed4f649a50d0d6b8b67b373487e46dd56&baseRepo=mozilla-central&newRev=55142668d01174ee804cdee8c877f6d0212fd421&newRepo=mozilla-central&framework=12)

Before:
![image](https://github.com/mozilla/perfcompare/assets/454175/95396c99-7bb4-4d87-bc29-56afeb7853f9)

After:
![image](https://github.com/mozilla/perfcompare/assets/454175/419639e3-bc1f-425f-9c54-8680a67f5910)
