### PR TITLE
Tweak styles and characteristics of the charts

### DIFF
--- a/src/components/CompareResults/CommonGraph.tsx
+++ b/src/components/CompareResults/CommonGraph.tsx
@@ -17,7 +17,7 @@ const styles = {
 };
 
 function CommonGraph(props: CommonGraphProps) {
-  const { baseRevisionRuns, newRevisionRuns } = props;
+  const { baseRevisionRuns, newRevisionRuns, min, max } = props;
 
   const options = {
     plugins: {
@@ -69,19 +69,13 @@ function CommonGraph(props: CommonGraphProps) {
   const baseRunsDensity = Array.from(
     kde.density1d(baseRevisionRuns.values, {
       bandwidth: baseRevisionRuns.stddev,
-      extent: [
-        Math.min(...baseRevisionRuns.values),
-        Math.max(...baseRevisionRuns.values),
-      ],
+      extent: [min, max],
     }),
   );
   const newRunsDensity = Array.from(
     kde.density1d(newRevisionRuns.values, {
       bandwidth: newRevisionRuns.stddev,
-      extent: [
-        Math.min(...newRevisionRuns.values),
-        Math.max(...newRevisionRuns.values),
-      ],
+      extent: [min, max],
     }),
   );
 
@@ -126,6 +120,8 @@ interface CommonGraphProps {
     stddev: number;
     stddevPercent: number;
   };
+  min: number;
+  max: number;
 }
 
 export default CommonGraph;

--- a/src/components/CompareResults/CommonGraph.tsx
+++ b/src/components/CompareResults/CommonGraph.tsx
@@ -63,6 +63,15 @@ function CommonGraph(props: CommonGraphProps) {
         },
       },
     },
+    elements: {
+      line: {
+        borderWidth: 3,
+      },
+      point: {
+        pointRadius: 0,
+        pointHoverRadius: 5,
+      },
+    },
   };
 
   //////////////////// START FAST KDE ////////////////////////
@@ -100,6 +109,7 @@ function CommonGraph(props: CommonGraphProps) {
 
   return (
     <div className={styles.container}>
+      {/* @ts-expect-error the types for chart.js do not seem great and do not support all options. */}
       <Line options={options} data={data} />
     </div>
   );

--- a/src/components/CompareResults/CommonGraph.tsx
+++ b/src/components/CompareResults/CommonGraph.tsx
@@ -82,15 +82,19 @@ function CommonGraph(props: CommonGraphProps) {
   };
 
   //////////////////// START FAST KDE ////////////////////////
+  // Arbitrary value that seems to work OK.
+  // In the future we'll want to compute a better value, see
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=1901248 for some ideas.
+  const bandwidth = (max - min) / 15;
   const baseRunsDensity = Array.from(
     kde.density1d(baseRevisionRuns.values, {
-      bandwidth: baseRevisionRuns.stddev,
+      bandwidth,
       extent: [min, max],
     }),
   );
   const newRunsDensity = Array.from(
     kde.density1d(newRevisionRuns.values, {
-      bandwidth: newRevisionRuns.stddev,
+      bandwidth,
       extent: [min, max],
     }),
   );

--- a/src/components/CompareResults/CommonGraph.tsx
+++ b/src/components/CompareResults/CommonGraph.tsx
@@ -72,6 +72,13 @@ function CommonGraph(props: CommonGraphProps) {
         pointHoverRadius: 5,
       },
     },
+    interaction: {
+      // Ideally we'd use this mode, but the tooltip then shows
+      // duplicate items. It could be good to debug this in the future.
+      //mode: 'x',
+      // It shows the tooltips as soon as the mouse cursor is on the graph.
+      intersect: false,
+    },
   };
 
   //////////////////// START FAST KDE ////////////////////////

--- a/src/components/CompareResults/Distribution.tsx
+++ b/src/components/CompareResults/Distribution.tsx
@@ -12,6 +12,23 @@ const styles = {
   }),
 };
 
