### PR TITLE
Used Grid to fix results header

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -719,72 +719,133 @@ exports[`Results Table Should match snapshot 1`] = `
                 Results
               </div>
               <div
-                class="f1wpas00"
+                class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 f1wpas00 css-1e9xsub-MuiGrid-root"
               >
-                <form
-                  aria-label="Search by title, platform, revision or options"
-                  class="MuiBox-root css-183ebj2"
+                <div
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 css-1k9lgq8-MuiGrid-root"
                 >
-                  <div
-                    class="MuiFormControl-root MuiTextField-root css-1cocm2p-MuiFormControl-root-MuiTextField-root"
+                  <form
+                    aria-label="Search by title, platform, revision or options"
+                    class="MuiBox-root css-1wxqtyp"
                   >
                     <div
-                      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-m7khg8-MuiInputBase-root-MuiOutlinedInput-root"
+                      class="MuiFormControl-root MuiTextField-root css-1cocm2p-MuiFormControl-root-MuiTextField-root"
                     >
                       <div
-                        class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-ittuaa-MuiInputAdornment-root"
+                        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-m7khg8-MuiInputBase-root-MuiOutlinedInput-root"
                       >
-                        <span
-                          class="notranslate"
+                        <div
+                          class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-ittuaa-MuiInputAdornment-root"
                         >
-                          ​
-                        </span>
-                        <svg
-                          aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                          data-testid="SearchIcon"
-                          focusable="false"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-                          />
-                        </svg>
-                      </div>
-                      <input
-                        aria-invalid="false"
-                        aria-label="Search by title, platform, revision or options"
-                        class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-rg83rj-MuiInputBase-input-MuiOutlinedInput-input"
-                        id=":r4:"
-                        placeholder="Search results"
-                        type="text"
-                        value=""
-                      />
-                      <div
-                        class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1laqsz7-MuiInputAdornment-root"
-                      >
-                        <button
-                          aria-label="Clear the search input"
-                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeSmall css-151ffkv-MuiButtonBase-root-MuiIconButton-root"
-                          tabindex="0"
-                          type="button"
-                        >
+                          <span
+                            class="notranslate"
+                          >
+                            ​
+                          </span>
                           <svg
                             aria-hidden="true"
                             class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                            data-testid="CloseIcon"
+                            data-testid="SearchIcon"
                             focusable="false"
                             viewBox="0 0 24 24"
                           >
                             <path
-                              d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                              d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
                             />
                           </svg>
-                          <span
-                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                          />
-                        </button>
+                        </div>
+                        <input
+                          aria-invalid="false"
+                          aria-label="Search by title, platform, revision or options"
+                          class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-rg83rj-MuiInputBase-input-MuiOutlinedInput-input"
+                          id=":r4:"
+                          placeholder="Search results"
+                          type="text"
+                          value=""
+                        />
+                        <div
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1laqsz7-MuiInputAdornment-root"
+                        >
+                          <button
+                            aria-label="Clear the search input"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeSmall css-151ffkv-MuiButtonBase-root-MuiIconButton-root"
+                            tabindex="0"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                              data-testid="CloseIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                              />
+                            </svg>
+                            <span
+                              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                            />
+                          </button>
+                        </div>
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+                        >
+                          <legend
+                            class="css-ihdtdm"
+                          >
+                            <span
+                              class="notranslate"
+                            >
+                              ​
+                            </span>
+                          </legend>
+                        </fieldset>
                       </div>
+                    </div>
+                  </form>
+                </div>
+                <div
+                  class="MuiGrid-root MuiGrid-item css-j8gwlw-MuiGrid-root"
+                >
+                  <div
+                    class="MuiFormControl-root css-q8hpuo-MuiFormControl-root"
+                  >
+                    <div
+                      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall framework-dropdown-select css-1iil27j-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+                      data-testid="framework-select"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-haspopup="listbox"
+                        aria-label="Framework"
+                        aria-labelledby="mui-component-select-framework"
+                        class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-jaypmb-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+                        id="mui-component-select-framework"
+                        role="button"
+                        tabindex="0"
+                      >
+                        talos
+                      </div>
+                      <input
+                        aria-hidden="true"
+                        class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                        name="framework"
+                        tabindex="-1"
+                        value="1"
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-w4piji-MuiSvgIcon-root-MuiSelect-icon"
+                        data-testid="ArrowDropDownIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M7 10l5 5 5-5z"
+                        />
+                      </svg>
                       <fieldset
                         aria-hidden="true"
                         class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
@@ -801,144 +862,99 @@ exports[`Results Table Should match snapshot 1`] = `
                       </fieldset>
                     </div>
                   </div>
