### PR TITLE
Better use Suspense to get a spinner when data is loading

### DIFF
--- a/src/components/CompareResults/DownloadButton.tsx
+++ b/src/components/CompareResults/DownloadButton.tsx
@@ -83,10 +83,10 @@ const styles = {
 };
 
 interface DownloadButtonProps {
-  results: CompareResultsItem[][];
+  resultsPromise: Promise<CompareResultsItem[][]> | CompareResultsItem[][];
 }
 
-function DownloadButton({ results }: DownloadButtonProps) {
+function DownloadButton({ resultsPromise }: DownloadButtonProps) {
   const activeComparison = useAppSelector(
     (state) => state.comparison.activeComparison,
   );
@@ -104,7 +104,8 @@ function DownloadButton({ results }: DownloadButtonProps) {
     }
   });
 
-  const handleDownloadClick = () => {
+  const handleDownloadClick = async () => {
+    const results = await resultsPromise;
     const processedResults = generateJsonDataFromComparisonResults(
       activeComparison,
       results,
@@ -129,7 +130,7 @@ function DownloadButton({ results }: DownloadButtonProps) {
       <Button
         variant='contained'
         color='secondary'
-        onClick={handleDownloadClick}
+        onClick={() => void handleDownloadClick()}
       >
         Download JSON
       </Button>

--- a/src/components/CompareResults/ResultsMain.tsx
+++ b/src/components/CompareResults/ResultsMain.tsx
@@ -83,7 +83,7 @@ function ResultsMain() {
             <RevisionSelect />
           </Grid>
           <Grid item xs>
-            <DownloadButton results={results} />
+            <DownloadButton resultsPromise={results} />
           </Grid>
         </Grid>
       </header>

--- a/src/components/CompareResults/ResultsMain.tsx
+++ b/src/components/CompareResults/ResultsMain.tsx
@@ -63,51 +63,49 @@ function ResultsMain() {
 
   return (
     <Container className={styles.container} data-testid='results-main'>
+      <header>
+        <div className={styles.title}>Results</div>
+        <Grid container className={styles.content} spacing={2}>
+          <Grid item md={6} xs={12}>
+            <SearchInput onChange={setSearchTerm} />
+          </Grid>
+          <Grid item xs>
+            <FormControl sx={{ width: '100%' }}>
+              <FrameworkDropdown
+                frameworkId={frameworkIdVal}
+                size='small'
+                variant='outlined'
+                onChange={onFrameworkChange}
+              />
+            </FormControl>
+          </Grid>
+          <Grid item xs>
+            <RevisionSelect />
+          </Grid>
+          <Grid item xs>
+            <DownloadButton results={results} />
+          </Grid>
+        </Grid>
+      </header>
       {/* Using a key in Suspense makes it that it displays the fallback more
           consistently.
           See https://github.com/mozilla/perfcompare/pull/702#discussion_r1705274740
           for more explanation (and questioning) about this issue. */}
       <Suspense
         fallback={
-          <Box display='flex' justifyContent='center'>
+          <Box display='flex' justifyContent='center' sx={{ marginTop: 3 }}>
             <CircularProgress />
           </Box>
         }
         key={generation}
       >
         <Await resolve={results}>
-          {(resolvedResults: CompareResultsItem[][]) => (
-            <>
-              <header>
-                <div className={styles.title}>Results</div>
-                <Grid container className={styles.content} spacing={2}>
-                  <Grid item md={6} xs={12}>
-                    <SearchInput onChange={setSearchTerm} />
-                  </Grid>
-                  <Grid item xs>
-                    <FormControl sx={{ width: '100%' }}>
-                      <FrameworkDropdown
-                        frameworkId={frameworkIdVal}
-                        size='small'
-                        variant='outlined'
-                        onChange={onFrameworkChange}
-                      />
-                    </FormControl>
-                  </Grid>
-                  <Grid item xs>
-                    <RevisionSelect />
-                  </Grid>
-                  <Grid item xs>
-                    <DownloadButton results={resolvedResults} />
-                  </Grid>
-                </Grid>
-              </header>
-              <ResultsTable
-                filteringSearchTerm={searchTerm}
-                results={resolvedResults}
-                view={view}
-              />
-            </>
+          {(resolvedResults) => (
+            <ResultsTable
+              filteringSearchTerm={searchTerm}
+              results={resolvedResults as CompareResultsItem[][]}
+              view={view}
+            />
           )}
         </Await>
       </Suspense>

--- a/src/components/CompareResults/ResultsMain.tsx
+++ b/src/components/CompareResults/ResultsMain.tsx
@@ -23,7 +23,7 @@ import RevisionSelect from './RevisionSelect';
 import SearchInput from './SearchInput';
 
 function ResultsMain() {
-  const { results, view, frameworkId } = useLoaderData() as
+  const { results, view, frameworkId, generation } = useLoaderData() as
     | LoaderReturnValue
     | OverTimeLoaderReturnValue;
 
@@ -63,12 +63,17 @@ function ResultsMain() {
 
   return (
     <Container className={styles.container} data-testid='results-main'>
+      {/* Using a key in Suspense makes it that it displays the fallback more
+          consistently.
+          See https://github.com/mozilla/perfcompare/pull/702#discussion_r1705274740
+          for more explanation (and questioning) about this issue. */}
       <Suspense
         fallback={
           <Box display='flex' justifyContent='center'>
             <CircularProgress />
           </Box>
         }
+        key={generation}
       >
         <Await resolve={results}>
           {(resolvedResults: CompareResultsItem[][]) => (

--- a/src/components/CompareResults/SubtestsResults/SubtestsResultsMain.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsResultsMain.tsx
@@ -66,7 +66,7 @@ function SubtestsResultsMain({ view }: SubtestsResultsMainProps) {
         <SubtestsRevisionHeader header={subtestsHeader} />
         <div className={styles.content}>
           <SearchInput onChange={setSearchTerm} />
-          <DownloadButton results={[results]} />
+          <DownloadButton resultsPromise={[results]} />
         </div>
       </header>
       <SubtestsResultsTable

--- a/src/components/CompareResults/loader.ts
+++ b/src/components/CompareResults/loader.ts
@@ -5,7 +5,7 @@ import {
   fetchFakeCompareResults,
   memoizedFetchRevisionForRepository,
 } from '../../logic/treeherder';
-import { Changeset, Repository } from '../../types/state';
+import { Changeset, CompareResultsItem, Repository } from '../../types/state';
 import { FakeCommitHash, Framework } from '../../types/types';
 
 // This function checks and sanitizes the input values, then returns values that
@@ -242,7 +242,7 @@ export async function loader({ request }: { request: Request }) {
 }
 
 type DeferredLoaderData = {
-  results: Promise<unknown>;
+  results: Promise<CompareResultsItem[][]>;
   baseRev: string;
   baseRevInfo: Changeset;
   baseRepo: Repository['name'];

--- a/src/components/CompareResults/loader.ts
+++ b/src/components/CompareResults/loader.ts
@@ -1,5 +1,3 @@
-import { defer } from 'react-router-dom';
-
 import { repoMap, frameworks } from '../../common/constants';
 import { compareView } from '../../common/constants';
 import {
@@ -222,7 +220,7 @@ export async function loader({ request }: { request: Request }) {
     ...newRevsInfoPromises,
   ]);
 
-  return defer({
+  return {
     results: resultsPromise,
     baseRev,
     baseRevInfo,
@@ -233,7 +231,7 @@ export async function loader({ request }: { request: Request }) {
     frameworkId,
     frameworkName,
     view: compareView,
-  });
+  };
 }
 
 type DeferredLoaderData = {
@@ -249,6 +247,6 @@ type DeferredLoaderData = {
   view: typeof compareView;
 };
 
-//had to be more explicit with the type because the defer
-//function returns a an inaccessible type
+// Be explicit with the returned type to control it better than if we were
+// inferring it.
 export type LoaderReturnValue = DeferredLoaderData;

--- a/src/components/CompareResults/loader.ts
+++ b/src/components/CompareResults/loader.ts
@@ -142,6 +142,11 @@ async function fetchAllFakeCompareResults() {
   return Promise.all(promises);
 }
 
+// This counter is incremented for each call of the loader. This allows the
+// components to know when a new load happened and use it in keys.
+// Essentially a workaround to https://github.com/remix-run/react-router/issues/11864
+let generationCounter = 0;
+
 // This function is responsible for fetching the data from the URL. It's called
 // by React Router DOM when the compare-results path is requested.
 // It uses the URL parameters as inputs, and returns all the fetched data to the
@@ -171,6 +176,7 @@ export async function loader({ request }: { request: Request }) {
       frameworkId,
       frameworkName,
       view: compareView,
+      generation: generationCounter++,
     };
   }
 
@@ -231,6 +237,7 @@ export async function loader({ request }: { request: Request }) {
     frameworkId,
     frameworkName,
     view: compareView,
+    generation: generationCounter++,
   };
 }
 
@@ -245,6 +252,7 @@ type DeferredLoaderData = {
   frameworkId: Framework['id'];
   frameworkName: Framework['name'];
   view: typeof compareView;
+  generation: number;
 };
 
 // Be explicit with the returned type to control it better than if we were

--- a/src/components/CompareResults/overTimeLoader.ts
+++ b/src/components/CompareResults/overTimeLoader.ts
@@ -129,6 +129,11 @@ async function fetchCompareOverTimeResultsOnTreeherder({
   return Promise.all(promises);
 }
 
+// This counter is incremented for each call of the loader. This allows the
+// components to know when a new load happened and use it in keys.
+// Essentially a workaround to https://github.com/remix-run/react-router/issues/11864
+let generationCounter = 0;
+
 // This function is responsible for fetching the data from the URL. It's called
 // by React Router DOM when the compare-over-time-results path is requested.
 // It uses the URL parameters as inputs, and returns all the fetched data to the
@@ -191,6 +196,7 @@ export async function loader({ request }: { request: Request }) {
     intervalValue,
     intervalText,
     view: compareOverTimeView,
+    generation: generationCounter++,
   };
 }
 
@@ -205,6 +211,7 @@ type DeferredLoaderData = {
   intervalValue: TimeRange['value'];
   intervalText: TimeRange['text'];
   view: typeof compareOverTimeView;
+  generation: number;
 };
 
 // Be explicit with the returned type to control it better than if we were

--- a/src/components/CompareResults/overTimeLoader.ts
+++ b/src/components/CompareResults/overTimeLoader.ts
@@ -1,5 +1,3 @@
-import { defer } from 'react-router-dom';
-
 import { repoMap, frameworks, timeRanges } from '../../common/constants';
 import { compareOverTimeView } from '../../common/constants';
 import {
@@ -182,7 +180,7 @@ export async function loader({ request }: { request: Request }) {
 
   const newRevsInfo = await Promise.all(newRevsInfoPromises);
 
-  return defer({
+  return {
     results: resultsTimePromise,
     baseRepo,
     newRevs,
@@ -193,7 +191,7 @@ export async function loader({ request }: { request: Request }) {
     intervalValue,
     intervalText,
     view: compareOverTimeView,
-  });
+  };
 }
 
 type DeferredLoaderData = {
@@ -209,4 +207,6 @@ type DeferredLoaderData = {
   view: typeof compareOverTimeView;
 };
 
+// Be explicit with the returned type to control it better than if we were
+// inferring it.
 export type LoaderReturnValue = DeferredLoaderData;

--- a/src/components/CompareResults/overTimeLoader.ts
+++ b/src/components/CompareResults/overTimeLoader.ts
@@ -4,7 +4,7 @@ import {
   fetchCompareOverTimeResults,
   memoizedFetchRevisionForRepository,
 } from '../../logic/treeherder';
-import { Changeset, Repository } from '../../types/state';
+import { Changeset, CompareResultsItem, Repository } from '../../types/state';
 import { Framework, TimeRange } from '../../types/types';
 
 // This function checks and sanitizes the input values, then returns values that
@@ -201,7 +201,7 @@ export async function loader({ request }: { request: Request }) {
 }
 
 type DeferredLoaderData = {
-  results: Promise<unknown>;
+  results: Promise<CompareResultsItem[][]>;
   baseRepo: Repository['name'];
   newRevs: string[];
   newRevsInfo: Changeset[];

--- a/src/components/Search/CompareWithBase.tsx
+++ b/src/components/Search/CompareWithBase.tsx
@@ -250,7 +250,6 @@ function CompareWithBase({
           className='form-wrapper'
           onSubmit={onFormSubmit}
           aria-label='Compare with base form'
-          reloadDocument={hasEditButton ?? true}
         >
           {/**** Edit Button ****/}
           <div


### PR DESCRIPTION
This is ready for review !

Commit 1 is #708.
Commit 2 is the thing that you did in other PRs: remove `defer`
Commit 3 adds a key like mentioned in the comment below. Hopefully the comments in the code should be clear but tell me if we need more.
Commit 4 moves the results table header out of the Suspend area, so that it's visible while the data loads.
Commit 5 is a small fix for the types returned by the loaders.
Commit 6 fixes the DownloadButton after commit 4: because it's now outside of the Suspense/Await, it gets a promise in the normal results page, but the non-promise in the subtests page. This commit makes it work in both cases.

