### PR TITLE
Memoize the fetches for the revision information

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "format": "^0.2.2",
         "json-e": "^4.7.0",
         "material-ui-popup-state": "^5.1.2",
+        "moize": "^6.1.6",
         "notistack": "^2.0.5",
         "process": "^0.11.10",
         "react": "^18.2.0",
@@ -9045,6 +9046,11 @@
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
+    "node_modules/fast-equals": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-3.0.3.tgz",
+      "integrity": "sha512-NCe8qxnZFARSHGztGMZOO/PC1qa5MIFB5Hp66WdzbCRAz8U8US3bx1UTgLS49efBQPcUtO9gf5oVEY8o7y/7Kg=="
+    },
     "node_modules/fast-glob": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
@@ -13743,6 +13749,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/micro-memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/micro-memoize/-/micro-memoize-4.1.2.tgz",
+      "integrity": "sha512-+HzcV2H+rbSJzApgkj0NdTakkC+bnyeiUxgT6/m7mjcz1CmM22KYFKp+EVj1sWe4UYcnriJr5uqHQD/gMHLD+g=="
+    },
     "node_modules/micromatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
@@ -13847,6 +13858,15 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
+    },
+    "node_modules/moize": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/moize/-/moize-6.1.6.tgz",
+      "integrity": "sha512-vSKdIUO61iCmTqhdoIDrqyrtp87nWZUmBPniNjO0fX49wEYmyDO4lvlnFXiGcaH1JLE/s/9HbiK4LSHsbiUY6Q==",
+      "dependencies": {
+        "fast-equals": "^3.0.1",
+        "micro-memoize": "^4.1.2"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -24573,6 +24593,11 @@
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
+    "fast-equals": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-3.0.3.tgz",
+      "integrity": "sha512-NCe8qxnZFARSHGztGMZOO/PC1qa5MIFB5Hp66WdzbCRAz8U8US3bx1UTgLS49efBQPcUtO9gf5oVEY8o7y/7Kg=="
+    },
     "fast-glob": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
@@ -28011,6 +28036,11 @@
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
     },
+    "micro-memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/micro-memoize/-/micro-memoize-4.1.2.tgz",
+      "integrity": "sha512-+HzcV2H+rbSJzApgkj0NdTakkC+bnyeiUxgT6/m7mjcz1CmM22KYFKp+EVj1sWe4UYcnriJr5uqHQD/gMHLD+g=="
+    },
     "micromatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
@@ -28090,6 +28120,15 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
+    },
+    "moize": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/moize/-/moize-6.1.6.tgz",
+      "integrity": "sha512-vSKdIUO61iCmTqhdoIDrqyrtp87nWZUmBPniNjO0fX49wEYmyDO4lvlnFXiGcaH1JLE/s/9HbiK4LSHsbiUY6Q==",
+      "requires": {
+        "fast-equals": "^3.0.1",
+        "micro-memoize": "^4.1.2"
+      }
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "format": "^0.2.2",
     "json-e": "^4.7.0",
     "material-ui-popup-state": "^5.1.2",
+    "moize": "^6.1.6",
     "notistack": "^2.0.5",
     "process": "^0.11.10",
     "react": "^18.2.0",

--- a/src/components/CompareResults/loader.ts
+++ b/src/components/CompareResults/loader.ts
@@ -5,7 +5,7 @@ import { compareView } from '../../common/constants';
 import {
   fetchCompareResults,
   fetchFakeCompareResults,
-  fetchRecentRevisions,
+  fetchRevisionForRepository,
 } from '../../logic/treeherder';
 import { Changeset, Repository } from '../../types/state';
 import { FakeCommitHash, Framework } from '../../types/types';
