### PR TITLE
Display a notification to the user after the retrigger request is sent

### DIFF
--- a/@types/taskcluster-client-web.d.ts
+++ b/@types/taskcluster-client-web.d.ts
@@ -8,6 +8,6 @@ declare module 'taskcluster-client-web' {
       hookGroupId: string,
       hookId: string,
       hookPayload: unknown,
-    ): Promise<string>;
+    ): Promise<{ taskId: string; status: { taskId: string } }>;
   }
 }

--- a/src/__tests__/CompareResults/Retrigger.test.tsx
+++ b/src/__tests__/CompareResults/Retrigger.test.tsx
@@ -9,7 +9,6 @@ import {
   fireEvent,
   render,
   screen,
-  waitFor,
   within,
 } from '../utils/test-utils';
 
@@ -229,8 +228,40 @@ describe('Retrigger', () => {
 
     await user.click(triggerJobsButton);
 
-    await waitFor(() =>
-      expect(new MockedHooks().triggerHook).toHaveBeenCalled(),
+    // Ideally we shuold use this when https://github.com/iamhosseindhv/notistack/pull/609
+    // is merged and we update notistack.
+    // const baseNotification = await screen.findByRole('alert', {
+    //   description: /The retrigger request for the base run/,
+    // });
+    // const newNotification = await screen.findByRole('alert', {
+    //   description: /The retrigger request for the new run/,
+    // });
+    // In the mean time we use this:
+    const baseNotification = (
+      await screen.findByText(/The retrigger request for the base run/)
+    ).parentElement!;
+    const newNotification = (
+      await screen.findByText(/The retrigger request for the new run/)
+    ).parentElement!;
+
+    const baseButton: HTMLLinkElement = within(baseNotification).getByRole(
+      'link',
+      { name: /Open Treeherder/, hidden: true },
     );
+    expect(baseButton.href).toBe(
+      'https://treeherder.mozilla.org/jobs?repo=mozilla-central&revision=coconut',
+    );
+    const newButton: HTMLLinkElement = within(newNotification).getByRole(
+      'link',
+      { name: /Open Treeherder/, hidden: true },
+    );
+    expect(newButton.href).toBe(
+      'https://treeherder.mozilla.org/jobs?repo=mozilla-central&revision=spam',
+    );
+
+    expect(baseNotification).toMatchSnapshot();
+    expect(newNotification).toMatchSnapshot();
+
+    expect(new MockedHooks().triggerHook).toHaveBeenCalled();
   });
 });

