### PR TITLE
Use position sticky for the headers

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -7,6 +7,245 @@ exports[`Results View The table should match snapshot and other elements should 
   role="table"
 >
   <div
+    class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 f1wpas00 css-1e9xsub-MuiGrid-root"
+  >
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 css-fo77co-MuiGrid-root"
+    >
+      <form
+        aria-label="Search by title, platform, revision or options"
+        class="MuiBox-root css-1wxqtyp"
+      >
+        <div
+          class="MuiFormControl-root MuiTextField-root css-1cocm2p-MuiFormControl-root-MuiTextField-root"
+        >
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-m7khg8-MuiInputBase-root-MuiOutlinedInput-root"
+          >
+            <div
+              class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-ittuaa-MuiInputAdornment-root"
+            >
+              <span
+                class="notranslate"
+              >
+                ​
+              </span>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                data-testid="SearchIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                />
+              </svg>
+            </div>
+            <input
+              aria-invalid="false"
+              aria-label="Search by title, platform, revision or options"
+              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-rg83rj-MuiInputBase-input-MuiOutlinedInput-input"
+              id=":r3:"
+              placeholder="Search results"
+              type="text"
+              value=""
+            />
+            <div
+              class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1laqsz7-MuiInputAdornment-root"
+            >
+              <button
+                aria-label="Clear the search input"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeSmall css-151ffkv-MuiButtonBase-root-MuiIconButton-root"
+                tabindex="0"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                  data-testid="CloseIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+            >
+              <legend
+                class="css-ihdtdm"
+              >
+                <span
+                  class="notranslate"
+                >
+                  ​
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1t7ybvx-MuiGrid-root"
+    >
+      <div
+        class="MuiFormControl-root css-q8hpuo-MuiFormControl-root"
+      >
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall framework-dropdown-select css-1iil27j-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+          data-testid="framework-select"
+        >
+          <div
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-label="Framework"
+            aria-labelledby="mui-component-select-framework"
+            class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-jaypmb-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+            id="mui-component-select-framework"
+            role="button"
+            tabindex="0"
+          >
+            talos
+          </div>
+          <input
+            aria-hidden="true"
+            class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+            name="framework"
+            tabindex="-1"
+            value="1"
+          />
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-w4piji-MuiSvgIcon-root-MuiSelect-icon"
+            data-testid="ArrowDropDownIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-ihdtdm"
+            >
+              <span
+                class="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1t7ybvx-MuiGrid-root"
+    >
+      <div
+        class="MuiBox-root css-0"
+        data-testid="revision-select"
+      >
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-sizeSmall f96or0t css-1iil27j-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+        >
+          <div
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-jaypmb-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+            role="button"
+            tabindex="0"
+          >
+            <div
+              class="fbc330 MuiBox-root css-0"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                  data-testid="SortIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M3 18h6v-2H3v2zM3 6v2h18V6H3zm0 7h12v-2H3v2z"
+                  />
+                </svg>
+              </svg>
+              All revisions
+            </div>
+          </div>
+          <input
+            aria-hidden="true"
+            class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+            tabindex="-1"
+            value="all-revisions"
+          />
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-w4piji-MuiSvgIcon-root-MuiSelect-icon"
+            data-testid="ArrowDropDownIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-ihdtdm"
+            >
+              <span
+                class="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1t7ybvx-MuiGrid-root"
+    >
+      <div
+        class="f6hg2jo"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-iendvr-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          Download JSON
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+  <div
     class="f6frt4b fr2n4tx"
     data-testid="table-header"
     role="row"

--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -7,75 +7,136 @@ exports[`Results View The table should match snapshot and other elements should 
   role="table"
 >
   <div
-    class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 f1wpas00 css-1e9xsub-MuiGrid-root"
+    class="MuiBox-root css-1rw0zd7"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 css-fo77co-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 f1wpas00 css-1e9xsub-MuiGrid-root"
     >
-      <form
-        aria-label="Search by title, platform, revision or options"
-        class="MuiBox-root css-1wxqtyp"
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 css-fo77co-MuiGrid-root"
       >
-        <div
-          class="MuiFormControl-root MuiTextField-root css-1cocm2p-MuiFormControl-root-MuiTextField-root"
+        <form
+          aria-label="Search by title, platform, revision or options"
+          class="MuiBox-root css-1wxqtyp"
         >
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-m7khg8-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiFormControl-root MuiTextField-root css-1cocm2p-MuiFormControl-root-MuiTextField-root"
           >
             <div
-              class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-ittuaa-MuiInputAdornment-root"
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-m7khg8-MuiInputBase-root-MuiOutlinedInput-root"
             >
-              <span
-                class="notranslate"
+              <div
+                class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-ittuaa-MuiInputAdornment-root"
               >
-                ​
-              </span>
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                data-testid="SearchIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-                />
-              </svg>
-            </div>
-            <input
-              aria-invalid="false"
-              aria-label="Search by title, platform, revision or options"
-              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-rg83rj-MuiInputBase-input-MuiOutlinedInput-input"
-              id=":r3:"
-              placeholder="Search results"
-              type="text"
-              value=""
-            />
-            <div
-              class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1laqsz7-MuiInputAdornment-root"
-            >
-              <button
-                aria-label="Clear the search input"
-                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeSmall css-151ffkv-MuiButtonBase-root-MuiIconButton-root"
-                tabindex="0"
-                type="button"
-              >
+                <span
+                  class="notranslate"
+                >
+                  ​
+                </span>
                 <svg
                   aria-hidden="true"
                   class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                  data-testid="CloseIcon"
+                  data-testid="SearchIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
                   <path
-                    d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
                   />
                 </svg>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
-              </button>
+              </div>
+              <input
+                aria-invalid="false"
+                aria-label="Search by title, platform, revision or options"
+                class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-rg83rj-MuiInputBase-input-MuiOutlinedInput-input"
+                id=":r3:"
+                placeholder="Search results"
+                type="text"
+                value=""
+              />
+              <div
+                class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1laqsz7-MuiInputAdornment-root"
+              >
+                <button
+                  aria-label="Clear the search input"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeSmall css-151ffkv-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                    data-testid="CloseIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+              <fieldset
+                aria-hidden="true"
+                class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="css-ihdtdm"
+                >
+                  <span
+                    class="notranslate"
+                  >
+                    ​
+                  </span>
+                </legend>
+              </fieldset>
             </div>
+          </div>
+        </form>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1t7ybvx-MuiGrid-root"
+      >
+        <div
+          class="MuiFormControl-root css-q8hpuo-MuiFormControl-root"
+        >
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall framework-dropdown-select css-1iil27j-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+            data-testid="framework-select"
+          >
+            <div
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-label="Framework"
+              aria-labelledby="mui-component-select-framework"
+              class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-jaypmb-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+              id="mui-component-select-framework"
+              role="button"
+              tabindex="0"
+            >
+              talos
+            </div>
+            <input
+              aria-hidden="true"
+              class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+              name="framework"
+              tabindex="-1"
+              value="1"
+            />
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-w4piji-MuiSvgIcon-root-MuiSelect-icon"
+              data-testid="ArrowDropDownIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7 10l5 5 5-5z"
+              />
+            </svg>
             <fieldset
               aria-hidden="true"
               class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
@@ -92,293 +153,236 @@ exports[`Results View The table should match snapshot and other elements should 
             </fieldset>
           </div>
         </div>
-      </form>
-    </div>
-    <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1t7ybvx-MuiGrid-root"
-    >
-      <div
-        class="MuiFormControl-root css-q8hpuo-MuiFormControl-root"
-      >
-        <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall framework-dropdown-select css-1iil27j-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
-          data-testid="framework-select"
-        >
-          <div
-            aria-expanded="false"
-            aria-haspopup="listbox"
-            aria-label="Framework"
-            aria-labelledby="mui-component-select-framework"
-            class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-jaypmb-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-            id="mui-component-select-framework"
-            role="button"
-            tabindex="0"
-          >
-            talos
-          </div>
-          <input
-            aria-hidden="true"
-            class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
-            name="framework"
-            tabindex="-1"
-            value="1"
-          />
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-w4piji-MuiSvgIcon-root-MuiSelect-icon"
-            data-testid="ArrowDropDownIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M7 10l5 5 5-5z"
-            />
-          </svg>
-          <fieldset
-            aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-          >
-            <legend
-              class="css-ihdtdm"
-            >
-              <span
-                class="notranslate"
-              >
-                ​
-              </span>
-            </legend>
-          </fieldset>
-        </div>
       </div>
-    </div>
-    <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1t7ybvx-MuiGrid-root"
-    >
       <div
-        class="MuiBox-root css-0"
-        data-testid="revision-select"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1t7ybvx-MuiGrid-root"
       >
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-sizeSmall f96or0t css-1iil27j-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+          class="MuiBox-root css-0"
+          data-testid="revision-select"
         >
           <div
-            aria-expanded="false"
-            aria-haspopup="listbox"
-            class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-jaypmb-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-            role="button"
-            tabindex="0"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-sizeSmall f96or0t css-1iil27j-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
           >
             <div
-              class="fbc330 MuiBox-root css-0"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-jaypmb-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+              role="button"
+              tabindex="0"
             >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <div
+                class="fbc330 MuiBox-root css-0"
               >
                 <svg
                   aria-hidden="true"
                   class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                  data-testid="SortIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
-                  <path
-                    d="M3 18h6v-2H3v2zM3 6v2h18V6H3zm0 7h12v-2H3v2z"
-                  />
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                    data-testid="SortIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M3 18h6v-2H3v2zM3 6v2h18V6H3zm0 7h12v-2H3v2z"
+                    />
+                  </svg>
                 </svg>
-              </svg>
-              All revisions
+                All revisions
+              </div>
             </div>
-          </div>
-          <input
-            aria-hidden="true"
-            class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
-            tabindex="-1"
-            value="all-revisions"
-          />
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-w4piji-MuiSvgIcon-root-MuiSelect-icon"
-            data-testid="ArrowDropDownIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M7 10l5 5 5-5z"
+            <input
+              aria-hidden="true"
+              class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+              tabindex="-1"
+              value="all-revisions"
             />
-          </svg>
-          <fieldset
-            aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-          >
-            <legend
-              class="css-ihdtdm"
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-w4piji-MuiSvgIcon-root-MuiSelect-icon"
+              data-testid="ArrowDropDownIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
             >
-              <span
-                class="notranslate"
+              <path
+                d="M7 10l5 5 5-5z"
+              />
+            </svg>
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+            >
+              <legend
+                class="css-ihdtdm"
               >
-                ​
-              </span>
-            </legend>
-          </fieldset>
+                <span
+                  class="notranslate"
+                >
+                  ​
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1t7ybvx-MuiGrid-root"
+      >
+        <div
+          class="f6hg2jo"
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-iendvr-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            Download JSON
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
         </div>
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1t7ybvx-MuiGrid-root"
+      class="f1wqnr25 fr2n4tx"
+      data-testid="table-header"
+      role="row"
     >
       <div
-        class="f6hg2jo"
+        class="cell platform-header"
+        role="columnheader"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-iendvr-MuiButtonBase-root-MuiButton-root"
+          aria-haspopup="true"
+          aria-label="Platform (Click to filter values)"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-gsklu7-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
-          Download JSON
+          Platform
+          <svg
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-reqpbo-MuiSvgIcon-root"
+            data-testid="FilterListIcon"
+            focusable="false"
+            role="img"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+            />
+            <title>
+              No active filters
+            </title>
+          </svg>
           <span
             class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
           />
         </button>
       </div>
-    </div>
-  </div>
-  <div
-    class="f1wqnr25 fr2n4tx"
-    data-testid="table-header"
-    role="row"
-  >
-    <div
-      class="cell platform-header"
-      role="columnheader"
-    >
-      <button
-        aria-haspopup="true"
-        aria-label="Platform (Click to filter values)"
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-gsklu7-MuiButtonBase-root-MuiButton-root"
-        tabindex="0"
-        type="button"
+      <div
+        class="cell base-header"
+        role="columnheader"
       >
-        Platform
-        <svg
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-reqpbo-MuiSvgIcon-root"
-          data-testid="FilterListIcon"
-          focusable="false"
-          role="img"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
-          />
-          <title>
-            No active filters
-          </title>
-        </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
-      </button>
-    </div>
-    <div
-      class="cell base-header"
-      role="columnheader"
-    >
-      Base
-    </div>
-    <div
-      class="cell comparisonSign-header"
-      role="columnheader"
-    />
-    <div
-      class="cell new-header"
-      role="columnheader"
-    >
-      New
-    </div>
-    <div
-      class="cell status-header"
-      role="columnheader"
-    >
-      <button
-        aria-haspopup="true"
-        aria-label="Status (Click to filter values)"
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-gsklu7-MuiButtonBase-root-MuiButton-root"
-        tabindex="0"
-        type="button"
+        Base
+      </div>
+      <div
+        class="cell comparisonSign-header"
+        role="columnheader"
+      />
+      <div
+        class="cell new-header"
+        role="columnheader"
       >
-        Status
-        <svg
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-reqpbo-MuiSvgIcon-root"
-          data-testid="FilterListIcon"
-          focusable="false"
-          role="img"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
-          />
-          <title>
-            No active filters
-          </title>
-        </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
-      </button>
-    </div>
-    <div
-      class="cell delta-header"
-      role="columnheader"
-    >
-      Delta(%)
-    </div>
-    <div
-      class="cell confidence-header"
-      role="columnheader"
-    >
-      <button
-        aria-haspopup="true"
-        aria-label="Confidence (Click to filter values)"
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-gsklu7-MuiButtonBase-root-MuiButton-root"
-        tabindex="0"
-        type="button"
+        New
+      </div>
+      <div
+        class="cell status-header"
+        role="columnheader"
       >
-        Confidence
-        <svg
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-reqpbo-MuiSvgIcon-root"
-          data-testid="FilterListIcon"
-          focusable="false"
-          role="img"
-          viewBox="0 0 24 24"
+        <button
+          aria-haspopup="true"
+          aria-label="Status (Click to filter values)"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-gsklu7-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
         >
-          <path
-            d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+          Status
+          <svg
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-reqpbo-MuiSvgIcon-root"
+            data-testid="FilterListIcon"
+            focusable="false"
+            role="img"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+            />
+            <title>
+              No active filters
+            </title>
+          </svg>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
           />
-          <title>
-            No active filters
-          </title>
-        </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
-      </button>
+        </button>
+      </div>
+      <div
+        class="cell delta-header"
+        role="columnheader"
+      >
+        Delta(%)
+      </div>
+      <div
+        class="cell confidence-header"
+        role="columnheader"
+      >
+        <button
+          aria-haspopup="true"
+          aria-label="Confidence (Click to filter values)"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-gsklu7-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          Confidence
+          <svg
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-reqpbo-MuiSvgIcon-root"
+            data-testid="FilterListIcon"
+            focusable="false"
+            role="img"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+            />
+            <title>
+              No active filters
+            </title>
+          </svg>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+      <div
+        class="cell runs-header"
+        role="columnheader"
+      >
+        Total Runs
+      </div>
+      <div
+        class="cell buttons-header"
+        role="columnheader"
+      />
+      <div
+        class="cell expand-header"
+        role="columnheader"
+      />
     </div>
-    <div
-      class="cell runs-header"
-      role="columnheader"
-    >
-      Total Runs
-    </div>
-    <div
-      class="cell buttons-header"
-      role="columnheader"
-    />
-    <div
-      class="cell expand-header"
-      role="columnheader"
-    />
   </div>
   <div
     data-virtuoso-scroller="true"

--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Results View The table should match snapshot and other elements should be present in the page 1`] = `
 <div
-  class="MuiBox-root css-10qup14"
+  class="MuiBox-root css-hshm0p"
   data-testid="results-table"
   role="table"
 >
@@ -246,7 +246,7 @@ exports[`Results View The table should match snapshot and other elements should 
     </div>
   </div>
   <div
-    class="f6frt4b fr2n4tx"
+    class="f1wqnr25 fr2n4tx"
     data-testid="table-header"
     role="row"
   >

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -725,75 +725,136 @@ exports[`Results Table Should match snapshot 1`] = `
               role="table"
             >
               <div
-                class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 f1wpas00 css-1e9xsub-MuiGrid-root"
+                class="MuiBox-root css-1rw0zd7"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 css-fo77co-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 f1wpas00 css-1e9xsub-MuiGrid-root"
                 >
-                  <form
-                    aria-label="Search by title, platform, revision or options"
-                    class="MuiBox-root css-1wxqtyp"
+                  <div
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 css-fo77co-MuiGrid-root"
                   >
-                    <div
-                      class="MuiFormControl-root MuiTextField-root css-1cocm2p-MuiFormControl-root-MuiTextField-root"
+                    <form
+                      aria-label="Search by title, platform, revision or options"
+                      class="MuiBox-root css-1wxqtyp"
                     >
                       <div
-                        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-m7khg8-MuiInputBase-root-MuiOutlinedInput-root"
+                        class="MuiFormControl-root MuiTextField-root css-1cocm2p-MuiFormControl-root-MuiTextField-root"
                       >
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-ittuaa-MuiInputAdornment-root"
+                          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-m7khg8-MuiInputBase-root-MuiOutlinedInput-root"
                         >
-                          <span
-                            class="notranslate"
+                          <div
+                            class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-ittuaa-MuiInputAdornment-root"
                           >
-                            ​
-                          </span>
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                            data-testid="SearchIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-                            />
-                          </svg>
-                        </div>
-                        <input
-                          aria-invalid="false"
-                          aria-label="Search by title, platform, revision or options"
-                          class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-rg83rj-MuiInputBase-input-MuiOutlinedInput-input"
-                          id=":r4:"
-                          placeholder="Search results"
-                          type="text"
-                          value=""
-                        />
-                        <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1laqsz7-MuiInputAdornment-root"
-                        >
-                          <button
-                            aria-label="Clear the search input"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeSmall css-151ffkv-MuiButtonBase-root-MuiIconButton-root"
-                            tabindex="0"
-                            type="button"
-                          >
+                            <span
+                              class="notranslate"
+                            >
+                              ​
+                            </span>
                             <svg
                               aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                              data-testid="CloseIcon"
+                              data-testid="SearchIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
                             >
                               <path
-                                d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
                               />
                             </svg>
-                            <span
-                              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                            />
-                          </button>
+                          </div>
+                          <input
+                            aria-invalid="false"
+                            aria-label="Search by title, platform, revision or options"
+                            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-rg83rj-MuiInputBase-input-MuiOutlinedInput-input"
+                            id=":r4:"
+                            placeholder="Search results"
+                            type="text"
+                            value=""
+                          />
+                          <div
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1laqsz7-MuiInputAdornment-root"
+                          >
+                            <button
+                              aria-label="Clear the search input"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeSmall css-151ffkv-MuiButtonBase-root-MuiIconButton-root"
+                              tabindex="0"
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                                data-testid="CloseIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                />
+                              </svg>
+                              <span
+                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                              />
+                            </button>
+                          </div>
+                          <fieldset
+                            aria-hidden="true"
+                            class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+                          >
+                            <legend
+                              class="css-ihdtdm"
+                            >
+                              <span
+                                class="notranslate"
+                              >
+                                ​
+                              </span>
+                            </legend>
+                          </fieldset>
                         </div>
+                      </div>
+                    </form>
+                  </div>
+                  <div
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1t7ybvx-MuiGrid-root"
+                  >
+                    <div
+                      class="MuiFormControl-root css-q8hpuo-MuiFormControl-root"
+                    >
+                      <div
+                        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall framework-dropdown-select css-1iil27j-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+                        data-testid="framework-select"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="listbox"
+                          aria-label="Framework"
+                          aria-labelledby="mui-component-select-framework"
+                          class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-jaypmb-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+                          id="mui-component-select-framework"
+                          role="button"
+                          tabindex="0"
+                        >
+                          talos
+                        </div>
+                        <input
+                          aria-hidden="true"
+                          class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                          name="framework"
+                          tabindex="-1"
+                          value="1"
+                        />
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-w4piji-MuiSvgIcon-root-MuiSelect-icon"
+                          data-testid="ArrowDropDownIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M7 10l5 5 5-5z"
+                          />
+                        </svg>
                         <fieldset
                           aria-hidden="true"
                           class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
@@ -810,293 +871,236 @@ exports[`Results Table Should match snapshot 1`] = `
                         </fieldset>
                       </div>
                     </div>
-                  </form>
-                </div>
-                <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1t7ybvx-MuiGrid-root"
-                >
-                  <div
-                    class="MuiFormControl-root css-q8hpuo-MuiFormControl-root"
-                  >
-                    <div
-                      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall framework-dropdown-select css-1iil27j-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
-                      data-testid="framework-select"
-                    >
-                      <div
-                        aria-expanded="false"
-                        aria-haspopup="listbox"
-                        aria-label="Framework"
-                        aria-labelledby="mui-component-select-framework"
-                        class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-jaypmb-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-                        id="mui-component-select-framework"
-                        role="button"
-                        tabindex="0"
-                      >
-                        talos
-                      </div>
-                      <input
-                        aria-hidden="true"
-                        class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
-                        name="framework"
-                        tabindex="-1"
-                        value="1"
-                      />
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-w4piji-MuiSvgIcon-root-MuiSelect-icon"
-                        data-testid="ArrowDropDownIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M7 10l5 5 5-5z"
-                        />
-                      </svg>
-                      <fieldset
-                        aria-hidden="true"
-                        class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-                      >
-                        <legend
-                          class="css-ihdtdm"
-                        >
-                          <span
-                            class="notranslate"
-                          >
-                            ​
-                          </span>
-                        </legend>
-                      </fieldset>
-                    </div>
                   </div>
-                </div>
-                <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1t7ybvx-MuiGrid-root"
-                >
                   <div
-                    class="MuiBox-root css-0"
-                    data-testid="revision-select"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1t7ybvx-MuiGrid-root"
                   >
                     <div
-                      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-sizeSmall f96or0t css-1iil27j-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+                      class="MuiBox-root css-0"
+                      data-testid="revision-select"
                     >
                       <div
-                        aria-expanded="false"
-                        aria-haspopup="listbox"
-                        class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-jaypmb-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-                        role="button"
-                        tabindex="0"
+                        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-sizeSmall f96or0t css-1iil27j-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
                       >
                         <div
-                          class="fbc330 MuiBox-root css-0"
+                          aria-expanded="false"
+                          aria-haspopup="listbox"
+                          class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-jaypmb-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+                          role="button"
+                          tabindex="0"
                         >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                            focusable="false"
-                            viewBox="0 0 24 24"
+                          <div
+                            class="fbc330 MuiBox-root css-0"
                           >
                             <svg
                               aria-hidden="true"
                               class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                              data-testid="SortIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
                             >
-                              <path
-                                d="M3 18h6v-2H3v2zM3 6v2h18V6H3zm0 7h12v-2H3v2z"
-                              />
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                                data-testid="SortIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M3 18h6v-2H3v2zM3 6v2h18V6H3zm0 7h12v-2H3v2z"
+                                />
+                              </svg>
                             </svg>
-                          </svg>
-                          All revisions
+                            All revisions
+                          </div>
                         </div>
-                      </div>
-                      <input
-                        aria-hidden="true"
-                        class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
-                        tabindex="-1"
-                        value="all-revisions"
-                      />
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-w4piji-MuiSvgIcon-root-MuiSelect-icon"
-                        data-testid="ArrowDropDownIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M7 10l5 5 5-5z"
+                        <input
+                          aria-hidden="true"
+                          class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                          tabindex="-1"
+                          value="all-revisions"
                         />
-                      </svg>
-                      <fieldset
-                        aria-hidden="true"
-                        class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-                      >
-                        <legend
-                          class="css-ihdtdm"
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-w4piji-MuiSvgIcon-root-MuiSelect-icon"
+                          data-testid="ArrowDropDownIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
                         >
-                          <span
-                            class="notranslate"
+                          <path
+                            d="M7 10l5 5 5-5z"
+                          />
+                        </svg>
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+                        >
+                          <legend
+                            class="css-ihdtdm"
                           >
-                            ​
-                          </span>
-                        </legend>
-                      </fieldset>
+                            <span
+                              class="notranslate"
+                            >
+                              ​
+                            </span>
+                          </legend>
+                        </fieldset>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1t7ybvx-MuiGrid-root"
+                  >
+                    <div
+                      class="f6hg2jo"
+                    >
+                      <button
+                        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-iendvr-MuiButtonBase-root-MuiButton-root"
+                        tabindex="0"
+                        type="button"
+                      >
+                        Download JSON
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
                     </div>
                   </div>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1t7ybvx-MuiGrid-root"
+                  class="f1wqnr25 fr2n4tx"
+                  data-testid="table-header"
+                  role="row"
                 >
                   <div
-                    class="f6hg2jo"
+                    class="cell platform-header"
+                    role="columnheader"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-iendvr-MuiButtonBase-root-MuiButton-root"
+                      aria-haspopup="true"
+                      aria-label="Platform (Click to filter values)"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-gsklu7-MuiButtonBase-root-MuiButton-root"
                       tabindex="0"
                       type="button"
                     >
-                      Download JSON
+                      Platform
+                      <svg
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-reqpbo-MuiSvgIcon-root"
+                        data-testid="FilterListIcon"
+                        focusable="false"
+                        role="img"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+                        />
+                        <title>
+                          No active filters
+                        </title>
+                      </svg>
                       <span
                         class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                       />
                     </button>
                   </div>
-                </div>
-              </div>
-              <div
-                class="f1wqnr25 fr2n4tx"
-                data-testid="table-header"
-                role="row"
-              >
-                <div
-                  class="cell platform-header"
-                  role="columnheader"
-                >
-                  <button
-                    aria-haspopup="true"
-                    aria-label="Platform (Click to filter values)"
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-gsklu7-MuiButtonBase-root-MuiButton-root"
-                    tabindex="0"
-                    type="button"
+                  <div
+                    class="cell base-header"
+                    role="columnheader"
                   >
-                    Platform
-                    <svg
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-reqpbo-MuiSvgIcon-root"
-                      data-testid="FilterListIcon"
-                      focusable="false"
-                      role="img"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
-                      />
-                      <title>
-                        No active filters
-                      </title>
-                    </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
-                  </button>
-                </div>
-                <div
-                  class="cell base-header"
-                  role="columnheader"
-                >
-                  Base
-                </div>
-                <div
-                  class="cell comparisonSign-header"
-                  role="columnheader"
-                />
-                <div
-                  class="cell new-header"
-                  role="columnheader"
-                >
-                  New
-                </div>
-                <div
-                  class="cell status-header"
-                  role="columnheader"
-                >
-                  <button
-                    aria-haspopup="true"
-                    aria-label="Status (Click to filter values)"
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-gsklu7-MuiButtonBase-root-MuiButton-root"
-                    tabindex="0"
-                    type="button"
+                    Base
+                  </div>
+                  <div
+                    class="cell comparisonSign-header"
+                    role="columnheader"
+                  />
+                  <div
+                    class="cell new-header"
+                    role="columnheader"
                   >
-                    Status
-                    <svg
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-reqpbo-MuiSvgIcon-root"
-                      data-testid="FilterListIcon"
-                      focusable="false"
-                      role="img"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
-                      />
-                      <title>
-                        No active filters
-                      </title>
-                    </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
-                  </button>
-                </div>
-                <div
-                  class="cell delta-header"
-                  role="columnheader"
-                >
-                  Delta(%)
-                </div>
-                <div
-                  class="cell confidence-header"
-                  role="columnheader"
-                >
-                  <button
-                    aria-haspopup="true"
-                    aria-label="Confidence (Click to filter values)"
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-gsklu7-MuiButtonBase-root-MuiButton-root"
-                    tabindex="0"
-                    type="button"
+                    New
+                  </div>
+                  <div
+                    class="cell status-header"
+                    role="columnheader"
                   >
-                    Confidence
-                    <svg
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-reqpbo-MuiSvgIcon-root"
-                      data-testid="FilterListIcon"
-                      focusable="false"
-                      role="img"
-                      viewBox="0 0 24 24"
+                    <button
+                      aria-haspopup="true"
+                      aria-label="Status (Click to filter values)"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-gsklu7-MuiButtonBase-root-MuiButton-root"
+                      tabindex="0"
+                      type="button"
                     >
-                      <path
-                        d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+                      Status
+                      <svg
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-reqpbo-MuiSvgIcon-root"
+                        data-testid="FilterListIcon"
+                        focusable="false"
+                        role="img"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+                        />
+                        <title>
+                          No active filters
+                        </title>
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                       />
-                      <title>
-                        No active filters
-                      </title>
-                    </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
-                  </button>
+                    </button>
+                  </div>
+                  <div
+                    class="cell delta-header"
+                    role="columnheader"
+                  >
+                    Delta(%)
+                  </div>
+                  <div
+                    class="cell confidence-header"
+                    role="columnheader"
+                  >
+                    <button
+                      aria-haspopup="true"
+                      aria-label="Confidence (Click to filter values)"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-gsklu7-MuiButtonBase-root-MuiButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      Confidence
+                      <svg
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-reqpbo-MuiSvgIcon-root"
+                        data-testid="FilterListIcon"
+                        focusable="false"
+                        role="img"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+                        />
+                        <title>
+                          No active filters
+                        </title>
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
+                  </div>
+                  <div
+                    class="cell runs-header"
+                    role="columnheader"
+                  >
+                    Total Runs
+                  </div>
+                  <div
+                    class="cell buttons-header"
+                    role="columnheader"
+                  />
+                  <div
+                    class="cell expand-header"
+                    role="columnheader"
+                  />
                 </div>
-                <div
-                  class="cell runs-header"
-                  role="columnheader"
-                >
-                  Total Runs
-                </div>
-                <div
-                  class="cell buttons-header"
-                  role="columnheader"
-                />
-                <div
-                  class="cell expand-header"
-                  role="columnheader"
-                />
               </div>
               <div
                 data-virtuoso-scroller="true"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -720,7 +720,7 @@ exports[`Results Table Should match snapshot 1`] = `
               </div>
             </header>
             <div
-              class="MuiBox-root css-10qup14"
+              class="MuiBox-root css-hshm0p"
               data-testid="results-table"
               role="table"
             >
@@ -964,7 +964,7 @@ exports[`Results Table Should match snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="f6frt4b fr2n4tx"
+                class="f1wqnr25 fr2n4tx"
                 data-testid="table-header"
                 role="row"
               >

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -718,6 +718,12 @@ exports[`Results Table Should match snapshot 1`] = `
               >
                 Results
               </div>
+            </header>
+            <div
+              class="MuiBox-root css-10qup14"
+              data-testid="results-table"
+              role="table"
+            >
               <div
                 class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 f1wpas00 css-1e9xsub-MuiGrid-root"
               >
@@ -957,12 +963,6 @@ exports[`Results Table Should match snapshot 1`] = `
                   </div>
                 </div>
               </div>
-            </header>
-            <div
-              class="MuiBox-root css-10qup14"
-              data-testid="results-table"
-              role="table"
-            >
               <div
                 class="f6frt4b fr2n4tx"
                 data-testid="table-header"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -670,75 +670,136 @@ exports[`Results View The table should match snapshot and other elements should 
   role="table"
 >
   <div
-    class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 f1wpas00 css-1e9xsub-MuiGrid-root"
+    class="MuiBox-root css-1rw0zd7"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 css-fo77co-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 f1wpas00 css-1e9xsub-MuiGrid-root"
     >
-      <form
-        aria-label="Search by title, platform, revision or options"
-        class="MuiBox-root css-1wxqtyp"
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 css-fo77co-MuiGrid-root"
       >
-        <div
-          class="MuiFormControl-root MuiTextField-root css-1cocm2p-MuiFormControl-root-MuiTextField-root"
+        <form
+          aria-label="Search by title, platform, revision or options"
+          class="MuiBox-root css-1wxqtyp"
         >
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-m7khg8-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiFormControl-root MuiTextField-root css-1cocm2p-MuiFormControl-root-MuiTextField-root"
           >
             <div
-              class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-ittuaa-MuiInputAdornment-root"
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-m7khg8-MuiInputBase-root-MuiOutlinedInput-root"
             >
-              <span
-                class="notranslate"
+              <div
+                class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-ittuaa-MuiInputAdornment-root"
               >
-                ​
-              </span>
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                data-testid="SearchIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-                />
-              </svg>
-            </div>
-            <input
-              aria-invalid="false"
-              aria-label="Search by title, platform, revision or options"
-              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-rg83rj-MuiInputBase-input-MuiOutlinedInput-input"
-              id=":r4:"
-              placeholder="Search results"
-              type="text"
-              value=""
-            />
-            <div
-              class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1laqsz7-MuiInputAdornment-root"
-            >
-              <button
-                aria-label="Clear the search input"
-                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeSmall css-151ffkv-MuiButtonBase-root-MuiIconButton-root"
-                tabindex="0"
-                type="button"
-              >
+                <span
+                  class="notranslate"
+                >
+                  ​
+                </span>
                 <svg
                   aria-hidden="true"
                   class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                  data-testid="CloseIcon"
+                  data-testid="SearchIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
                   <path
-                    d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
                   />
                 </svg>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
-              </button>
+              </div>
+              <input
+                aria-invalid="false"
+                aria-label="Search by title, platform, revision or options"
+                class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-rg83rj-MuiInputBase-input-MuiOutlinedInput-input"
+                id=":r4:"
+                placeholder="Search results"
+                type="text"
+                value=""
+              />
+              <div
+                class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1laqsz7-MuiInputAdornment-root"
+              >
+                <button
+                  aria-label="Clear the search input"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeSmall css-151ffkv-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                    data-testid="CloseIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+              <fieldset
+                aria-hidden="true"
+                class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="css-ihdtdm"
+                >
+                  <span
+                    class="notranslate"
+                  >
+                    ​
+                  </span>
+                </legend>
+              </fieldset>
             </div>
+          </div>
+        </form>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1t7ybvx-MuiGrid-root"
+      >
+        <div
+          class="MuiFormControl-root css-q8hpuo-MuiFormControl-root"
+        >
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall framework-dropdown-select css-1iil27j-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+            data-testid="framework-select"
+          >
+            <div
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-label="Framework"
+              aria-labelledby="mui-component-select-framework"
+              class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-jaypmb-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+              id="mui-component-select-framework"
+              role="button"
+              tabindex="0"
+            >
+              build_metrics
+            </div>
+            <input
+              aria-hidden="true"
+              class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+              name="framework"
+              tabindex="-1"
+              value="2"
+            />
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-w4piji-MuiSvgIcon-root-MuiSelect-icon"
+              data-testid="ArrowDropDownIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7 10l5 5 5-5z"
+              />
+            </svg>
             <fieldset
               aria-hidden="true"
               class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
@@ -755,293 +816,236 @@ exports[`Results View The table should match snapshot and other elements should 
             </fieldset>
           </div>
         </div>
-      </form>
-    </div>
-    <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1t7ybvx-MuiGrid-root"
-    >
-      <div
-        class="MuiFormControl-root css-q8hpuo-MuiFormControl-root"
-      >
-        <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall framework-dropdown-select css-1iil27j-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
-          data-testid="framework-select"
-        >
-          <div
-            aria-expanded="false"
-            aria-haspopup="listbox"
-            aria-label="Framework"
-            aria-labelledby="mui-component-select-framework"
-            class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-jaypmb-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-            id="mui-component-select-framework"
-            role="button"
-            tabindex="0"
-          >
-            build_metrics
-          </div>
-          <input
-            aria-hidden="true"
-            class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
-            name="framework"
-            tabindex="-1"
-            value="2"
-          />
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-w4piji-MuiSvgIcon-root-MuiSelect-icon"
-            data-testid="ArrowDropDownIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M7 10l5 5 5-5z"
-            />
-          </svg>
-          <fieldset
-            aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-          >
-            <legend
-              class="css-ihdtdm"
-            >
-              <span
-                class="notranslate"
-              >
-                ​
-              </span>
-            </legend>
-          </fieldset>
-        </div>
       </div>
-    </div>
-    <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1t7ybvx-MuiGrid-root"
-    >
       <div
-        class="MuiBox-root css-0"
-        data-testid="revision-select"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1t7ybvx-MuiGrid-root"
       >
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-sizeSmall f96or0t css-1iil27j-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+          class="MuiBox-root css-0"
+          data-testid="revision-select"
         >
           <div
-            aria-expanded="false"
-            aria-haspopup="listbox"
-            class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-jaypmb-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-            role="button"
-            tabindex="0"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-sizeSmall f96or0t css-1iil27j-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
           >
             <div
-              class="fbc330 MuiBox-root css-0"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-jaypmb-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+              role="button"
+              tabindex="0"
             >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <div
+                class="fbc330 MuiBox-root css-0"
               >
                 <svg
                   aria-hidden="true"
                   class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                  data-testid="SortIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
-                  <path
-                    d="M3 18h6v-2H3v2zM3 6v2h18V6H3zm0 7h12v-2H3v2z"
-                  />
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                    data-testid="SortIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M3 18h6v-2H3v2zM3 6v2h18V6H3zm0 7h12v-2H3v2z"
+                    />
+                  </svg>
                 </svg>
-              </svg>
-              All revisions
+                All revisions
+              </div>
             </div>
-          </div>
-          <input
-            aria-hidden="true"
-            class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
-            tabindex="-1"
-            value="all-revisions"
-          />
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-w4piji-MuiSvgIcon-root-MuiSelect-icon"
-            data-testid="ArrowDropDownIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M7 10l5 5 5-5z"
+            <input
+              aria-hidden="true"
+              class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+              tabindex="-1"
+              value="all-revisions"
             />
-          </svg>
-          <fieldset
-            aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-          >
-            <legend
-              class="css-ihdtdm"
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-w4piji-MuiSvgIcon-root-MuiSelect-icon"
+              data-testid="ArrowDropDownIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
             >
-              <span
-                class="notranslate"
+              <path
+                d="M7 10l5 5 5-5z"
+              />
+            </svg>
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+            >
+              <legend
+                class="css-ihdtdm"
               >
-                ​
-              </span>
-            </legend>
-          </fieldset>
+                <span
+                  class="notranslate"
+                >
+                  ​
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1t7ybvx-MuiGrid-root"
+      >
+        <div
+          class="f6hg2jo"
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-iendvr-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            Download JSON
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
         </div>
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1t7ybvx-MuiGrid-root"
+      class="f1wqnr25 fr2n4tx"
+      data-testid="table-header"
+      role="row"
     >
       <div
-        class="f6hg2jo"
+        class="cell platform-header"
+        role="columnheader"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-iendvr-MuiButtonBase-root-MuiButton-root"
+          aria-haspopup="true"
+          aria-label="Platform (Click to filter values)"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-gsklu7-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
-          Download JSON
+          Platform
+          <svg
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-reqpbo-MuiSvgIcon-root"
+            data-testid="FilterListIcon"
+            focusable="false"
+            role="img"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+            />
+            <title>
+              No active filters
+            </title>
+          </svg>
           <span
             class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
           />
         </button>
       </div>
-    </div>
-  </div>
-  <div
-    class="f1wqnr25 fr2n4tx"
-    data-testid="table-header"
-    role="row"
-  >
-    <div
-      class="cell platform-header"
-      role="columnheader"
-    >
-      <button
-        aria-haspopup="true"
-        aria-label="Platform (Click to filter values)"
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-gsklu7-MuiButtonBase-root-MuiButton-root"
-        tabindex="0"
-        type="button"
+      <div
+        class="cell base-header"
+        role="columnheader"
       >
-        Platform
-        <svg
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-reqpbo-MuiSvgIcon-root"
-          data-testid="FilterListIcon"
-          focusable="false"
-          role="img"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
-          />
-          <title>
-            No active filters
-          </title>
-        </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
-      </button>
-    </div>
-    <div
-      class="cell base-header"
-      role="columnheader"
-    >
-      Base
-    </div>
-    <div
-      class="cell comparisonSign-header"
-      role="columnheader"
-    />
-    <div
-      class="cell new-header"
-      role="columnheader"
-    >
-      New
-    </div>
-    <div
-      class="cell status-header"
-      role="columnheader"
-    >
-      <button
-        aria-haspopup="true"
-        aria-label="Status (Click to filter values)"
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-gsklu7-MuiButtonBase-root-MuiButton-root"
-        tabindex="0"
-        type="button"
+        Base
+      </div>
+      <div
+        class="cell comparisonSign-header"
+        role="columnheader"
+      />
+      <div
+        class="cell new-header"
+        role="columnheader"
       >
-        Status
-        <svg
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-reqpbo-MuiSvgIcon-root"
-          data-testid="FilterListIcon"
-          focusable="false"
-          role="img"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
-          />
-          <title>
-            No active filters
-          </title>
-        </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
-      </button>
-    </div>
-    <div
-      class="cell delta-header"
-      role="columnheader"
-    >
-      Delta(%)
-    </div>
-    <div
-      class="cell confidence-header"
-      role="columnheader"
-    >
-      <button
-        aria-haspopup="true"
-        aria-label="Confidence (Click to filter values)"
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-gsklu7-MuiButtonBase-root-MuiButton-root"
-        tabindex="0"
-        type="button"
+        New
+      </div>
+      <div
+        class="cell status-header"
+        role="columnheader"
       >
-        Confidence
-        <svg
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-reqpbo-MuiSvgIcon-root"
-          data-testid="FilterListIcon"
-          focusable="false"
-          role="img"
-          viewBox="0 0 24 24"
+        <button
+          aria-haspopup="true"
+          aria-label="Status (Click to filter values)"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-gsklu7-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
         >
-          <path
-            d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+          Status
+          <svg
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-reqpbo-MuiSvgIcon-root"
+            data-testid="FilterListIcon"
+            focusable="false"
+            role="img"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+            />
+            <title>
+              No active filters
+            </title>
+          </svg>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
           />
-          <title>
-            No active filters
-          </title>
-        </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
-      </button>
+        </button>
+      </div>
+      <div
+        class="cell delta-header"
+        role="columnheader"
+      >
+        Delta(%)
+      </div>
+      <div
+        class="cell confidence-header"
+        role="columnheader"
+      >
+        <button
+          aria-haspopup="true"
+          aria-label="Confidence (Click to filter values)"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-gsklu7-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          Confidence
+          <svg
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-reqpbo-MuiSvgIcon-root"
+            data-testid="FilterListIcon"
+            focusable="false"
+            role="img"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"
+            />
+            <title>
+              No active filters
+            </title>
+          </svg>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+      <div
+        class="cell runs-header"
+        role="columnheader"
+      >
+        Total Runs
+      </div>
+      <div
+        class="cell buttons-header"
+        role="columnheader"
+      />
+      <div
+        class="cell expand-header"
+        role="columnheader"
+      />
     </div>
-    <div
-      class="cell runs-header"
-      role="columnheader"
-    >
-      Total Runs
-    </div>
-    <div
-      class="cell buttons-header"
-      role="columnheader"
-    />
-    <div
-      class="cell expand-header"
-      role="columnheader"
-    />
   </div>
   <div
     data-virtuoso-scroller="true"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -665,7 +665,7 @@ exports[`Results View Should display Base, New and Common graphs with tooltips 1
 
 exports[`Results View The table should match snapshot and other elements should be present in the page 1`] = `
 <div
-  class="MuiBox-root css-10qup14"
+  class="MuiBox-root css-hshm0p"
   data-testid="results-table"
   role="table"
 >
@@ -909,7 +909,7 @@ exports[`Results View The table should match snapshot and other elements should 
     </div>
   </div>
   <div
-    class="f6frt4b fr2n4tx"
+    class="f1wqnr25 fr2n4tx"
     data-testid="table-header"
     role="row"
   >

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -670,6 +670,245 @@ exports[`Results View The table should match snapshot and other elements should 
   role="table"
 >
   <div
+    class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 f1wpas00 css-1e9xsub-MuiGrid-root"
+  >
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 css-fo77co-MuiGrid-root"
+    >
+      <form
+        aria-label="Search by title, platform, revision or options"
+        class="MuiBox-root css-1wxqtyp"
+      >
+        <div
+          class="MuiFormControl-root MuiTextField-root css-1cocm2p-MuiFormControl-root-MuiTextField-root"
+        >
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart MuiInputBase-adornedEnd css-m7khg8-MuiInputBase-root-MuiOutlinedInput-root"
+          >
+            <div
+              class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-ittuaa-MuiInputAdornment-root"
+            >
+              <span
+                class="notranslate"
+              >
+                ​
+              </span>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                data-testid="SearchIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                />
+              </svg>
+            </div>
+            <input
+              aria-invalid="false"
+              aria-label="Search by title, platform, revision or options"
+              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-rg83rj-MuiInputBase-input-MuiOutlinedInput-input"
+              id=":r4:"
+              placeholder="Search results"
+              type="text"
+              value=""
+            />
+            <div
+              class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1laqsz7-MuiInputAdornment-root"
+            >
+              <button
+                aria-label="Clear the search input"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeSmall css-151ffkv-MuiButtonBase-root-MuiIconButton-root"
+                tabindex="0"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                  data-testid="CloseIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+                <span
+                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+            >
+              <legend
+                class="css-ihdtdm"
+              >
+                <span
+                  class="notranslate"
+                >
+                  ​
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1t7ybvx-MuiGrid-root"
+    >
+      <div
+        class="MuiFormControl-root css-q8hpuo-MuiFormControl-root"
+      >
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall framework-dropdown-select css-1iil27j-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+          data-testid="framework-select"
+        >
+          <div
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-label="Framework"
+            aria-labelledby="mui-component-select-framework"
+            class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-jaypmb-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+            id="mui-component-select-framework"
+            role="button"
+            tabindex="0"
+          >
+            build_metrics
+          </div>
+          <input
+            aria-hidden="true"
+            class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+            name="framework"
+            tabindex="-1"
+            value="2"
+          />
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-w4piji-MuiSvgIcon-root-MuiSelect-icon"
+            data-testid="ArrowDropDownIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-ihdtdm"
+            >
+              <span
+                class="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1t7ybvx-MuiGrid-root"
+    >
+      <div
+        class="MuiBox-root css-0"
+        data-testid="revision-select"
+      >
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-sizeSmall f96or0t css-1iil27j-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+        >
+          <div
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-jaypmb-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+            role="button"
+            tabindex="0"
+          >
+            <div
+              class="fbc330 MuiBox-root css-0"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                  data-testid="SortIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M3 18h6v-2H3v2zM3 6v2h18V6H3zm0 7h12v-2H3v2z"
+                  />
+                </svg>
+              </svg>
+              All revisions
+            </div>
+          </div>
+          <input
+            aria-hidden="true"
+            class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+            tabindex="-1"
+            value="all-revisions"
+          />
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-w4piji-MuiSvgIcon-root-MuiSelect-icon"
+            data-testid="ArrowDropDownIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-ihdtdm"
+            >
+              <span
+                class="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1t7ybvx-MuiGrid-root"
+    >
+      <div
+        class="f6hg2jo"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-iendvr-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          Download JSON
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+  <div
     class="f6frt4b fr2n4tx"
     data-testid="table-header"
     role="row"

--- a/src/components/CompareResults/ResultsControls.tsx
+++ b/src/components/CompareResults/ResultsControls.tsx
@@ -1,0 +1,58 @@
+import FormControl from '@mui/material/FormControl';
+import Grid from '@mui/material/Grid';
+import { style } from 'typestyle';
+
+import type { CompareResultsItem } from '../../types/state';
+import type { Framework } from '../../types/types';
+import FrameworkDropdown from '../Shared/FrameworkDropdown';
+import DownloadButton from './DownloadButton';
+import RevisionSelect from './RevisionSelect';
+import SearchInput from './SearchInput';
+
+const controlsStyles = style({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  alignItems: 'center',
+});
+
+interface Props {
+  initialSearchTerm: string;
+  frameworkId: Framework['id'];
+  resultsPromise: Promise<CompareResultsItem[][]>;
+  onSearchTermChange: (searchTerm: string) => unknown;
+  onFrameworkChange: (frameworkId: Framework['id']) => unknown;
+}
+export default function ResultsControls({
+  initialSearchTerm,
+  frameworkId,
+  resultsPromise,
+  onSearchTermChange,
+  onFrameworkChange,
+}: Props) {
+  return (
+    <Grid container className={controlsStyles} spacing={2}>
+      <Grid item md={6} xs={12}>
+        <SearchInput
+          defaultValue={initialSearchTerm}
+          onChange={onSearchTermChange}
+        />
+      </Grid>
+      <Grid item xs>
+        <FormControl sx={{ width: '100%' }}>
+          <FrameworkDropdown
+            frameworkId={frameworkId}
+            size='small'
+            variant='outlined'
+            onChange={onFrameworkChange}
+          />
+        </FormControl>
+      </Grid>
+      <Grid item xs>
+        <RevisionSelect />
+      </Grid>
+      <Grid item xs>
+        <DownloadButton resultsPromise={resultsPromise} />
+      </Grid>
+    </Grid>
+  );
+}

--- a/src/components/CompareResults/ResultsMain.tsx
+++ b/src/components/CompareResults/ResultsMain.tsx
@@ -2,8 +2,6 @@ import { Suspense, useState } from 'react';
 
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
-import FormControl from '@mui/material/FormControl';
-import Grid from '@mui/material/Grid';
 import { Container } from '@mui/system';
 import { useSearchParams } from 'react-router-dom';
 import { Await, useLoaderData } from 'react-router-dom';
@@ -14,13 +12,10 @@ import useRawSearchParams from '../../hooks/useRawSearchParams';
 import { Colors, Spacing } from '../../styles';
 import type { CompareResultsItem } from '../../types/state';
 import { Framework } from '../../types/types';
-import FrameworkDropdown from '../Shared/FrameworkDropdown';
-import DownloadButton from './DownloadButton';
 import type { LoaderReturnValue } from './loader';
 import type { LoaderReturnValue as OverTimeLoaderReturnValue } from './overTimeLoader';
+import ResultsControls from './ResultsControls';
 import ResultsTable from './ResultsTable';
-import RevisionSelect from './RevisionSelect';
-import SearchInput from './SearchInput';
 
 function ResultsMain() {
   const { results, view, frameworkId, generation } = useLoaderData() as
@@ -49,11 +44,6 @@ function ResultsMain() {
       margin: 0,
       marginBottom: Spacing.Medium,
     }),
-    content: style({
-      display: 'flex',
-      justifyContent: 'flex-end',
-      alignItems: 'center',
-    }),
   };
 
   const onFrameworkChange = (newFrameworkId: Framework['id']) => {
@@ -77,30 +67,13 @@ function ResultsMain() {
     <Container className={styles.container} data-testid='results-main'>
       <header>
         <div className={styles.title}>Results</div>
-        <Grid container className={styles.content} spacing={2}>
-          <Grid item md={6} xs={12}>
-            <SearchInput
-              defaultValue={initialSearchTerm}
-              onChange={onSearchTermChange}
-            />
-          </Grid>
-          <Grid item xs>
-            <FormControl sx={{ width: '100%' }}>
-              <FrameworkDropdown
-                frameworkId={frameworkIdVal}
-                size='small'
-                variant='outlined'
-                onChange={onFrameworkChange}
-              />
-            </FormControl>
-          </Grid>
-          <Grid item xs>
-            <RevisionSelect />
-          </Grid>
-          <Grid item xs>
-            <DownloadButton resultsPromise={results} />
-          </Grid>
-        </Grid>
+        <ResultsControls
+          initialSearchTerm={initialSearchTerm}
+          frameworkId={frameworkIdVal}
+          resultsPromise={results}
+          onSearchTermChange={onSearchTermChange}
+          onFrameworkChange={onFrameworkChange}
+        />
       </header>
       {/* Using a key in Suspense makes it that it displays the fallback more
           consistently.

--- a/src/components/CompareResults/ResultsMain.tsx
+++ b/src/components/CompareResults/ResultsMain.tsx
@@ -1,32 +1,12 @@
-import { useState } from 'react';
-
 import { Container } from '@mui/system';
-import { useSearchParams } from 'react-router-dom';
-import { useLoaderData } from 'react-router-dom';
 import { style } from 'typestyle';
 
 import { useAppSelector } from '../../hooks/app';
-import useRawSearchParams from '../../hooks/useRawSearchParams';
 import { Colors, Spacing } from '../../styles';
-import { Framework } from '../../types/types';
-import type { LoaderReturnValue } from './loader';
-import type { LoaderReturnValue as OverTimeLoaderReturnValue } from './overTimeLoader';
-import ResultsControls from './ResultsControls';
 import ResultsTable from './ResultsTable';
 
 function ResultsMain() {
-  const { results, view, frameworkId, generation } = useLoaderData() as
-    | LoaderReturnValue
-    | OverTimeLoaderReturnValue;
-
   const themeMode = useAppSelector((state) => state.theme.mode);
-  const [searchParams, setSearchParams] = useSearchParams();
-
-  // This is our custom hook that updates the search params without a rerender.
-  const [rawSearchParams, updateRawSearchParams] = useRawSearchParams();
-  const initialSearchTerm = rawSearchParams.get('search') ?? '';
-  const [searchTerm, setSearchTerm] = useState(initialSearchTerm);
-  const [frameworkIdVal, setFrameworkIdVal] = useState(frameworkId);
 
   const themeColor100 =
     themeMode === 'light' ? Colors.Background300 : Colors.Background100Dark;
@@ -43,41 +23,12 @@ function ResultsMain() {
     }),
   };
 
-  const onFrameworkChange = (newFrameworkId: Framework['id']) => {
-    setFrameworkIdVal(newFrameworkId);
-
-    searchParams.set('framework', newFrameworkId.toString());
-    setSearchParams(searchParams);
-  };
-
-  const onSearchTermChange = (newSearchTerm: string) => {
-    setSearchTerm(newSearchTerm);
-    if (newSearchTerm) {
-      rawSearchParams.set('search', newSearchTerm);
-    } else {
-      rawSearchParams.delete('search');
-    }
-    updateRawSearchParams(rawSearchParams);
-  };
-
   return (
     <Container className={styles.container} data-testid='results-main'>
       <header>
         <div className={styles.title}>Results</div>
-        <ResultsControls
-          initialSearchTerm={initialSearchTerm}
-          frameworkId={frameworkIdVal}
-          resultsPromise={results}
-          onSearchTermChange={onSearchTermChange}
-          onFrameworkChange={onFrameworkChange}
-        />
       </header>
-      <ResultsTable
-        filteringSearchTerm={searchTerm}
-        resultsPromise={results}
-        view={view}
-        generation={generation}
-      />
+      <ResultsTable />
     </Container>
   );
 }

--- a/src/components/CompareResults/ResultsMain.tsx
+++ b/src/components/CompareResults/ResultsMain.tsx
@@ -1,16 +1,13 @@
-import { Suspense, useState } from 'react';
+import { useState } from 'react';
 
-import Box from '@mui/material/Box';
-import CircularProgress from '@mui/material/CircularProgress';
 import { Container } from '@mui/system';
 import { useSearchParams } from 'react-router-dom';
-import { Await, useLoaderData } from 'react-router-dom';
+import { useLoaderData } from 'react-router-dom';
 import { style } from 'typestyle';
 
 import { useAppSelector } from '../../hooks/app';
 import useRawSearchParams from '../../hooks/useRawSearchParams';
 import { Colors, Spacing } from '../../styles';
-import type { CompareResultsItem } from '../../types/state';
 import { Framework } from '../../types/types';
 import type { LoaderReturnValue } from './loader';
 import type { LoaderReturnValue as OverTimeLoaderReturnValue } from './overTimeLoader';
@@ -75,28 +72,12 @@ function ResultsMain() {
           onFrameworkChange={onFrameworkChange}
         />
       </header>
-      {/* Using a key in Suspense makes it that it displays the fallback more
-          consistently.
-          See https://github.com/mozilla/perfcompare/pull/702#discussion_r1705274740
-          for more explanation (and questioning) about this issue. */}
-      <Suspense
-        fallback={
-          <Box display='flex' justifyContent='center' sx={{ marginTop: 3 }}>
-            <CircularProgress />
-          </Box>
-        }
-        key={generation}
-      >
-        <Await resolve={results}>
-          {(resolvedResults) => (
-            <ResultsTable
-              filteringSearchTerm={searchTerm}
-              results={resolvedResults as CompareResultsItem[][]}
-              view={view}
-            />
-          )}
-        </Await>
-      </Suspense>
+      <ResultsTable
+        filteringSearchTerm={searchTerm}
+        resultsPromise={results}
+        view={view}
+        generation={generation}
+      />
     </Container>
   );
 }

--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -145,11 +145,7 @@ export default function ResultsTable() {
     .join(' ');
 
   return (
-    <Box
-      data-testid='results-table'
-      role='table'
-      sx={{ marginTop: 3, paddingBottom: 3 }}
-    >
+    <Box data-testid='results-table' role='table' sx={{ paddingBottom: 3 }}>
       <ResultsControls
         initialSearchTerm={initialSearchTerm}
         frameworkId={frameworkIdVal}

--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -10,8 +10,8 @@ import type { CompareResultsItem, RevisionsHeader } from '../../types/state';
 import type { CompareResultsTableConfig } from '../../types/types';
 import { getPlatformShortName } from '../../utils/platform';
 import NoResultsFound from './NoResultsFound';
-import TableContent from './TableContent';
 import TableHeader from './TableHeader';
+import TableRevisionContent from './TableRevisionContent';
 
 type Results = {
   key: string;
@@ -274,7 +274,7 @@ function ResultsTable({
         data={processedResults}
         computeItemKey={(_, res) => res.key}
         itemContent={(_, res) => (
-          <TableContent
+          <TableRevisionContent
             identifier={res.key}
             header={res.revisionHeader}
             results={res.value}

--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -1,61 +1,13 @@
-import { useMemo, useState, memo } from 'react';
+import { useState, memo } from 'react';
 
 import Box from '@mui/material/Box';
-import { Virtuoso } from 'react-virtuoso';
 
 import type { compareView, compareOverTimeView } from '../../common/constants';
-import { useAppSelector } from '../../hooks/app';
-import { Strings } from '../../resources/Strings';
-import type { CompareResultsItem, RevisionsHeader } from '../../types/state';
+import type { CompareResultsItem } from '../../types/state';
 import type { CompareResultsTableConfig } from '../../types/types';
 import { getPlatformShortName } from '../../utils/platform';
-import NoResultsFound from './NoResultsFound';
+import TableContent from './TableContent';
 import TableHeader from './TableHeader';
-import TableRevisionContent from './TableRevisionContent';
-
-type Results = {
-  key: string;
-  value: CompareResultsItem[];
-  revisionHeader: RevisionsHeader;
-};
-
-function processResults(results: CompareResultsItem[]) {
-  const processedResults: Map<string, CompareResultsItem[]> = new Map<
-    string,
-    CompareResultsItem[]
-  >();
-  results.forEach((result) => {
-    const { new_rev: newRevision, header_name: header } = result;
-    const rowIdentifier = header.concat(' ', newRevision);
-    if (processedResults.has(rowIdentifier)) {
-      (processedResults.get(rowIdentifier) as CompareResultsItem[]).push(
-        result,
-      );
-    } else {
-      processedResults.set(rowIdentifier, [result]);
-    }
-  });
-  const restructuredResults: Results[] = Array.from(
-    processedResults,
-    function ([rowIdentifier, result]) {
-      return {
-        key: rowIdentifier,
-        value: result,
-        revisionHeader: {
-          suite: result[0].suite,
-          framework_id: result[0].framework_id,
-          test: result[0].test,
-          option_name: result[0].option_name,
-          extra_options: result[0].extra_options,
-          new_rev: result[0].new_rev,
-          new_repo: result[0].new_repository_name,
-        },
-      };
-    },
-  );
-
-  return restructuredResults;
-}
 
 const cellsConfiguration: CompareResultsTableConfig[] = [
   {
@@ -129,104 +81,16 @@ const cellsConfiguration: CompareResultsTableConfig[] = [
   { key: 'expand', gridWidth: '0.2fr' },
 ];
 
-function resultMatchesSearchTerm(
-  result: CompareResultsItem,
-  searchTerm: string,
-) {
-  searchTerm = searchTerm.toLowerCase();
-  return (
-    result.suite.toLowerCase().includes(searchTerm) ||
-    result.extra_options.toLowerCase().includes(searchTerm) ||
-    result.option_name.toLowerCase().includes(searchTerm) ||
-    result.test.toLowerCase().includes(searchTerm) ||
-    result.new_rev.toLowerCase().includes(searchTerm) ||
-    result.platform.toLowerCase().includes(searchTerm)
-  );
-}
-
-function resultMatchesColumnFilter(
-  result: CompareResultsItem,
-  columnId: string,
-  uncheckedValues: Set<string>,
-): boolean {
-  const cellConfiguration = cellsConfiguration.find(
-    (cell) => cell.key === columnId,
-  );
-  if (!cellConfiguration || !cellConfiguration.filter) {
-    return true;
-  }
-
-  const { matchesFunction } = cellConfiguration;
-  for (const filterValue of uncheckedValues) {
-    if (matchesFunction(result, filterValue)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-// This function filters the results array using both the searchTerm and the
-// tableFilters. The tableFilters is a map ColumnID -> Set of values to remove.
-function filterResults(
-  results: CompareResultsItem[],
-  searchTerm: string,
-  tableFilters: Map<string, Set<string>>,
-) {
-  if (!searchTerm && !tableFilters.size) {
-    return results;
-  }
-
-  return results.filter((result) => {
-    if (!resultMatchesSearchTerm(result, searchTerm)) {
-      return false;
-    }
-
-    for (const [columnId, uncheckedValues] of tableFilters) {
-      if (resultMatchesColumnFilter(result, columnId, uncheckedValues)) {
-        return false;
-      }
-    }
-
-    return true;
-  });
-}
-
-const allRevisionsOption =
-  Strings.components.comparisonRevisionDropdown.allRevisions.key;
-
-type ResultsTableProps = {
+type Props = {
   filteringSearchTerm: string;
   results: CompareResultsItem[][];
   view: typeof compareView | typeof compareOverTimeView;
 };
 
-function ResultsTable({
-  filteringSearchTerm,
-  results,
-  view,
-}: ResultsTableProps) {
-  const activeComparison = useAppSelector(
-    (state) => state.comparison.activeComparison,
-  );
-
+function ResultsTable({ filteringSearchTerm, results, view }: Props) {
   const [tableFilters, setTableFilters] = useState(
     new Map() as Map<string, Set<string>>, // ColumnID -> Set<Values to remove>
   );
-
-  const processedResults = useMemo(() => {
-    const resultsForCurrentComparison =
-      activeComparison === allRevisionsOption
-        ? results.flat()
-        : results.find((result) => result[0].new_rev === activeComparison) ??
-          [];
-
-    const filteredResults = filterResults(
-      resultsForCurrentComparison,
-      filteringSearchTerm,
-      tableFilters,
-    );
-    return processResults(filteredResults);
-  }, [results, activeComparison, filteringSearchTerm, tableFilters]);
 
   const onClearFilter = (columnId: string) => {
     setTableFilters((oldFilters) => {
@@ -260,31 +124,14 @@ function ResultsTable({
         onToggleFilter={onToggleFilter}
         onClearFilter={onClearFilter}
       />
-      <Virtuoso
-        useWindowScroll
-        totalCount={processedResults.length}
-        overscan={{
-          /* These values are pretty arbitrary. The goal is to have more rows
-           * rendered than the current viewport, so that when scrolling fast
-           * (but not too fast) the white checkerboarding doesn't appear.
-           */
-          main: 5000,
-          reverse: 5000,
-        }}
-        data={processedResults}
-        computeItemKey={(_, res) => res.key}
-        itemContent={(_, res) => (
-          <TableRevisionContent
-            identifier={res.key}
-            header={res.revisionHeader}
-            results={res.value}
-            view={view}
-            rowGridTemplateColumns={rowGridTemplateColumns}
-          />
-        )}
+      <TableContent
+        cellsConfiguration={cellsConfiguration}
+        results={results}
+        filteringSearchTerm={filteringSearchTerm}
+        tableFilters={tableFilters}
+        view={view}
+        rowGridTemplateColumns={rowGridTemplateColumns}
       />
-
-      {processedResults.length == 0 && <NoResultsFound />}
     </Box>
   );
 }

--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -146,19 +146,28 @@ export default function ResultsTable() {
 
   return (
     <Box data-testid='results-table' role='table' sx={{ paddingBottom: 3 }}>
-      <ResultsControls
-        initialSearchTerm={initialSearchTerm}
-        frameworkId={frameworkIdVal}
-        resultsPromise={resultsPromise}
-        onSearchTermChange={onSearchTermChange}
-        onFrameworkChange={onFrameworkChange}
-      />
-      <TableHeader
-        cellsConfiguration={cellsConfiguration}
-        filters={tableFilters}
-        onToggleFilter={onToggleFilter}
-        onClearFilter={onClearFilter}
-      />
+      <Box
+        sx={{
+          position: 'sticky',
+          top: 0,
+          zIndex: 100,
+          bgcolor: 'background.default',
+        }}
+      >
+        <ResultsControls
+          initialSearchTerm={initialSearchTerm}
+          frameworkId={frameworkIdVal}
+          resultsPromise={resultsPromise}
+          onSearchTermChange={onSearchTermChange}
+          onFrameworkChange={onFrameworkChange}
+        />
+        <TableHeader
+          cellsConfiguration={cellsConfiguration}
+          filters={tableFilters}
+          onToggleFilter={onToggleFilter}
+          onClearFilter={onClearFilter}
+        />
+      </Box>
       {/* Using a key in Suspense makes it that it displays the fallback more
         consistently.
         See https://github.com/mozilla/perfcompare/pull/702#discussion_r1705274740

--- a/src/components/CompareResults/TableContent.tsx
+++ b/src/components/CompareResults/TableContent.tsx
@@ -1,0 +1,205 @@
+import { useMemo, memo } from 'react';
+
+import { Virtuoso } from 'react-virtuoso';
+
+import type { compareView, compareOverTimeView } from '../../common/constants';
+import { useAppSelector } from '../../hooks/app';
+import { Strings } from '../../resources/Strings';
+import type { CompareResultsItem, RevisionsHeader } from '../../types/state';
+import type { CompareResultsTableConfig } from '../../types/types';
+import NoResultsFound from './NoResultsFound';
+import TableRevisionContent from './TableRevisionContent';
+
+type ResultsForRevision = {
+  key: string;
+  value: CompareResultsItem[];
+  revisionHeader: RevisionsHeader;
+};
+
+function processResults(results: CompareResultsItem[]) {
+  const processedResults: Map<string, CompareResultsItem[]> = new Map<
+    string,
+    CompareResultsItem[]
+  >();
+  results.forEach((result) => {
+    const { new_rev: newRevision, header_name: header } = result;
+    const rowIdentifier = header.concat(' ', newRevision);
+    if (processedResults.has(rowIdentifier)) {
+      (processedResults.get(rowIdentifier) as CompareResultsItem[]).push(
+        result,
+      );
+    } else {
+      processedResults.set(rowIdentifier, [result]);
+    }
+  });
+  const restructuredResults: ResultsForRevision[] = Array.from(
+    processedResults,
+    function ([rowIdentifier, result]) {
+      return {
+        key: rowIdentifier,
+        value: result,
+        revisionHeader: {
+          suite: result[0].suite,
+          framework_id: result[0].framework_id,
+          test: result[0].test,
+          option_name: result[0].option_name,
+          extra_options: result[0].extra_options,
+          new_rev: result[0].new_rev,
+          new_repo: result[0].new_repository_name,
+        },
+      };
+    },
+  );
+
+  return restructuredResults;
+}
+
+function resultMatchesSearchTerm(
+  result: CompareResultsItem,
+  searchTerm: string,
+) {
+  searchTerm = searchTerm.toLowerCase();
+  return (
+    result.suite.toLowerCase().includes(searchTerm) ||
+    result.extra_options.toLowerCase().includes(searchTerm) ||
+    result.option_name.toLowerCase().includes(searchTerm) ||
+    result.test.toLowerCase().includes(searchTerm) ||
+    result.new_rev.toLowerCase().includes(searchTerm) ||
+    result.platform.toLowerCase().includes(searchTerm)
+  );
+}
+
+function resultMatchesColumnFilter(
+  cellsConfiguration: CompareResultsTableConfig[],
+  result: CompareResultsItem,
+  columnId: string,
+  uncheckedValues: Set<string>,
+): boolean {
+  const cellConfiguration = cellsConfiguration.find(
+    (cell) => cell.key === columnId,
+  );
+  if (!cellConfiguration || !cellConfiguration.filter) {
+    return true;
+  }
+
+  const { matchesFunction } = cellConfiguration;
+  for (const filterValue of uncheckedValues) {
+    if (matchesFunction(result, filterValue)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// This function filters the results array using both the searchTerm and the
+// tableFilters. The tableFilters is a map ColumnID -> Set of values to remove.
+function filterResults(
+  cellsConfiguration: CompareResultsTableConfig[],
+  results: CompareResultsItem[],
+  searchTerm: string,
+  tableFilters: Map<string, Set<string>>,
+) {
+  if (!searchTerm && !tableFilters.size) {
+    return results;
+  }
+
+  return results.filter((result) => {
+    if (!resultMatchesSearchTerm(result, searchTerm)) {
+      return false;
+    }
+
+    for (const [columnId, uncheckedValues] of tableFilters) {
+      if (
+        resultMatchesColumnFilter(
+          cellsConfiguration,
+          result,
+          columnId,
+          uncheckedValues,
+        )
+      ) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+}
+
+const allRevisionsOption =
+  Strings.components.comparisonRevisionDropdown.allRevisions.key;
+
+type Props = {
+  cellsConfiguration: CompareResultsTableConfig[];
+  results: CompareResultsItem[][];
+  filteringSearchTerm: string;
+  tableFilters: Map<string, Set<string>>; // ColumnID -> Set<Values to remove>
+  view: typeof compareView | typeof compareOverTimeView;
+  rowGridTemplateColumns: string;
+};
+
+function TableContent({
+  cellsConfiguration,
+  results,
+  filteringSearchTerm,
+  tableFilters,
+  view,
+  rowGridTemplateColumns,
+}: Props) {
+  const activeComparison = useAppSelector(
+    (state) => state.comparison.activeComparison,
+  );
+
+  const processedResults = useMemo(() => {
+    const resultsForCurrentComparison =
+      activeComparison === allRevisionsOption
+        ? results.flat()
+        : results.find((result) => result[0].new_rev === activeComparison) ??
+          [];
+
+    const filteredResults = filterResults(
+      cellsConfiguration,
+      resultsForCurrentComparison,
+      filteringSearchTerm,
+      tableFilters,
+    );
+    return processResults(filteredResults);
+  }, [
+    results,
+    activeComparison,
+    filteringSearchTerm,
+    tableFilters,
+    cellsConfiguration,
+  ]);
+
+  return (
+    <>
+      <Virtuoso
+        useWindowScroll
+        totalCount={processedResults.length}
+        overscan={{
+          /* These values are pretty arbitrary. The goal is to have more rows
+           * rendered than the current viewport, so that when scrolling fast
+           * (but not too fast) the white checkerboarding doesn't appear.
+           */
+          main: 5000,
+          reverse: 5000,
+        }}
+        data={processedResults}
+        computeItemKey={(_, res) => res.key}
+        itemContent={(_, res) => (
+          <TableRevisionContent
+            identifier={res.key}
+            header={res.revisionHeader}
+            results={res.value}
+            view={view}
+            rowGridTemplateColumns={rowGridTemplateColumns}
+          />
+        )}
+      />
+
+      {processedResults.length == 0 && <NoResultsFound />}
+    </>
+  );
+}
+
+export default memo(TableContent);

--- a/src/components/CompareResults/TableHeader.tsx
+++ b/src/components/CompareResults/TableHeader.tsx
@@ -124,6 +124,7 @@ function TableHeader({
         themeMode == 'light' ? Colors.Background100 : Colors.Background300Dark,
       borderRadius: '4px',
       padding: Spacing.Small,
+      marginTop: Spacing.Medium,
       $nest: {
         '.cell': {
           borderBottom: 'none',

--- a/src/components/CompareResults/TableRevisionContent.tsx
+++ b/src/components/CompareResults/TableRevisionContent.tsx
@@ -12,7 +12,7 @@ const styles = {
   }),
 };
 
-function TableContent(props: TableContentProps) {
+function TableRevisionContent(props: Props) {
   const { results, header, identifier, view, rowGridTemplateColumns } = props;
 
   return (
@@ -33,7 +33,7 @@ function TableContent(props: TableContentProps) {
   );
 }
 
-interface TableContentProps {
+interface Props {
   results: CompareResultsItem[];
   header: RevisionsHeader;
   identifier: string;
@@ -41,4 +41,4 @@ interface TableContentProps {
   view: typeof compareView | typeof compareOverTimeView;
 }
 
-export default TableContent;
+export default TableRevisionContent;


### PR DESCRIPTION
Problem statement: after the user scrolled down, then the search and filter are out of sight and it can be diffcult to find them back if the page is long. After #712 Full Page Search (Ctrl-F) doesn't work anymore, so it starts to be a bigger problem.

[deploy preview](https://deploy-preview-719--mozilla-perfcompare.netlify.app/compare-results?baseRev=a87b00c4f5cfad5ef2fee563342574340e983619&baseRepo=mozilla-central&newRev=0be9e6fdab7b5eb39e27461cbec046d8a0f9f951&newRepo=mozilla-central&framework=1)

It was much more work than what it looked initially, because the 2 components to make sticky were in very different places and I had to move a lot of code around.

I tried to split it in separate commits. The first commit is #750, I extracted it because it's fairly unrelated to that one. The other commits should be all related to this specific issue but I could split them to separate PRs if you prefer.

Also I didn't do it in the subtests view, mainly because I didn't think about it, but I believe this is still valuable to merge without it.

Tell me what you think!
