### PR TITLE
Generate the results blob on click instead of at render time

### DIFF
--- a/src/components/CompareResults/DownloadButton.tsx
+++ b/src/components/CompareResults/DownloadButton.tsx
@@ -1,5 +1,3 @@
-import { useMemo } from 'react';
-
 import { Button } from '@mui/material';
 import { useAsyncValue } from 'react-router-dom';
 import { style } from 'typestyle';
@@ -91,10 +89,6 @@ function DownloadButton() {
   const activeComparison = useAppSelector(
     (state) => state.comparison.activeComparison,
   );
-  const processedResults = useMemo(
-    () => generateJsonDataFromComparisonResults(activeComparison, results),
-    [results, activeComparison],
-  );
 
   const fileName = useAppSelector((state: RootState) => {
     if (
@@ -110,6 +104,10 @@ function DownloadButton() {
   });
 
   const handleDownloadClick = () => {
+    const processedResults = generateJsonDataFromComparisonResults(
+      activeComparison,
+      results,
+    );
     const blob = new Blob([processedResults], {
       type: 'application/json',
     });


### PR DESCRIPTION
I was looking at the performance of the results page with the react profiler tool, and found that the DownloadButton component was using more time than it should have. So here is a small patch to fix that.

I tested manually that clicking the button was still responsive, even with the "browsertime" framework selection.

There are existing tests covering this piece of functionality that didn't need any change.