+function computeMinMax(
+  baseRuns: number[],
+  newRuns: number[],
+): [number, number] {
+  let min = Infinity;
+  let max = -Infinity;
+  for (const value of baseRuns) {
+    min = Math.min(min, value);
+    max = Math.max(max, value);
+  }
+  for (const value of newRuns) {
+    min = Math.min(min, value);
+    max = Math.max(max, value);
+  }
+  return [min, max];
+}
+
 function Distribution(props: DistributionProps) {
   const { result } = props;
   const {
@@ -49,13 +66,21 @@ function Distribution(props: DistributionProps) {
     measurementUnit: newUnit,
   };
 
+  const [minValue, maxValue] = computeMinMax(baseRuns, newRuns);
+
   return (
     <div className={styles.container}>
-      <RunValues revisionRuns={baseRevisionRuns} />
-      <RunValues revisionRuns={newRevisionRuns} />
+      <RunValues
+        revisionRuns={baseRevisionRuns}
+        min={minValue}
+        max={maxValue}
+      />
+      <RunValues revisionRuns={newRevisionRuns} min={minValue} max={maxValue} />
       <CommonGraph
         baseRevisionRuns={baseRevisionRuns}
         newRevisionRuns={newRevisionRuns}
+        min={minValue}
+        max={maxValue}
       />
     </div>
   );

--- a/src/components/CompareResults/GraphDistribution.tsx
+++ b/src/components/CompareResults/GraphDistribution.tsx
@@ -18,7 +18,7 @@ interface GraphContextRaw {
 }
 
 function GraphDistribution(props: GraphDistributionProps) {
-  const { name, values } = props;
+  const { name, values, min, max } = props;
 
   const graphData = values.map((v) => {
     return { x: v, y: 0, r: 10 };
@@ -43,6 +43,8 @@ function GraphDistribution(props: GraphDistributionProps) {
         grid: {
           display: false,
         },
+        suggestedMin: min,
+        suggestedMax: max,
       },
       y: {
         ticks: {
@@ -81,6 +83,8 @@ function GraphDistribution(props: GraphDistributionProps) {
 interface GraphDistributionProps {
   name: string;
   values: number[];
+  min: number;
+  max: number;
 }
 
 export default GraphDistribution;

--- a/src/components/CompareResults/GraphDistribution.tsx
+++ b/src/components/CompareResults/GraphDistribution.tsx
@@ -55,6 +55,11 @@ function GraphDistribution(props: GraphDistributionProps) {
         },
       },
     },
+    elements: {
+      point: {
+        pointStyle: 'triangle',
+      },
+    },
   };
 
   const data = {

--- a/src/components/CompareResults/RunValues.tsx
+++ b/src/components/CompareResults/RunValues.tsx
@@ -45,7 +45,12 @@ function RunValues(props: RunValuesProps) {
         </div>
       )}
       <div>
-        <GraphDistribution name={name} values={values} />
+        <GraphDistribution
+          name={name}
+          values={values}
+          min={props.min}
+          max={props.max}
+        />
       </div>
       <div>
         <div className={styles.values}>
@@ -72,6 +77,8 @@ interface RunValuesProps {
     stddevPercent: number;
     measurementUnit: MeasurementUnit;
   };
+  min: number;
+  max: number;
 }
 
 export default RunValues;


### PR DESCRIPTION
I've been testing with [this URL](https://deploy-preview-709--mozilla-perfcompare.netlify.app/compare-results?baseRev=c6bbeb21b9650e398bd364eba25a1e61bd285a19&baseRepo=mozilla-central&newRev=70728a2fa4a234daf6c2ce7278965031bc2565a6&newRepo=mozilla-central&framework=1) (compare with the [beta branch](https://beta--mozilla-perfcompare.netlify.app/compare-results?baseRev=c6bbeb21b9650e398bd364eba25a1e61bd285a19&baseRepo=mozilla-central&newRev=70728a2fa4a234daf6c2ce7278965031bc2565a6&newRepo=mozilla-central&framework=1)) that has a few retriggers.

I tweaked a few things with this patch (each line is a separate commit):
* By using triangles instead of circles, we get a sharper shape, and therefore it's easier to distinguish them when they're closer
* all graphs are now on the same scale, which makes them easier to compare
* the perceived width of the runs density graph is now smaller
* the runs density graph is now (IMO) nicer to interact with
* the bandwidth for the KDE computation is more sensible, at least for the graphs I tried them with. Hopefully it's OK for others too.

Before:
![image](https://github.com/user-attachments/assets/736ebb08-ebdb-4e69-a071-fe602f57f294)


After:
![image](https://github.com/user-attachments/assets/7ffaae99-0fc4-482e-b63a-130e27653123)
