### PR TITLE
Use the Dialog component instead of the Modal component for the retrigger modals

### DIFF
--- a/src/components/CompareResults/Retrigger/CenteredModal.tsx
+++ b/src/components/CompareResults/Retrigger/CenteredModal.tsx
@@ -1,5 +1,5 @@
 import CloseIcon from '@mui/icons-material/Close';
-import { IconButton, Modal, Paper } from '@mui/material';
+import { IconButton, Dialog, Paper } from '@mui/material';
 
 type CenteredModalProps = {
   open: boolean;
@@ -11,34 +11,27 @@ type CenteredModalProps = {
 
 export function CenteredModal(props: CenteredModalProps) {
   return (
-    <Modal
+    <Dialog
       open={props.open}
       onClose={props.onClose}
       aria-labelledby={props.ariaLabelledby}
-      sx={{ display: 'flex' }}
-    >
-      <Paper
-        sx={{
-          margin: 'auto',
+      PaperProps={{
+        sx: {
+          gap: 2,
           padding: 6,
-          maxHeight: 0.6,
-          width: 0.6,
-          maxWidth: 500,
-          overflow: 'auto',
-          position: 'relative' /* to be able to position the close icon */,
           ...props.paperStyle,
-        }}
+        },
+      }}
+    >
+      <IconButton
+        aria-label='Close'
+        size='large'
+        sx={{ position: 'absolute', top: 8, right: 8 }}
+        onClick={props.onClose}
       >
-        <IconButton
-          aria-label='Close'
-          size='large'
-          sx={{ position: 'absolute', top: 8, right: 8 }}
-          onClick={props.onClose}
-        >
-          <CloseIcon />
-        </IconButton>
-        {props.children}
-      </Paper>
-    </Modal>
+        <CloseIcon />
+      </IconButton>
+      {props.children}
+    </Dialog>
   );
 }

--- a/src/components/CompareResults/Retrigger/RetriggerConfigModal.tsx
+++ b/src/components/CompareResults/Retrigger/RetriggerConfigModal.tsx
@@ -65,7 +65,6 @@ export function RetriggerConfigModal(props: RetriggerModalProps) {
       open={props.open}
       onClose={props.onClose}
       ariaLabelledby='retrigger-modal-title'
-      paperStyle={{ display: 'flex', flexDirection: 'column', gap: 2 }}
     >
       <Typography id='retrigger-modal-title' component='h2' variant='h2'>
         {retriggerStrings.title}

--- a/src/components/CompareResults/Retrigger/RetriggerSignInModal.tsx
+++ b/src/components/CompareResults/Retrigger/RetriggerSignInModal.tsx
@@ -34,11 +34,8 @@ export function RetriggerSignInModal(props: SignInModalProps) {
       onClose={onClose}
       ariaLabelledby='sign-in-modal-title'
       paperStyle={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        gap: 2,
         paddingBottom: 5,
+        alignItems: 'center',
         textAlign: 'center',
       }}
     >

--- a/src/theme/components.js
+++ b/src/theme/components.js
@@ -60,16 +60,6 @@ const components = {
       },
     },
   },
-  MuiBackdrop: {
-    styleOverrides: {
-      root: ({ theme }) => ({
-        backgroundColor:
-          theme.palette.mode === 'light'
-            ? 'rgb(0, 0, 0, 0.5)'
-            : 'rgb(255, 255, 255, 0.5)',
-      }),
-    },
-  },
   MuiPaper: {
     styleOverrides: {
       root: {


### PR DESCRIPTION
This fixes one issue that @canova reported to me: the various selection dropdowns were showing a grey backdrop behind them when opened:

![image](https://github.com/user-attachments/assets/d4c03490-d9bf-434f-a9e2-e2e0a58f7718)


I quickly considered that https://github.com/mozilla/perfcompare/pull/684/commits/15de4c6794737f92c9ddc07d36197719ef009f30 would be the issue. Indeed the selection dropdowns also insert a backdrop, and that change would make them all grey, while before they were transparent.

I tried to change it for just Modals... but turns out the selection dropdowns also use a Modal to position themselves!
Then in https://mui.com/material-ui/api/modal/, I've seen this small sentence:
> If you are creating a modal dialog, you probably want to use the [Dialog](https://mui.com/material-ui/api/dialog/) component rather than directly using Modal.

I missed it when I implemented it back then, before my PTOs.

So here it is: reimplementation of the modals using `Dialog` instead of `Modal`. It looks like it also has some better defaults for the Paper, so I could also remove some CSS. Also because of the better default for the dark mode, I could also remove the background color change for the backdrop, fixing the initial issue.

### Light mode:
Before:
![image](https://github.com/user-attachments/assets/c85549d6-5bf0-43ca-ac19-1e2068f6d8e4)
![image](https://github.com/user-attachments/assets/530336e6-a803-4a31-8a4f-96a30e760e74)

After:
![image](https://github.com/user-attachments/assets/434b6665-ea33-4384-aa49-18504e1b069a)
![image](https://github.com/user-attachments/assets/db0c3274-58ea-411d-aefb-62cbf638d944)

### Dark mode:
Before:
![image](https://github.com/user-attachments/assets/4d3747fa-0776-4b68-9d64-ad0e0b5b4630)
![image](https://github.com/user-attachments/assets/fef166fc-c24f-43e8-ab47-9b05cf578697)

After:
![image](https://github.com/user-attachments/assets/5873a274-f0dc-4d8c-a2da-e5aefad969d9)
![image](https://github.com/user-attachments/assets/9a2656a9-8cbc-484d-a36a-5608fcd26936)
