### PR TITLE
Move around some code so that the token retrieval is more self-contained

### DIFF
--- a/src/__tests__/TaskclusterAuth/TaskclusterCallback.test.tsx
+++ b/src/__tests__/TaskclusterAuth/TaskclusterCallback.test.tsx
@@ -36,6 +36,9 @@ describe('Taskcluster Callback', () => {
   });
 
   it('should fetch credentials with token bearer', async () => {
+    // Make window.close a noop so that the component can be rendered after the
+    // authentication process.
+    jest.spyOn(window, 'close').mockImplementation(() => {});
     (window.fetch as FetchMockSandbox).post(
       'begin:https://firefox-ci-tc.services.mozilla.com/login/oauth/token',
       {
@@ -90,5 +93,7 @@ describe('Taskcluster Callback', () => {
     expect(localStorage.userCredentials).toBe(
       '{"https://firefox-ci-tc.services.mozilla.com":{"expires":"2024-05-20T14:07:40.828Z","credentials":{"clientId":"mozilla-auth0/ad|Mozilla-LDAP|ldapuser/perfcompare-localhost-3000-client-OCvzh5","accessToken":"jQWJVQdeRceT-YymPwTWagPh2PwJr0RmmZyL1uAfMSWg"}}}',
     );
+
+    expect(window.close).toHaveBeenCalled();
   });
 });

--- a/src/components/CompareResults/RetriggerButton.tsx
+++ b/src/components/CompareResults/RetriggerButton.tsx
@@ -1,33 +1,15 @@
 import RefreshOutlinedIcon from '@mui/icons-material/RefreshOutlined';
 import { IconButton } from '@mui/material';
 
-import { checkTaskclusterCredentials } from '../../logic/taskcluster';
+import { getTaskclusterAccessToken } from '../../logic/taskcluster';
 import { Strings } from '../../resources/Strings';
-
-function waitForStorageEvent(): Promise<void> {
-  return new Promise((resolve) => {
-    window.addEventListener(
-      'storage',
-      function storageListener(event: StorageEvent) {
-        // TODO change userCredentials with userTokens
-        // when the userCredentials fetch is moved here
-        if (event.key === 'userCredentials') {
-          resolve();
-          window.removeEventListener('storage', storageListener);
-        }
-      },
-    );
-  });
-}
-
-async function checkLocalStorage() {
-  await waitForStorageEvent();
-}
 
 function RetriggerButton() {
   const onOpenModal = async () => {
-    checkTaskclusterCredentials();
-    await checkLocalStorage();
+    const accessToken = await getTaskclusterAccessToken();
+
+    // TODO do something with accessToken
+    console.log('We have an access token!', accessToken);
   };
 
   // TODO implement modal

--- a/src/components/CompareResults/RetriggerButton.tsx
+++ b/src/components/CompareResults/RetriggerButton.tsx
@@ -9,13 +9,13 @@ import { Strings } from '../../resources/Strings';
 
 function RetriggerButton() {
   const onOpenModal = async () => {
-    let accessToken = getTaskclusterCredentials();
-    if (!accessToken) {
+    let credentials = getTaskclusterCredentials();
+    if (!credentials) {
       await signInIntoTaskcluster();
-      accessToken = getTaskclusterCredentials();
+      credentials = getTaskclusterCredentials();
     }
 
-    console.log('We have an access token!', accessToken);
+    console.log('We have an access token!', credentials);
   };
 
   // TODO implement modal

--- a/src/components/CompareResults/RetriggerButton.tsx
+++ b/src/components/CompareResults/RetriggerButton.tsx
@@ -1,14 +1,20 @@
 import RefreshOutlinedIcon from '@mui/icons-material/RefreshOutlined';
 import { IconButton } from '@mui/material';
 
-import { getTaskclusterAccessToken } from '../../logic/taskcluster';
+import {
+  getTaskclusterCredentials,
+  signInIntoTaskcluster,
+} from '../../logic/taskcluster';
 import { Strings } from '../../resources/Strings';
 
 function RetriggerButton() {
   const onOpenModal = async () => {
-    const accessToken = await getTaskclusterAccessToken();
+    let accessToken = getTaskclusterCredentials();
+    if (!accessToken) {
+      await signInIntoTaskcluster();
+      accessToken = getTaskclusterCredentials();
+    }
 
-    // TODO do something with accessToken
     console.log('We have an access token!', accessToken);
   };
 

--- a/src/components/TaskclusterAuth/loader.ts
+++ b/src/components/TaskclusterAuth/loader.ts
@@ -42,6 +42,10 @@ export async function loader({ request }: { request: Request }) {
 
   storeUserCredentials(rootUrl, userCredentials);
 
+  window.close();
+
+  // TODO Use defer values as explained in https://reactrouter.com/en/main/guides/deferred
+  // so that the component displays while retrieving all the data
   return userCredentials;
 }
 

--- a/src/logic/credentials-storage.ts
+++ b/src/logic/credentials-storage.ts
@@ -43,10 +43,26 @@ export function retrieveUserCredentials(
 ): UserCredentials | null {
   const allCredentialsAsString = localStorage.userCredentials as string;
 
-  if (allCredentialsAsString) return null;
+  if (!allCredentialsAsString) return null;
 
   const allCredentials = JSON.parse(
     allCredentialsAsString,
   ) as UserCredentialsDictionary;
   return allCredentials[rootUrl] ?? null;
+}
+
+export function waitForStorageEvent(): Promise<void> {
+  return new Promise((resolve) => {
+    window.addEventListener(
+      'storage',
+      function storageListener(event: StorageEvent) {
+        // TODO change userCredentials with userTokens
+        // when the userCredentials fetch is moved here
+        if (event.key === 'userCredentials') {
+          resolve();
+          window.removeEventListener('storage', storageListener);
+        }
+      },
+    );
+  });
 }

--- a/src/logic/taskcluster.ts
+++ b/src/logic/taskcluster.ts
@@ -66,9 +66,8 @@ const openTaskclusterAuthenticationPage = (tcParams: TaskclusterParams) => {
 };
 
 // This function returns the stored credentials in localStorage.
-export const getTaskclusterCredentials = (
-  taskclusterParams: TaskclusterParams,
-) => {
+export const getTaskclusterCredentials = () => {
+  const taskclusterParams = getTaskclusterParams();
   const locationOrigin = getLocationOrigin();
 
   if (!taskclusterParams.clientId) {
@@ -77,25 +76,16 @@ export const getTaskclusterCredentials = (
   }
 
   const credentials = retrieveUserCredentials(taskclusterParams.url);
+  // TOOD Check if it is expired, return false if they are.
   return credentials;
 };
 
-// This returns the taskcluster access token, either stored or possibly opening
-// a new tab for authentication.
-export async function getTaskclusterAccessToken() {
+// This function opens a new page to the taskcluster authentication, and waits
+// for the user credentials to be stored in localStorage.
+export async function signInIntoTaskcluster() {
   const taskclusterParams = getTaskclusterParams();
-  let accessToken = getTaskclusterCredentials(taskclusterParams);
-  if (!accessToken) {
-    openTaskclusterAuthenticationPage(taskclusterParams);
-    await waitForStorageEvent();
-    accessToken = getTaskclusterCredentials(taskclusterParams);
-
-    if (!accessToken) {
-      throw new Error("Couldn't retrieve an access token for taskcluster");
-    }
-  }
-
-  return accessToken;
+  openTaskclusterAuthenticationPage(taskclusterParams);
+  await waitForStorageEvent();
 }
 
 async function checkTaskclusterResponse(response: Response) {


### PR DESCRIPTION
I moved around some code to make the authentication process more self contained and easier to work with.
Now the call to `getTaskclusterAccessToken` will always return an access token: sometimes it will return the one stored in localStorage, sometimes it will trigger the taskcluster authentication.

I added a few TODO to be done in future PRs too.