### PR TITLE
Avoid a spurious rerender when changing the framework (and other things related to the router)

### DIFF
--- a/src/__tests__/CompareResults/RevisionRow.test.tsx
+++ b/src/__tests__/CompareResults/RevisionRow.test.tsx
@@ -1,5 +1,6 @@
 import { ReactElement } from 'react';
 
+import { compareView } from '../../common/constants';
 import { loader } from '../../components/CompareResults/loader';
 import RevisionRow from '../../components/CompareResults/RevisionRow';
 import { Platform } from '../../types/types';
@@ -59,7 +60,7 @@ describe('<RevisionRow>', () => {
       } = getTestData();
 
       rowData.platform = platform as Platform;
-      renderWithRoute(<RevisionRow result={rowData} />);
+      renderWithRoute(<RevisionRow result={rowData} view={compareView} />);
       const shortNameNode = await screen.findByText(shortName);
       expect(shortNameNode).toBeInTheDocument();
       const previousNode = shortNameNode.previousSibling;

--- a/src/components/CompareResults/ResultsMain.tsx
+++ b/src/components/CompareResults/ResultsMain.tsx
@@ -11,12 +11,15 @@ import { Colors, Spacing } from '../../styles';
 import type { CompareResultsItem } from '../../types/state';
 import DownloadButton from './DownloadButton';
 import type { LoaderReturnValue } from './loader';
+import type { LoaderReturnValue as OverTimeLoaderReturnValue } from './overTimeLoader';
 import ResultsTable from './ResultsTable';
 import RevisionSelect from './RevisionSelect';
 import SearchInput from './SearchInput';
 
 function ResultsMain() {
-  const { results } = useLoaderData() as LoaderReturnValue;
+  const { results, view } = useLoaderData() as
+    | LoaderReturnValue
+    | OverTimeLoaderReturnValue;
 
   const themeMode = useAppSelector((state) => state.theme.mode);
   const [searchTerm, setSearchTerm] = useState('');
@@ -64,6 +67,7 @@ function ResultsMain() {
               <ResultsTable
                 filteringSearchTerm={searchTerm}
                 results={resolvedResults as CompareResultsItem[][]}
+                view={view}
               />
             </>
           )}

--- a/src/components/CompareResults/ResultsMain.tsx
+++ b/src/components/CompareResults/ResultsMain.tsx
@@ -8,6 +8,7 @@ import { style } from 'typestyle';
 
 import { useAppSelector } from '../../hooks/app';
 import { Colors, Spacing } from '../../styles';
+import type { CompareResultsItem } from '../../types/state';
 import DownloadButton from './DownloadButton';
 import type { LoaderReturnValue } from './loader';
 import ResultsTable from './ResultsTable';
@@ -50,15 +51,22 @@ function ResultsMain() {
         }
       >
         <Await resolve={results}>
-          <header>
-            <div className={styles.title}>Results</div>
-            <div className={styles.content}>
-              <SearchInput onChange={setSearchTerm} />
-              <RevisionSelect />
-              <DownloadButton />
-            </div>
-          </header>
-          <ResultsTable filteringSearchTerm={searchTerm} />
+          {(resolvedResults) => (
+            <>
+              <header>
+                <div className={styles.title}>Results</div>
+                <div className={styles.content}>
+                  <SearchInput onChange={setSearchTerm} />
+                  <RevisionSelect />
+                  <DownloadButton />
+                </div>
+              </header>
+              <ResultsTable
+                filteringSearchTerm={searchTerm}
+                results={resolvedResults as CompareResultsItem[][]}
+              />
+            </>
+          )}
         </Await>
       </Suspense>
     </Container>

--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -1,7 +1,6 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useState, memo } from 'react';
 
 import Box from '@mui/material/Box';
-import { useAsyncValue } from 'react-router-dom';
 
 import { useAppSelector } from '../../hooks/app';
 import { Strings } from '../../resources/Strings';
@@ -176,11 +175,10 @@ const allRevisionsOption =
 
 type ResultsTableProps = {
   filteringSearchTerm: string;
+  results: CompareResultsItem[][];
 };
 
-function ResultsTable({ filteringSearchTerm }: ResultsTableProps) {
-  const loaderData = useAsyncValue();
-  const results = loaderData as CompareResultsItem[][];
+function ResultsTable({ filteringSearchTerm, results }: ResultsTableProps) {
   const activeComparison = useAppSelector(
     (state) => state.comparison.activeComparison,
   );
@@ -246,4 +244,4 @@ function ResultsTable({ filteringSearchTerm }: ResultsTableProps) {
   );
 }
 
-export default ResultsTable;
+export default memo(ResultsTable);

--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState, memo } from 'react';
 
 import Box from '@mui/material/Box';
 
