### PR TITLE
Remove suspense comps and add lazy import for results table

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "test:watch": "npm test -- --watch",
     "test:update": "npm test -- -u",
     "test-all": "run-p test format:check lint tsc",
-    "fix-all": "run-p test:update format lint:fix",
+    "fix-all": "run-p test:update format lint:fix tsc",
     "tsc": "tsc"
   },
   "eslintConfig": {

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -88,7 +88,7 @@ describe('App', () => {
           'Error when requesting treeherder: (500) Internal Server Error',
         ),
       );
-      expect(console.error).toHaveBeenCalledTimes(14);
+      expect(console.error).toHaveBeenCalledTimes(10);
       expect(document.body).toMatchSnapshot();
     });
 
@@ -112,7 +112,7 @@ describe('App', () => {
       expect(console.error).toHaveBeenCalledWith(
         new Error('Error when requesting treeherder: Treeherder request error'),
       );
-      expect(console.error).toHaveBeenCalledTimes(14);
+      expect(console.error).toHaveBeenCalledTimes(10);
       expect(document.body).toMatchSnapshot();
     });
 
@@ -136,7 +136,7 @@ describe('App', () => {
       expect(console.error).toHaveBeenCalledWith(
         new Error('Error when requesting treeherder: Treeherder request error'),
       );
-      expect(console.error).toHaveBeenCalledTimes(14);
+      expect(console.error).toHaveBeenCalledTimes(10);
       expect(document.body).toMatchSnapshot();
     });
 

--- a/src/components/CompareResults/OverTimeResultsView.tsx
+++ b/src/components/CompareResults/OverTimeResultsView.tsx
@@ -60,7 +60,7 @@ function ResultsView(props: ResultsViewProps) {
       </section>
       <Grid container alignItems='center' justifyContent='center'>
         <Grid item xs={12}>
-          <ResultsMain />
+          <ResultsMain isLoadingResults={false} />
         </Grid>
       </Grid>
     </div>

--- a/src/components/CompareResults/ResultsMain.tsx
+++ b/src/components/CompareResults/ResultsMain.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useState } from 'react';
+import { useState, lazy } from 'react';
 
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -8,18 +8,20 @@ import { style } from 'typestyle';
 
 import { useAppSelector } from '../../hooks/app';
 import { Colors, Spacing } from '../../styles';
-// import type { CompareResultsItem } from '../../types/state';
 import DownloadButton from './DownloadButton';
 import type { LoaderReturnValue } from './loader';
-import ResultsTable from './ResultsTable';
 import RevisionSelect from './RevisionSelect';
 import SearchInput from './SearchInput';
 