--- a/src/__tests__/CompareResults/__snapshots__/Retrigger.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/Retrigger.test.tsx.snap
@@ -1,0 +1,133 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Retrigger should retrigger one job for base revision and one job for new revision 1`] = `
+<div
+  aria-describedby="notistack-snackbar"
+  class="SnackbarContent-root SnackbarItem-contentRoot SnackbarItem-variantInfo SnackbarItem-lessPadding css-hped4j"
+  role="alert"
+  style="webkit-transform: none; transform: none; webkit-transition: -webkit-transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms; transition: transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;"
+>
+  <div
+    class="SnackbarItem-message"
+    id="notistack-snackbar"
+  >
+    <svg
+      aria-hidden="true"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+      focusable="false"
+      style="font-size: 20px; margin-inline-end: 8px;"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M13,9H11V7H13M13,17H11V11H13M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,
+        0 22,12A10,10 0 0,0 12,2Z"
+      />
+    </svg>
+    The retrigger request for the base run has been sent successfully, with ID rEtrRigGERtaSkId.
+  </div>
+  <div
+    class="SnackbarItem-action"
+  >
+    <a
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-cm1dua-MuiButtonBase-root-MuiButton-root"
+      href="https://treeherder.mozilla.org/jobs?repo=mozilla-central&revision=coconut"
+      rel="noreferrer"
+      tabindex="0"
+      target="_blank"
+    >
+      Open Treeherder
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </a>
+    <button
+      aria-label="Dismiss"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-16podhg-MuiButtonBase-root-MuiIconButton-root"
+      data-testid="alert-close"
+      tabindex="0"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+        data-testid="CloseIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+        />
+      </svg>
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Retrigger should retrigger one job for base revision and one job for new revision 2`] = `
+<div
+  aria-describedby="notistack-snackbar"
+  class="SnackbarContent-root SnackbarItem-contentRoot SnackbarItem-variantInfo SnackbarItem-lessPadding css-hped4j"
+  role="alert"
+  style="webkit-transform: none; transform: none; webkit-transition: -webkit-transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms; transition: transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;"
+>
+  <div
+    class="SnackbarItem-message"
+    id="notistack-snackbar"
+  >
+    <svg
+      aria-hidden="true"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+      focusable="false"
+      style="font-size: 20px; margin-inline-end: 8px;"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M13,9H11V7H13M13,17H11V11H13M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,
+        0 22,12A10,10 0 0,0 12,2Z"
+      />
+    </svg>
+    The retrigger request for the new run has been sent successfully, with ID rEtrRigGERtaSkId.
+  </div>
+  <div
+    class="SnackbarItem-action"
+  >
+    <a
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-cm1dua-MuiButtonBase-root-MuiButton-root"
+      href="https://treeherder.mozilla.org/jobs?repo=mozilla-central&revision=spam"
+      rel="noreferrer"
+      tabindex="0"
+      target="_blank"
+    >
+      Open Treeherder
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </a>
+    <button
+      aria-label="Dismiss"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeMedium css-16podhg-MuiButtonBase-root-MuiIconButton-root"
+      data-testid="alert-close"
+      tabindex="0"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+        data-testid="CloseIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+        />
+      </svg>
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</div>
+`;

--- a/src/__tests__/utils/setupTests.ts
+++ b/src/__tests__/utils/setupTests.ts
@@ -49,7 +49,10 @@ jest.mock('taskcluster-client-web', () => {
 const MockedHooks = Hooks as jest.Mock;
 
 beforeEach(() => {
-  const triggerHook = jest.fn(() => Promise.resolve('rEtrRigGERtaSkId'));
+  const taskId = 'rEtrRigGERtaSkId';
+  const triggerHook = jest.fn(() =>
+    Promise.resolve({ taskId, status: { taskId } }),
+  );
   // After every test jest resets the mock implementation, so we need to define
   // it again for each test.
   MockedHooks.mockImplementation(() => {

--- a/src/components/CompareResults/Retrigger/RetriggerButton.tsx
+++ b/src/components/CompareResults/Retrigger/RetriggerButton.tsx
@@ -84,6 +84,10 @@ function RetriggerButton({ result }: RetriggerButtonProps) {
     enqueueSnackbar(message, {
       variant: 'info',
       autoHideDuration: 10000, // The default (6000ms) configured in App.tsx seems a bit low for this notification
+      // It's common that 2 notifications are sent (one for base, one for
+      // new), so specifying the width makes them look more consistent.
+      // This maxWidth is copied from notistack's own style.
+      style: { width: '1000px', maxWidth: 'calc(100vw - 40px)' },
       action: (snackbarKey) => (
         <>
           <Button

--- a/src/logic/taskcluster.ts
+++ b/src/logic/taskcluster.ts
@@ -197,7 +197,7 @@ export async function retrigger(retriggerJobConfig: {
   jobInfo: JobInformation;
   decisionTaskId: string;
   times: number;
-}) {
+}): Promise<string | null> {
   const { rootUrl, jobInfo, decisionTaskId, times } = retriggerJobConfig;
 
   if (!times) return null;
@@ -244,7 +244,7 @@ export async function retrigger(retriggerJobConfig: {
     credentials: userCredentials.credentials,
   });
 
-  const newTaskId = await hooks.triggerHook(hookGroupId, hookId, hookPayload);
+  const response = await hooks.triggerHook(hookGroupId, hookId, hookPayload);
 
-  return newTaskId;
+  return response.taskId;
 }

--- a/src/resources/Strings.tsx
+++ b/src/resources/Strings.tsx
@@ -146,6 +146,11 @@ export const Strings = {
         body: 'Choose how many clones of the base and new tasks will be started.',
         submitButton: 'Retrigger',
       },
+      notification: {
+        body: (taskType: 'base' | 'new', id: string) =>
+          `The retrigger request for the ${taskType} run has been sent successfully, with ID ${id}.`,
+        treeherderButton: 'Open Treeherder',
+      },
     },
   },
   errors: {


### PR DESCRIPTION
This dislpays a notification for each retrigger request: one for base and one for new. I tried to merge them, but found that it looked better with 2 individual notifications. Please tell me if you think otherwise :-)

Also updated tests.

Do not look at the first commits, they are coming from Andra's PR #695 because my tests build on them.

![image](https://github.com/user-attachments/assets/772607d7-caff-433c-b446-d1ab085889ea)


I tested from [this results page](https://deploy-preview-703--mozilla-perfcompare.netlify.app/compare-results?baseRev=c6bbeb21b9650e398bd364eba25a1e61bd285a19&baseRepo=mozilla-central&framework=1) but retriggers don't work from a deploy preview, so if you want to try you need to checkout the pull request on your local computer.