@@ -206,14 +206,12 @@ export async function loader({ request }: { request: Request }) {
   // For each of these requests, we get a list of 1 item because we request one
   // specific hash.
   // TODO what happens if there's no result?
-  const baseRevInfoPromise = fetchRecentRevisions({
+  const baseRevInfoPromise = fetchRevisionForRepository({
     repository: baseRepo,
     hash: baseRev,
-  }).then((listOfRevisions) => listOfRevisions[0]);
+  });
   const newRevsInfoPromises = newRevs.map((newRev, i) =>
-    fetchRecentRevisions({ repository: newRepos[i], hash: newRev }).then(
-      (listOfRevisions) => listOfRevisions[0],
-    ),
+    fetchRevisionForRepository({ repository: newRepos[i], hash: newRev }),
   );
 
   const [baseRevInfo, ...newRevsInfo] = await Promise.all([

--- a/src/components/CompareResults/loader.ts
+++ b/src/components/CompareResults/loader.ts
@@ -5,7 +5,7 @@ import { compareView } from '../../common/constants';
 import {
   fetchCompareResults,
   fetchFakeCompareResults,
-  fetchRevisionForRepository,
+  memoizedFetchRevisionForRepository,
 } from '../../logic/treeherder';
 import { Changeset, Repository } from '../../types/state';
 import { FakeCommitHash, Framework } from '../../types/types';
@@ -206,12 +206,15 @@ export async function loader({ request }: { request: Request }) {
   // For each of these requests, we get a list of 1 item because we request one
   // specific hash.
   // TODO what happens if there's no result?
-  const baseRevInfoPromise = fetchRevisionForRepository({
+  const baseRevInfoPromise = memoizedFetchRevisionForRepository({
     repository: baseRepo,
     hash: baseRev,
   });
   const newRevsInfoPromises = newRevs.map((newRev, i) =>
-    fetchRevisionForRepository({ repository: newRepos[i], hash: newRev }),
+    memoizedFetchRevisionForRepository({
+      repository: newRepos[i],
+      hash: newRev,
+    }),
   );
 
   const [baseRevInfo, ...newRevsInfo] = await Promise.all([

--- a/src/components/CompareResults/overTimeLoader.ts
+++ b/src/components/CompareResults/overTimeLoader.ts
@@ -4,7 +4,7 @@ import { repoMap, frameworks, timeRanges } from '../../common/constants';
 import { compareOverTimeView } from '../../common/constants';
 import {
   fetchCompareOverTimeResults,
-  fetchRevisionForRepository,
+  memoizedFetchRevisionForRepository,
 } from '../../logic/treeherder';
 import { Changeset, Repository } from '../../types/state';
 import { Framework, TimeRange } from '../../types/types';
@@ -174,7 +174,10 @@ export async function loader({ request }: { request: Request }) {
   });
 
   const newRevsInfoPromises = newRevs.map((newRev, i) =>
-    fetchRevisionForRepository({ repository: newRepos[i], hash: newRev }),
+    memoizedFetchRevisionForRepository({
+      repository: newRepos[i],
+      hash: newRev,
+    }),
   );
 
   const newRevsInfo = await Promise.all(newRevsInfoPromises);

--- a/src/components/CompareResults/overTimeLoader.ts
+++ b/src/components/CompareResults/overTimeLoader.ts
@@ -4,7 +4,7 @@ import { repoMap, frameworks, timeRanges } from '../../common/constants';
 import { compareOverTimeView } from '../../common/constants';
 import {
   fetchCompareOverTimeResults,
-  fetchRecentRevisions,
+  fetchRevisionForRepository,
 } from '../../logic/treeherder';
 import { Changeset, Repository } from '../../types/state';
 import { Framework, TimeRange } from '../../types/types';
@@ -174,9 +174,7 @@ export async function loader({ request }: { request: Request }) {
   });
 
   const newRevsInfoPromises = newRevs.map((newRev, i) =>
-    fetchRecentRevisions({ repository: newRepos[i], hash: newRev }).then(
-      (listOfRevisions) => listOfRevisions[0],
-    ),
+    fetchRevisionForRepository({ repository: newRepos[i], hash: newRev }),
   );
 
   const newRevsInfo = await Promise.all(newRevsInfoPromises);

--- a/src/logic/treeherder.ts
+++ b/src/logic/treeherder.ts
@@ -200,6 +200,17 @@ export async function fetchRecentRevisions(params: RecentRevisionsParams) {
   return json.results;
 }
 
+// This is a specialised version of fetchRecentRevisions dedicated to fetching
+// information about one specific revision.
+export async function fetchRevisionForRepository(opts: {
+  repository: string;
+  hash: string;
+}) {
+  // We get a list of 1 item because we request one specific hash.
+  const listOfOneRevision = await fetchRecentRevisions(opts);
+  return listOfOneRevision[0];
+}
+
 export async function fetchJobInformationFromJobId(
   repo: string,
   jobId: number,

--- a/src/logic/treeherder.ts
+++ b/src/logic/treeherder.ts
@@ -1,3 +1,5 @@
+import moize from 'moize';
+
 import { JobInformation } from '../types/api';
 import { CompareResultsItem, Repository, Changeset } from '../types/state';
 import { Framework, TimeRange } from '../types/types';
@@ -210,6 +212,15 @@ export async function fetchRevisionForRepository(opts: {
   const listOfOneRevision = await fetchRecentRevisions(opts);
   return listOfOneRevision[0];
 }
+
+// The memoized version of fetchRecentRevisions.
+// We picked an arbitrary number of 5: we need 4 for base + 3 revs, and added an
+// extra one to allow moving back and worth with some options. It could be
+// increased some more later if needed.
+export const memoizedFetchRevisionForRepository = moize(
+  fetchRevisionForRepository,
+  { isPromise: true, isShallowEqual: true, maxSize: 5 },
+) as typeof fetchRevisionForRepository;
 
 export async function fetchJobInformationFromJobId(
   repo: string,


### PR DESCRIPTION
The goal for this patch is to memoize the result of fetching the revision information for specific revisions.

This has 2 commits:
1. Commit 1 is a preparation commit: this creates a specific function for this operation, so that it can be memoized in step 2.
2. Commit 2 uses the library https://github.com/planttheidea/moize to implement the memoization itself. I looked at many libraries and decided to use this one because of its simple yet effective API, with all the features we need here. Especially it makes it easy to use an option object for the function, and configure the number of calls to be memoized.
It can also be configured with an expiration, which could be useful for us later if we decide to use it for the results (maybe), and the cache can also be controlled from outside, which can be useful if we'd want to prime it from the revision selections in the home page.