-                </form>
-                <div
-                  class="MuiFormControl-root css-1nrlq1o-MuiFormControl-root"
-                >
-                  <div
-                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall framework-dropdown-select css-o91dfy-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
-                    data-testid="framework-select"
-                  >
-                    <div
-                      aria-expanded="false"
-                      aria-haspopup="listbox"
-                      aria-label="Framework"
-                      aria-labelledby="mui-component-select-framework"
-                      class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-jaypmb-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-                      id="mui-component-select-framework"
-                      role="button"
-                      tabindex="0"
-                    >
-                      talos
-                    </div>
-                    <input
-                      aria-hidden="true"
-                      class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
-                      name="framework"
-                      tabindex="-1"
-                      value="1"
-                    />
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-w4piji-MuiSvgIcon-root-MuiSelect-icon"
-                      data-testid="ArrowDropDownIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M7 10l5 5 5-5z"
-                      />
-                    </svg>
-                    <fieldset
-                      aria-hidden="true"
-                      class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-                    >
-                      <legend
-                        class="css-ihdtdm"
-                      >
-                        <span
-                          class="notranslate"
-                        >
-                          ​
-                        </span>
-                      </legend>
-                    </fieldset>
-                  </div>
                 </div>
                 <div
-                  class="MuiBox-root css-0"
-                  data-testid="revision-select"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1t7ybvx-MuiGrid-root"
                 >
                   <div
-                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-sizeSmall fiy3v8i css-1iil27j-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+                    class="MuiBox-root css-0"
+                    data-testid="revision-select"
                   >
                     <div
-                      aria-expanded="false"
-                      aria-haspopup="listbox"
-                      class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-jaypmb-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-                      role="button"
-                      tabindex="0"
+                      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-sizeSmall f96or0t css-1iil27j-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
                     >
                       <div
-                        class="fbc330 MuiBox-root css-0"
+                        aria-expanded="false"
+                        aria-haspopup="listbox"
+                        class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-jaypmb-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+                        role="button"
+                        tabindex="0"
                       >
-                        <svg
-                          aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                          focusable="false"
-                          viewBox="0 0 24 24"
+                        <div
+                          class="fbc330 MuiBox-root css-0"
                         >
                           <svg
                             aria-hidden="true"
                             class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                            data-testid="SortIcon"
                             focusable="false"
                             viewBox="0 0 24 24"
                           >
-                            <path
-                              d="M3 18h6v-2H3v2zM3 6v2h18V6H3zm0 7h12v-2H3v2z"
-                            />
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                              data-testid="SortIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M3 18h6v-2H3v2zM3 6v2h18V6H3zm0 7h12v-2H3v2z"
+                              />
+                            </svg>
                           </svg>
-                        </svg>
-                        All revisions
+                          All revisions
+                        </div>
                       </div>
-                    </div>
-                    <input
-                      aria-hidden="true"
-                      class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
-                      tabindex="-1"
-                      value="all-revisions"
-                    />
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-w4piji-MuiSvgIcon-root-MuiSelect-icon"
-                      data-testid="ArrowDropDownIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M7 10l5 5 5-5z"
+                      <input
+                        aria-hidden="true"
+                        class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                        tabindex="-1"
+                        value="all-revisions"
                       />
