### PR TITLE
Add some spacing between total runs and explain the letters with a title

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -204,7 +204,7 @@ exports[`Results View The table should match snapshot and other elements should 
     </div>
     <div>
       <div
-        class="revisionRow f1x1c13s fp4ugv1"
+        class="revisionRow fib0xwf fp4ugv1"
         role="row"
       >
         <div
@@ -285,22 +285,25 @@ exports[`Results View The table should match snapshot and other elements should 
           role="cell"
         >
           <span>
-            B:
+            <span
+              title="Base runs"
+            >
+              B:
+            </span>
+            <strong>
+              1
+            </strong>
           </span>
-          <strong>
-             
-            1
-             
-          </strong>
-           
           <span>
-             N: 
+            <span
+              title="New runs"
+            >
+              N:
+            </span>
+            <strong>
+              1
+            </strong>
           </span>
-          <strong>
-             
-            1
-             
-          </strong>
         </div>
         <div
           class="row-buttons cell"
@@ -431,7 +434,7 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="revisionRow f1x1c13s fp4ugv1"
+        class="revisionRow fib0xwf fp4ugv1"
         role="row"
       >
         <div
@@ -511,22 +514,25 @@ exports[`Results View The table should match snapshot and other elements should 
           role="cell"
         >
           <span>
-            B:
+            <span
+              title="Base runs"
+            >
+              B:
+            </span>
+            <strong>
+              1
+            </strong>
           </span>
-          <strong>
-             
-            1
-             
-          </strong>
-           
           <span>
-             N: 
+            <span
+              title="New runs"
+            >
+              N:
+            </span>
+            <strong>
+              1
+            </strong>
           </span>
-          <strong>
-             
-            1
-             
-          </strong>
         </div>
         <div
           class="row-buttons cell"
@@ -657,7 +663,7 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="revisionRow f1x1c13s fp4ugv1"
+        class="revisionRow fib0xwf fp4ugv1"
         role="row"
       >
         <div
@@ -738,22 +744,25 @@ exports[`Results View The table should match snapshot and other elements should 
           role="cell"
         >
           <span>
-            B:
+            <span
+              title="Base runs"
+            >
+              B:
+            </span>
+            <strong>
+              1
+            </strong>
           </span>
-          <strong>
-             
-            1
-             
-          </strong>
-           
           <span>
-             N: 
+            <span
+              title="New runs"
+            >
+              N:
+            </span>
+            <strong>
+              1
+            </strong>
           </span>
-          <strong>
-             
-            1
-             
-          </strong>
         </div>
         <div
           class="row-buttons cell"
@@ -884,7 +893,7 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="revisionRow f1x1c13s fp4ugv1"
+        class="revisionRow fib0xwf fp4ugv1"
         role="row"
       >
         <div
@@ -964,22 +973,25 @@ exports[`Results View The table should match snapshot and other elements should 
           role="cell"
         >
           <span>
-            B:
+            <span
+              title="Base runs"
+            >
+              B:
+            </span>
+            <strong>
+              1
+            </strong>
           </span>
-          <strong>
-             
-            1
-             
-          </strong>
-           
           <span>
-             N: 
+            <span
+              title="New runs"
+            >
+              N:
+            </span>
+            <strong>
+              1
+            </strong>
           </span>
-          <strong>
-             
-            1
-             
-          </strong>
         </div>
         <div
           class="row-buttons cell"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -1145,7 +1145,7 @@ exports[`Results Table Should match snapshot 1`] = `
                 </div>
                 <div>
                   <div
-                    class="revisionRow f1x1c13s fp4ugv1"
+                    class="revisionRow fib0xwf fp4ugv1"
                     role="row"
                   >
                     <div
@@ -1226,22 +1226,25 @@ exports[`Results Table Should match snapshot 1`] = `
                       role="cell"
                     >
                       <span>
-                        B:
+                        <span
+                          title="Base runs"
+                        >
+                          B:
+                        </span>
+                        <strong>
+                          1
+                        </strong>
                       </span>
-                      <strong>
-                         
-                        1
-                         
-                      </strong>
-                       
                       <span>
-                         N: 
+                        <span
+                          title="New runs"
+                        >
+                          N:
+                        </span>
+                        <strong>
+                          1
+                        </strong>
                       </span>
-                      <strong>
-                         
-                        1
-                         
-                      </strong>
                     </div>
                     <div
                       class="row-buttons cell"
@@ -1372,7 +1375,7 @@ exports[`Results Table Should match snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="revisionRow f1x1c13s fp4ugv1"
+                    class="revisionRow fib0xwf fp4ugv1"
                     role="row"
                   >
                     <div
@@ -1452,22 +1455,25 @@ exports[`Results Table Should match snapshot 1`] = `
                       role="cell"
                     >
                       <span>
-                        B:
+                        <span
+                          title="Base runs"
+                        >
+                          B:
+                        </span>
+                        <strong>
+                          1
+                        </strong>
                       </span>
-                      <strong>
-                         
-                        1
-                         
-                      </strong>
-                       
                       <span>
-                         N: 
+                        <span
+                          title="New runs"
+                        >
+                          N:
+                        </span>
+                        <strong>
+                          1
+                        </strong>
                       </span>
-                      <strong>
-                         
-                        1
-                         
-                      </strong>
                     </div>
                     <div
                       class="row-buttons cell"
@@ -1598,7 +1604,7 @@ exports[`Results Table Should match snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="revisionRow f1x1c13s fp4ugv1"
+                    class="revisionRow fib0xwf fp4ugv1"
                     role="row"
                   >
                     <div
@@ -1679,22 +1685,25 @@ exports[`Results Table Should match snapshot 1`] = `
                       role="cell"
                     >
                       <span>
-                        B:
+                        <span
+                          title="Base runs"
+                        >
+                          B:
+                        </span>
+                        <strong>
+                          1
+                        </strong>
                       </span>
-                      <strong>
-                         
-                        1
-                         
-                      </strong>
-                       
                       <span>
-                         N: 
+                        <span
+                          title="New runs"
+                        >
+                          N:
+                        </span>
+                        <strong>
+                          1
+                        </strong>
                       </span>
-                      <strong>
-                         
-                        1
-                         
-                      </strong>
                     </div>
                     <div
                       class="row-buttons cell"
@@ -1869,7 +1878,7 @@ exports[`Results Table Should match snapshot 1`] = `
                 </div>
                 <div>
                   <div
-                    class="revisionRow f1x1c13s fp4ugv1"
+                    class="revisionRow fib0xwf fp4ugv1"
                     role="row"
                   >
                     <div
@@ -1949,22 +1958,25 @@ exports[`Results Table Should match snapshot 1`] = `
                       role="cell"
                     >
                       <span>
-                        B:
+                        <span
+                          title="Base runs"
+                        >
+                          B:
+                        </span>
+                        <strong>
+                          1
+                        </strong>
                       </span>
-                      <strong>
-                         
-                        1
-                         
-                      </strong>
-                       
                       <span>
-                         N: 
+                        <span
+                          title="New runs"
+                        >
+                          N:
+                        </span>
+                        <strong>
+                          1
+                        </strong>
                       </span>
-                      <strong>
-                         
-                        1
-                         
-                      </strong>
                     </div>
                     <div
                       class="row-buttons cell"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -402,7 +402,7 @@ exports[`Results View The table should match snapshot and other elements should 
     </div>
     <div>
       <div
-        class="revisionRow f1x1c13s fp4ugv1"
+        class="revisionRow fib0xwf fp4ugv1"
         role="row"
       >
         <div
@@ -483,22 +483,25 @@ exports[`Results View The table should match snapshot and other elements should 
           role="cell"
         >
           <span>
-            B:
+            <span
+              title="Base runs"
+            >
+              B:
+            </span>
+            <strong>
+              1
+            </strong>
           </span>
-          <strong>
-             
-            1
-             
-          </strong>
-           
           <span>
-             N: 
+            <span
+              title="New runs"
+            >
+              N:
+            </span>
+            <strong>
+              1
+            </strong>
           </span>
-          <strong>
-             
-            1
-             
-          </strong>
         </div>
         <div
           class="row-buttons cell"
@@ -629,7 +632,7 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="revisionRow f1x1c13s fp4ugv1"
+        class="revisionRow fib0xwf fp4ugv1"
         role="row"
       >
         <div
@@ -709,22 +712,25 @@ exports[`Results View The table should match snapshot and other elements should 
           role="cell"
         >
           <span>
-            B:
+            <span
+              title="Base runs"
+            >
+              B:
+            </span>
+            <strong>
+              1
+            </strong>
           </span>
-          <strong>
-             
-            1
-             
-          </strong>
-           
           <span>
-             N: 
+            <span
+              title="New runs"
+            >
+              N:
+            </span>
+            <strong>
+              1
+            </strong>
           </span>
-          <strong>
-             
-            1
-             
-          </strong>
         </div>
         <div
           class="row-buttons cell"
@@ -855,7 +861,7 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="revisionRow f1x1c13s fp4ugv1"
+        class="revisionRow fib0xwf fp4ugv1"
         role="row"
       >
         <div
@@ -936,22 +942,25 @@ exports[`Results View The table should match snapshot and other elements should 
           role="cell"
         >
           <span>
-            B:
+            <span
+              title="Base runs"
+            >
+              B:
+            </span>
+            <strong>
+              1
+            </strong>
           </span>
-          <strong>
-             
-            1
-             
-          </strong>
-           
           <span>
-             N: 
+            <span
+              title="New runs"
+            >
+              N:
+            </span>
+            <strong>
+              1
+            </strong>
           </span>
-          <strong>
-             
-            1
-             
-          </strong>
         </div>
         <div
           class="row-buttons cell"
@@ -1082,7 +1091,7 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="revisionRow f1x1c13s fp4ugv1"
+        class="revisionRow fib0xwf fp4ugv1"
         role="row"
       >
         <div
@@ -1162,22 +1171,25 @@ exports[`Results View The table should match snapshot and other elements should 
           role="cell"
         >
           <span>
-            B:
+            <span
+              title="Base runs"
+            >
+              B:
+            </span>
+            <strong>
+              1
+            </strong>
           </span>
-          <strong>
-             
-            1
-             
-          </strong>
-           
           <span>
-             N: 
+            <span
+              title="New runs"
+            >
+              N:
+            </span>
+            <strong>
+              1
+            </strong>
           </span>
-          <strong>
-             
-            1
-             
-          </strong>
         </div>
         <div
           class="row-buttons cell"

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -90,6 +90,7 @@ const stylesLight = {
       },
       '.total-runs': {
         backgroundColor: Colors.Background200,
+        gap: '8px',
       },
       '.row-buttons': {
         backgroundColor: Colors.Background200,
@@ -161,6 +162,7 @@ const stylesDark = {
       },
       '.total-runs': {
         backgroundColor: Colors.Background200Dark,
+        gap: '8px',
       },
       '.row-buttons': {
         backgroundColor: Colors.Background200Dark,
@@ -314,9 +316,14 @@ function RevisionRow(props: RevisionRowProps) {
           {confidenceText}{' '}
         </div>
         <div className='total-runs cell' role='cell'>
-          <span>B:</span>
-          <strong> {baseRuns.length} </strong> <span> N: </span>
-          <strong> {newRuns.length} </strong>
+          <span>
+            <span title='Base runs'>B:</span>
+            <strong>{baseRuns.length}</strong>
+          </span>
+          <span>
+            <span title='New runs'>N:</span>
+            <strong>{newRuns.length}</strong>
+          </span>
         </div>
         <div className='row-buttons cell'>
           {result.has_subtests && (


### PR DESCRIPTION
I was looking at the results page and I had no idea what "B" and "N" was first in the results view. I had to go into the code to read the variable to understand.

This patch adds a `title` to these letters so people can hover over them to understand what they are.
Also it didn't have an adequate spacing between those values. Looked at the figma file and it does indeed have spacing. So I added it as well.

Before:
<img width="328" alt="Screenshot 2024-07-25 at 12 58 55 PM" src="https://github.com/user-attachments/assets/a5d052e5-9b32-4e4f-9fed-7d5a7e2719b6">

After:
<img width="240" alt="Screenshot 2024-07-25 at 12 59 31 PM" src="https://github.com/user-attachments/assets/1fa09640-0251-4372-bee7-8f64f344c74c">