+import type { compareView, compareOverTimeView } from '../../common/constants';
 import { useAppSelector } from '../../hooks/app';
 import { Strings } from '../../resources/Strings';
 import type { CompareResultsItem, RevisionsHeader } from '../../types/state';
@@ -176,9 +177,14 @@ const allRevisionsOption =
 type ResultsTableProps = {
   filteringSearchTerm: string;
   results: CompareResultsItem[][];
+  view: typeof compareView | typeof compareOverTimeView;
 };
 
-function ResultsTable({ filteringSearchTerm, results }: ResultsTableProps) {
+function ResultsTable({
+  filteringSearchTerm,
+  results,
+  view,
+}: ResultsTableProps) {
   const activeComparison = useAppSelector(
     (state) => state.comparison.activeComparison,
   );
@@ -236,6 +242,7 @@ function ResultsTable({ filteringSearchTerm, results }: ResultsTableProps) {
           identifier={res.key}
           header={res.revisionHeader}
           results={res.value}
+          view={view}
         />
       ))}
 

--- a/src/components/CompareResults/TableContent.tsx
+++ b/src/components/CompareResults/TableContent.tsx
@@ -1,5 +1,6 @@
 import { style } from 'typestyle';
 
+import type { compareView, compareOverTimeView } from '../../common/constants';
 import { Spacing } from '../../styles';
 import type { CompareResultsItem, RevisionsHeader } from '../../types/state';
 import RevisionHeader from './RevisionHeader';
@@ -12,7 +13,7 @@ const styles = {
 };
 
 function TableContent(props: TableContentProps) {
-  const { results, header, identifier } = props;
+  const { results, header, identifier, view } = props;
 
   return (
     <div className={styles.tableBody} role='rowgroup'>
@@ -20,7 +21,11 @@ function TableContent(props: TableContentProps) {
       <div>
         {results.length > 0 &&
           results.map((result) => (
-            <RevisionRow key={identifier + result.platform} result={result} />
+            <RevisionRow
+              key={identifier + result.platform}
+              result={result}
+              view={view}
+            />
           ))}
       </div>
     </div>
@@ -31,6 +36,7 @@ interface TableContentProps {
   results: CompareResultsItem[];
   header: RevisionsHeader;
   identifier: string;
+  view: typeof compareView | typeof compareOverTimeView;
 }
 
 export default TableContent;

--- a/src/components/CompareResults/loader.ts
+++ b/src/components/CompareResults/loader.ts
@@ -245,7 +245,7 @@ type DeferredLoaderData = {
   newRepos: Repository['name'][];
   frameworkId: Framework['id'];
   frameworkName: Framework['name'];
-  view: string;
+  view: typeof compareView;
 };
 
 //had to be more explicit with the type because the defer

--- a/src/components/CompareResults/overTimeLoader.ts
+++ b/src/components/CompareResults/overTimeLoader.ts
@@ -205,7 +205,7 @@ type DeferredLoaderData = {
   frameworkName: Framework['name'];
   intervalValue: TimeRange['value'];
   intervalText: TimeRange['text'];
-  view: string;
+  view: typeof compareOverTimeView;
 };
 
 export type LoaderReturnValue = DeferredLoaderData;

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -115,8 +115,6 @@ export type CompareResultsItem = {
 
 export type InputType = 'base' | 'new';
 
-export type View = 'compare-results' | 'search';
-
 export type ThemeMode = 'light' | 'dark';
 
 export type SelectedRevisionsState = {


### PR DESCRIPTION
This issue is especially visible when changing the framework... but only after removing the `reloadDocument` property, which I'm not doing in this deploy preview, so you won't be able to check this from the deploy preview. You can checkout the pull request locally and remove `reloadDocument` to check for yourself.

The issue is that the table is rerendered again even though nothing changed yet. From the react profiler, I found that it's rerendered because "context changed", that is the context from react router. This happens when using `useLoaderData` (see the issue I filed in https://github.com/remix-run/react-router/issues/11864).

So I fixed this through 2 commits:
1. Commit 1 is the simplest: it uses the "children function" style of `Await` so that `ResultsTable` can be a memoized component. Indeed `ResultsMain` gets the spurious rerender because of its use of `useLoaderData`.
2. Commit 2 is a bit more complex. It's goal is to remove the use of `useLoaderData` in `RevisionRow`, and more work was needed here. Maybe this could be reverted if https://github.com/remix-run/react-router/issues/11864 is fixed later...