-                    </svg>
-                    <fieldset
-                      aria-hidden="true"
-                      class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-                    >
-                      <legend
-                        class="css-ihdtdm"
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-w4piji-MuiSvgIcon-root-MuiSelect-icon"
+                        data-testid="ArrowDropDownIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
                       >
-                        <span
-                          class="notranslate"
+                        <path
+                          d="M7 10l5 5 5-5z"
+                        />
+                      </svg>
+                      <fieldset
+                        aria-hidden="true"
+                        class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+                      >
+                        <legend
+                          class="css-ihdtdm"
                         >
-                          ​
-                        </span>
-                      </legend>
-                    </fieldset>
+                          <span
+                            class="notranslate"
+                          >
+                            ​
+                          </span>
+                        </legend>
+                      </fieldset>
+                    </div>
                   </div>
                 </div>
                 <div
-                  class="fs7ec1a"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1t7ybvx-MuiGrid-root"
                 >
-                  <button
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-iendvr-MuiButtonBase-root-MuiButton-root"
-                    tabindex="0"
-                    type="button"
+                  <div
+                    class="f6hg2jo"
                   >
-                    Download JSON
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
-                  </button>
+                    <button
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-iendvr-MuiButtonBase-root-MuiButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      Download JSON
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </header>

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -722,7 +722,7 @@ exports[`Results Table Should match snapshot 1`] = `
                 class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 f1wpas00 css-1e9xsub-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 css-1k9lgq8-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 css-fo77co-MuiGrid-root"
                 >
                   <form
                     aria-label="Search by title, platform, revision or options"
@@ -807,7 +807,7 @@ exports[`Results Table Should match snapshot 1`] = `
                   </form>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item css-j8gwlw-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1t7ybvx-MuiGrid-root"
                 >
                   <div
                     class="MuiFormControl-root css-q8hpuo-MuiFormControl-root"