-function ResultsMain() {
+const ResultsTable = lazy(() => import('./ResultsTable'));
+
+function ResultsMain(props: { isLoadingResults: boolean }) {
   const { results } = useLoaderData() as LoaderReturnValue;
 
   const themeMode = useAppSelector((state) => state.theme.mode);
   const [searchTerm, setSearchTerm] = useState('');
+
+  const { isLoadingResults } = props;
 
   const themeColor100 =
     themeMode === 'light' ? Colors.Background300 : Colors.Background100Dark;
@@ -43,25 +45,29 @@ function ResultsMain() {
 
   return (
     <Container className={styles.container} data-testid='results-main'>
-      <Suspense
-        fallback={
-          <Box display='flex' justifyContent='center'>
+      <Await resolve={results}>
+        <header>
+          <div className={styles.title}>Results</div>
+          <div className={styles.content}>
+            <SearchInput onChange={setSearchTerm} />
+            <RevisionSelect />
+            <DownloadButton />
+          </div>
+        </header>
+
+        {isLoadingResults ? (
+          <Box
+            display='flex'
+            justifyContent='center'
+            alignItems='center'
+            minHeight='300px'
+          >
             <CircularProgress />
           </Box>
-        }
-      >
-        <Await resolve={results}>
-          <header>
-            <div className={styles.title}>Results</div>
-            <div className={styles.content}>
-              <SearchInput onChange={setSearchTerm} />
-              <RevisionSelect />
-              <DownloadButton />
-            </div>
-          </header>
+        ) : (
           <ResultsTable filteringSearchTerm={searchTerm} />
-        </Await>
-      </Suspense>
+        )}
+      </Await>
     </Container>
   );
 }

--- a/src/components/CompareResults/ResultsView.tsx
+++ b/src/components/CompareResults/ResultsView.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import Grid from '@mui/material/Grid';
 import { useLoaderData } from 'react-router-dom';
@@ -16,7 +16,7 @@ interface ResultsViewProps {
   title: string;
 }
 function ResultsView(props: ResultsViewProps) {
-  const { baseRevInfo, newRevsInfo, frameworkId, baseRepo, newRepos } =
+  const { baseRevInfo, newRevsInfo, frameworkId, baseRepo, newRepos, results } =
     useLoaderData() as LoaderReturnValue;
 
   const newRepo = newRepos[0];
@@ -30,9 +30,21 @@ function ResultsView(props: ResultsViewProps) {
 
   const sectionStyles = SearchContainerStyles(themeMode, /* isHome */ false);
 
+  const [isLoadingResults, setIsLoadingResults] = useState(true);
+
   useEffect(() => {
     document.title = title;
   }, [title]);
+
+  useEffect(() => {
+    const waitForResults = async () => {
+      await results;
+      setTimeout(() => {
+        setIsLoadingResults(false);
+      }, 500);
+    };
+    void waitForResults();
+  }, [isLoadingResults]);
 
   return (
     <div
@@ -51,12 +63,13 @@ function ResultsView(props: ResultsViewProps) {
           expandBaseComponent={() => null}
           baseRepo={baseRepo}
           newRepo={newRepo}
+          onLoadingChange={() => setIsLoadingResults(true)}
         />
       </section>
 
       <Grid container alignItems='center' justifyContent='center'>
         <Grid item xs={12}>
-          <ResultsMain />
+          <ResultsMain isLoadingResults={isLoadingResults} />
         </Grid>
       </Grid>
     </div>

--- a/src/components/Search/CancelAndCompareButtons.tsx
+++ b/src/components/Search/CancelAndCompareButtons.tsx
@@ -1,13 +1,8 @@
-import { Suspense } from 'react';
-
 import Button from '@mui/material/Button';
-import { Await, useLoaderData } from 'react-router-dom';
 import { style } from 'typestyle';
 
 import { Strings } from '../../resources/Strings';
 import { Spacing } from '../../styles/Spacing';
-import type { LoaderReturnValue } from '../CompareResults/loader';
-import type { LoaderReturnValue as OverTimeLoaderReturnValue } from '../CompareResults/overTimeLoader';
 
 interface CompareButtonProps {
   label: string;
@@ -30,40 +25,6 @@ export default function CompareButton({
     gap: `${Spacing.Small}px`,
   });
 
-  const renderCompareButton = () => {
-    if (hasEditButton) {
-      const { results } = useLoaderData() as
-        | LoaderReturnValue
-        | OverTimeLoaderReturnValue;
-
-      return (
-        <Suspense
-          fallback={
-            <Button id='compare-button' color='primary' type='submit' disabled>
-              Loading...
-            </Button>
-          }
-        >
-          <Await resolve={results}>
-            <Button
-              id='compare-button'
-              color='primary'
-              type='submit'
-              sx={{ visibility: hasCancelButton ? 'visible' : 'hidden' }}
-            >
-              {label}
-            </Button>
-          </Await>
-        </Suspense>
-      );
-    } else
-      return (
-        <Button id='compare-button' color='primary' type='submit'>
-          {label}
-        </Button>
-      );
-  };
-
   return (
     <div className={`${cancelCompareStyles} cancel-compare`}>
       {hasCancelButton && (
@@ -76,8 +37,20 @@ export default function CompareButton({
           {cancelText}
         </Button>
       )}
-
-      {renderCompareButton()}
+      {hasEditButton ? (
+        <Button
+          id='compare-button'
+          color='primary'
+          type='submit'
+          sx={{ visibility: hasCancelButton ? 'visible' : 'hidden' }}
+        >
+          {label}
+        </Button>
+      ) : (
+        <Button id='compare-button' color='primary' type='submit'>
+          {label}
+        </Button>
+      )}
     </div>
   );
 }

--- a/src/components/Search/CompareWithBase.tsx
+++ b/src/components/Search/CompareWithBase.tsx
@@ -30,6 +30,7 @@ interface CompareWithBaseProps {
   frameworkIdVal: Framework['id'];
   isBaseSearch: null | boolean;
   expandBaseComponent: (expanded: boolean) => void | null;
+  onLoadingChange: () => void;
 }
 
 /**
@@ -76,6 +77,7 @@ function CompareWithBase({
   baseRepo,
   newRepo,
   expandBaseComponent,
+  onLoadingChange,
 }: CompareWithBaseProps) {
   const { enqueueSnackbar } = useSnackbar();
   const [frameWorkId, setframeWorkValue] = useState(frameworkIdVal);
@@ -119,6 +121,8 @@ function CompareWithBase({
 
   const onFormSubmit = (e: React.FormEvent) => {
     const isFormReadyToBeSubmitted = baseInProgressRev !== null;
+    setFormIsDisplayed(!isFormReadyToBeSubmitted);
+    onLoadingChange();
 
     if (!isFormReadyToBeSubmitted) {
       e.preventDefault();
@@ -259,7 +263,6 @@ function CompareWithBase({
           className='form-wrapper'
           onSubmit={onFormSubmit}
           aria-label='Compare with base form'
-          reloadDocument={hasEditButton ?? true}
         >
           {/**** Edit Button ****/}
           <div

--- a/src/components/Search/SearchContainer.tsx
+++ b/src/components/Search/SearchContainer.tsx
@@ -34,6 +34,7 @@ function SearchContainer(props: SearchViewProps) {
         expandBaseComponent={expandBaseComponent}
         baseRepo='try'
         newRepo='try'
+        onLoadingChange={() => null}
       />
       <CompareOverTime
         hasEditButton={false}


### PR DESCRIPTION
This [commit ](https://github.com/mozilla/perfcompare/pull/698/commits/c6d2d96e52a3b2f3d3d8364401a5f80cef66927c)removes the `Suspense` component since it doesn't fulfill our task of giving users feedback during the edit work flow. The current implementation requires reloading the page which isn't ideal and honestly, unnecessary. Therefore, I've also removed this from the form. 

My proposed solution adds an `isLoadingResults` state to `ResultView` to manage the rendering of the spinner upon initial loading of the `ResultsTable` and during any revision updates.  In this commit, I implement my fix only on the `CompareWithBase` component. The form in this component updates `isLoadingResults` to `true` until the results are ready. You'll see I added a delay in `ResultsView` since the `results` resolve too quickly for users to see any feedback. 

If the proposed fix is satisfactory upon review, I'll create a new commit to update `CompareOverTime` workflow.
Lastly, I've imported the `ResultTable` in `ResultsMain` using the [lazy API](https://react.dev/reference/react/lazy) to help improve performance. 
[
Profile for beta for initial loading of results table (browsertime framework) ](https://share.firefox.dev/4dk8cnS) / [Profile for my deployed PR '' ''](https://share.firefox.dev/4dm8cDN)

My patch reduces the first major jank by 3 seconds. 
