### PR TITLE
moved typestyle calls outside the component

### DIFF
--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -25,6 +25,166 @@ import type { LoaderReturnValue as OverTimeLoaderReturnValue } from './overTimeL
 import RetriggerButton from './Retrigger/RetriggerButton';
 import RevisionRowExpandable from './RevisionRowExpandable';
 
+const revisionsRow = {
+  borderRadius: '4px 0px 0px 4px',
+  display: 'grid',
+  margin: `${Spacing.Small}px 0px`,
+  // Should be kept in sync with the gridTemplateColumns from TableHeader
+  gridTemplateColumns: '2fr 1fr 0.2fr 1fr 1fr 1fr 1fr 1fr 2fr 0.2fr',
+};
+
+const typography = {
+  fontFamily: 'SF Pro',
+  fontStyle: 'normal',
+  fontWeight: 400,
+  fontSize: '13px',
+  lineHeight: '16px',
+};
+
+const stylesLight = {
+  revisionRow: style({
+    ...revisionsRow,
+    $nest: {
+      '.base-value': {
+        backgroundColor: Colors.Background200,
+      },
+      '.cell': {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      },
+      '.confidence': {
+        backgroundColor: Colors.Background200,
+      },
+      '.comparison-sign': {
+        backgroundColor: Colors.Background200,
+      },
+      '.delta': {
+        backgroundColor: Colors.Background200,
+      },
+      '.expand-button-container': {
+        justifyContent: 'right',
+      },
+      '.new-value': {
+        backgroundColor: Colors.Background200,
+      },
+      '.platform': {
+        backgroundColor: Colors.Background200,
+        borderRadius: '4px 0 0 4px',
+        paddingLeft: Spacing.xLarge,
+        justifyContent: 'left',
+      },
+      '.platform-container': {
+        alignItems: 'flex-end',
+        backgroundColor: Colors.Background200,
+        display: 'flex',
+      },
+      '.retrigger-button': {
+        backgroundColor: Colors.Background200,
+        borderRadius: '0px 4px 4px 0px',
+        cursor: 'not-allowed',
+      },
+      '.status': {
+        backgroundColor: Colors.Background200,
+        justifyContent: 'center',
+      },
+      '.total-runs': {
+        backgroundColor: Colors.Background200,
+      },
+      '.row-buttons': {
+        backgroundColor: Colors.Background200,
+        borderRadius: '0px 4px 4px 0px',
+        display: 'flex',
+        justifyContent: 'flex-end',
+        $nest: {
+          '.download': {
+            cursor: 'not-allowed',
+          },
+        },
+      },
+      '.expand-button': {
+        backgroundColor: Colors.Background300,
+      },
+    },
+  }),
+  typography: style({
+    ...typography,
+  }),
+};
+
+const stylesDark = {
+  revisionRow: style({
+    ...revisionsRow,
+    $nest: {
+      '.base-value': {
+        backgroundColor: Colors.Background200Dark,
+      },
+      '.cell': {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      },
+      '.confidence': {
+        backgroundColor: Colors.Background200Dark,
+      },
+      '.comparison-sign': {
+        backgroundColor: Colors.Background200Dark,
+      },
+      '.delta': {
+        backgroundColor: Colors.Background200Dark,
+      },
+      '.expand-button-container': {
+        justifyContent: 'right',
+      },
+      '.new-value': {
+        backgroundColor: Colors.Background200Dark,
+      },
+      '.platform': {
+        backgroundColor: Colors.Background200Dark,
+        borderRadius: '4px 0 0 4px',
+        paddingLeft: Spacing.xLarge,
+        justifyContent: 'left',
+      },
+      '.platform-container': {
+        alignItems: 'flex-end',
+        backgroundColor: Colors.Background200Dark,
+        display: 'flex',
+      },
+      '.retrigger-button': {
+        backgroundColor: Colors.Background200Dark,
+        borderRadius: '0px 4px 4px 0px',
+        cursor: 'not-allowed',
+      },
+      '.status': {
+        backgroundColor: Colors.Background200Dark,
+        justifyContent: 'center',
+      },
+      '.total-runs': {
+        backgroundColor: Colors.Background200Dark,
+      },
+      '.row-buttons': {
+        backgroundColor: Colors.Background200Dark,
+        borderRadius: '0px 4px 4px 0px',
+        display: 'flex',
+        justifyContent: 'flex-end',
+        $nest: {
+          '.download': {
+            cursor: 'not-allowed',
+          },
+        },
+      },
+      '.expand-button': {
+        backgroundColor: Colors.Background100Dark,
+      },
+    },
+  }),
+  typography: style({
+    ...typography,
+  }),
+};
+
+const stylesCard = ExpandableRowStyles();
+
 function determineStatus(improvement: boolean, regression: boolean) {
   if (improvement) return 'Improvement';
   if (regression) return 'Regression';
@@ -114,94 +274,10 @@ function RevisionRow(props: RevisionRowProps) {
           (loaderData as OverTimeLoaderReturnValue).intervalValue,
         );
 
-  const stylesCard = ExpandableRowStyles();
-
   const themeMode = useAppSelector((state) => state.theme.mode);
-  const expandButtonColor =
-    themeMode == 'light' ? Colors.Background300 : Colors.Background100Dark;
-  const themeColor200 =
-    themeMode == 'light' ? Colors.Background200 : Colors.Background200Dark;
 
-  const styles = {
-    revisionRow: style({
-      borderRadius: '4px 0px 0px 4px',
-      display: 'grid',
-      margin: `${Spacing.Small}px 0px`,
-      // Should be kept in sync with the gridTemplateColumns from TableHeader
-      gridTemplateColumns: '2fr 1fr 0.2fr 1fr 1fr 1fr 1fr 1fr 2fr 0.2fr',
-      $nest: {
-        '.base-value': {
-          backgroundColor: themeColor200,
-        },
-        '.cell': {
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        },
-        '.confidence': {
-          backgroundColor: themeColor200,
-        },
-        '.comparison-sign': {
-          backgroundColor: themeColor200,
-        },
-        '.delta': {
-          backgroundColor: themeColor200,
-        },
-        '.expand-button-container': {
-          justifyContent: 'right',
-        },
-        '.new-value': {
-          backgroundColor: themeColor200,
-        },
-        '.platform': {
-          backgroundColor: themeColor200,
-          borderRadius: '4px 0 0 4px',
-          paddingLeft: Spacing.xLarge,
-          justifyContent: 'left',
-        },
-        '.platform-container': {
-          alignItems: 'flex-end',
-          backgroundColor: themeColor200,
-          display: 'flex',
-        },
-        '.retrigger-button': {
-          backgroundColor: themeColor200,
-          borderRadius: '0px 4px 4px 0px',
-          cursor: 'not-allowed',
-        },
-        '.status': {
-          backgroundColor: themeColor200,
-          justifyContent: 'center',
-        },
-        '.total-runs': {
-          backgroundColor: themeColor200,
-        },
+  const styles = themeMode === 'light' ? stylesLight : stylesDark;
 
-        '.row-buttons': {
-          backgroundColor: themeColor200,
-          borderRadius: '0px 4px 4px 0px',
-          display: 'flex',
-          justifyContent: 'flex-end',
-          $nest: {
-            '.download': {
-              cursor: 'not-allowed',
-            },
-          },
-        },
-
-        '.expand-button': {
-          backgroundColor: expandButtonColor,
-        },
-      },
-    }),
-    typography: style({
-      fontFamily: 'SF Pro',
-      fontStyle: 'normal',
-      fontWeight: 400,
-      fontSize: '13px',
-      lineHeight: '16px',
-    }),
-  };
   return (
     <>
       <div

--- a/src/components/CompareResults/TableContent.tsx
+++ b/src/components/CompareResults/TableContent.tsx
@@ -5,14 +5,15 @@ import type { CompareResultsItem, RevisionsHeader } from '../../types/state';
 import RevisionHeader from './RevisionHeader';
 import RevisionRow from './RevisionRow';
 
+const styles = {
+  tableBody: style({
+    marginTop: Spacing.Large,
+  }),
+};
+
 function TableContent(props: TableContentProps) {
   const { results, header, identifier } = props;
 
-  const styles = {
-    tableBody: style({
-      marginTop: Spacing.Large,
-    }),
-  };
   return (
     <div className={styles.tableBody} role='rowgroup'>
       <RevisionHeader header={header} />


### PR DESCRIPTION
Ran the profiler and it reduces jank

This PR closes the following issue:[The typestyle calls in the RevisionRow are too costly]( https://mozilla-hub.atlassian.net/browse/PCF-448)

Profiles: [beta](https://share.firefox.dev/46bM2lb) / [deploy preview](https://share.firefox.dev/3y28fFM)

To test:

1.) open PR deploy link: https://deploy-preview-689--mozilla-perfcompare.netlify.app/ 
2.) Select a base revision and a new revision(s) from the `Compare with a base` component
3.) Select the browsertime testing framework - heavy testing framework where you can see the most change in performance
3.) Click the `Compare` button
4.) The results page should perform better re loading vs the most current beta link: https://beta--mozilla-perfcompare.netlify.app/) / [deploy preview](https://profiler.firefox.com/from-browser/calltree/?globalTrackOrder=0wx6&hiddenGlobalTracks=1wx5&hiddenLocalTracksByPid=2792-1wcewx9~22443-0~38509-0~2816-0&thread=yg&v=10)