--- a/src/__tests__/CompareResults/__snapshots__/RevisionSelect.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/RevisionSelect.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Revision select Should change 'All revisions' option to bb6a5e451dac 1`
       data-testid="revision-select"
     >
       <div
-        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-sizeSmall fiy3v8i css-1iil27j-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-sizeSmall f96or0t css-1iil27j-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
       >
         <div
           aria-expanded="false"

--- a/src/__tests__/CompareResults/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SearchInput.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Search by title/test name should filter results after a timeout or immediately with enter 1`] = `
 <form
   aria-label="Search by title, platform, revision or options"
-  class="MuiBox-root css-183ebj2"
+  class="MuiBox-root css-1wxqtyp"
 >
   <div
     class="MuiFormControl-root MuiTextField-root css-1cocm2p-MuiFormControl-root-MuiTextField-root"

--- a/src/components/CompareResults/DownloadButton.tsx
+++ b/src/components/CompareResults/DownloadButton.tsx
@@ -5,7 +5,6 @@ import { style } from 'typestyle';
 import { RootState } from '../../common/store';
 import { useAppSelector } from '../../hooks/app';
 import { Strings } from '../../resources/Strings';
-import { Spacing } from '../../styles';
 import type { CompareResultsItem } from '../../types/state';
 import { truncateHash } from '../../utils/helpers';
 
@@ -73,12 +72,12 @@ function generateJsonDataFromComparisonResults(
 
 const styles = {
   downloadButton: style({
-    marginLeft: Spacing.Small,
     height: '41px',
     flex: 'none',
     $nest: {
       '.MuiButtonBase-root': {
         height: '100%',
+        width: '100%',
       },
     },
   }),

--- a/src/components/CompareResults/ResultsMain.tsx
+++ b/src/components/CompareResults/ResultsMain.tsx
@@ -3,6 +3,7 @@ import { Suspense, useState } from 'react';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import FormControl from '@mui/material/FormControl';
+import Grid from '@mui/material/Grid';
 import { SelectChangeEvent } from '@mui/material/Select';
 import { Container } from '@mui/system';
 import { useSearchParams } from 'react-router-dom';
@@ -52,11 +53,6 @@ function ResultsMain() {
     }),
   };
 
-  const sxStyles = {
-    marginRight: 2,
-    marginLeft: 2,
-  };
-
   const onFrameworkChange = (event: SelectChangeEvent) => {
     const id = +event.target.value as Framework['id'];
     setFrameworkIdVal(id);
@@ -79,20 +75,28 @@ function ResultsMain() {
             <>
               <header>
                 <div className={styles.title}>Results</div>
-                <div className={styles.content}>
-                  <SearchInput onChange={setSearchTerm} />
-                  <FormControl>
-                    <FrameworkDropdown
-                      frameworkId={frameworkIdVal}
-                      sxStyles={sxStyles}
-                      size='small'
-                      variant='outlined'
-                      onChange={onFrameworkChange}
-                    />
-                  </FormControl>
-                  <RevisionSelect />
-                  <DownloadButton />
-                </div>
+
+                <Grid container className={styles.content} spacing={2}>
+                  <Grid item md={6} xs={12}>
+                    <SearchInput onChange={setSearchTerm} />
+                  </Grid>
+                  <Grid item xs>
+                    <FormControl sx={{ width: '100%' }}>
+                      <FrameworkDropdown
+                        frameworkId={frameworkIdVal}
+                        size='small'
+                        variant='outlined'
+                        onChange={onFrameworkChange}
+                      />
+                    </FormControl>
+                  </Grid>
+                  <Grid item xs>
+                    <RevisionSelect />
+                  </Grid>
+                  <Grid item xs>
+                    <DownloadButton />
+                  </Grid>
+                </Grid>
               </header>
               <ResultsTable
                 filteringSearchTerm={searchTerm}

--- a/src/components/CompareResults/RevisionSelect.tsx
+++ b/src/components/CompareResults/RevisionSelect.tsx
@@ -19,7 +19,7 @@ const styles = {
     gap: '1px',
   }),
   select: style({
-    width: '300px',
+    width: '100%',
   }),
 };
 

--- a/src/components/CompareResults/SearchInput.tsx
+++ b/src/components/CompareResults/SearchInput.tsx
@@ -43,7 +43,7 @@ function SearchInput({ onChange }: SearchInputProps) {
       component='form'
       aria-label={inputStrings.label}
       onSubmit={onSubmit}
-      sx={{ display: 'flex', marginRight: 'auto', width: '50%' }}
+      sx={{ display: 'flex', marginRight: 'auto', width: '100%' }}
     >
       <TextField
         placeholder={inputStrings.placeholder}

--- a/src/components/Shared/FrameworkDropdown.tsx
+++ b/src/components/Shared/FrameworkDropdown.tsx
@@ -7,7 +7,6 @@ import type { Framework } from '../../types/types';
 interface FrameworkDropdownProps {
   frameworkId: Framework['id'];
   labelId?: string;
-  sxStyles?: React.ComponentProps<typeof Select>['sx'];
   size?: 'small' | 'medium';
   variant?: 'standard' | 'outlined' | 'filled';
   onChange?: (event: SelectChangeEvent) => void;
@@ -31,7 +30,6 @@ const sortedFrameworks = sortFrameworks(frameworkMap);
 function FrameworkDropdown({
   frameworkId,
   labelId,
-  sxStyles,
   variant,
   size,
   onChange,
@@ -46,7 +44,6 @@ function FrameworkDropdown({
       name='framework'
       variant={variant}
       size={size}
-      sx={sxStyles}
       inputProps={{ 'aria-label': 'Framework' }}
     >
       {sortedFrameworks.map(([id, name]) => (


### PR DESCRIPTION
This PR fixes the header styles for the Results Table using `Grid`

<img width="1241" alt="Screenshot 2024-08-07 at 09 27 57" src="https://github.com/user-attachments/assets/c1813c56-318d-430b-afe6-8b51eeaf03f5">
