### PR TITLE
Make the improvement/regressions eaier to find by adding some colors and icons

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -204,7 +204,7 @@ exports[`Results View The table should match snapshot and other elements should 
     </div>
     <div>
       <div
-        class="revisionRow f1n3dbvc fp4ugv1"
+        class="revisionRow f603q1k fp4ugv1"
         role="row"
       >
         <div
@@ -262,7 +262,7 @@ exports[`Results View The table should match snapshot and other elements should 
           role="cell"
         >
           <span
-            class="status-hint improvement"
+            class="status-hint status-hint-improvement"
           >
             <svg
               aria-hidden="true"
@@ -419,7 +419,7 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="revisionRow f1n3dbvc fp4ugv1"
+        class="revisionRow f603q1k fp4ugv1"
         role="row"
       >
         <div
@@ -476,7 +476,7 @@ exports[`Results View The table should match snapshot and other elements should 
           role="cell"
         >
           <span
-            class="status-hint regression"
+            class="status-hint status-hint-regression"
           >
             <svg
               aria-hidden="true"
@@ -633,7 +633,7 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="revisionRow f1n3dbvc fp4ugv1"
+        class="revisionRow f603q1k fp4ugv1"
         role="row"
       >
         <div
@@ -837,7 +837,7 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="revisionRow f1n3dbvc fp4ugv1"
+        class="revisionRow f603q1k fp4ugv1"
         role="row"
       >
         <div

--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -204,7 +204,7 @@ exports[`Results View The table should match snapshot and other elements should 
     </div>
     <div>
       <div
-        class="revisionRow fib0xwf fp4ugv1"
+        class="revisionRow f1n3dbvc fp4ugv1"
         role="row"
       >
         <div
@@ -261,9 +261,22 @@ exports[`Results View The table should match snapshot and other elements should 
           class="status cell"
           role="cell"
         >
-           
-          Improvement
-           
+          <span
+            class="status-hint improvement"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+              data-testid="ThumbUpIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M1 21h4V9H1v12zm22-11c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 1 7.59 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2z"
+              />
+            </svg>
+            Improvement
+          </span>
         </div>
         <div
           class="delta cell"
@@ -406,7 +419,7 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="revisionRow fib0xwf fp4ugv1"
+        class="revisionRow f1n3dbvc fp4ugv1"
         role="row"
       >
         <div
@@ -462,9 +475,22 @@ exports[`Results View The table should match snapshot and other elements should 
           class="status cell"
           role="cell"
         >
-           
-          Regression
-           
+          <span
+            class="status-hint regression"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+              data-testid="ThumbDownIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2zm4 0v12h4V3h-4z"
+              />
+            </svg>
+            Regression
+          </span>
         </div>
         <div
           class="delta cell"
@@ -607,7 +633,7 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="revisionRow fib0xwf fp4ugv1"
+        class="revisionRow f1n3dbvc fp4ugv1"
         role="row"
       >
         <div
@@ -664,9 +690,11 @@ exports[`Results View The table should match snapshot and other elements should 
           class="status cell"
           role="cell"
         >
-           
-          -
-           
+          <span
+            class="status-hint "
+          >
+            -
+          </span>
         </div>
         <div
           class="delta cell"
@@ -809,7 +837,7 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="revisionRow fib0xwf fp4ugv1"
+        class="revisionRow f1n3dbvc fp4ugv1"
         role="row"
       >
         <div
@@ -866,9 +894,11 @@ exports[`Results View The table should match snapshot and other elements should 
           class="status cell"
           role="cell"
         >
-           
-          -
-           
+          <span
+            class="status-hint "
+          >
+            -
+          </span>
         </div>
         <div
           class="delta cell"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -1161,7 +1161,7 @@ exports[`Results Table Should match snapshot 1`] = `
                 </div>
                 <div>
                   <div
-                    class="revisionRow fib0xwf fp4ugv1"
+                    class="revisionRow f1n3dbvc fp4ugv1"
                     role="row"
                   >
                     <div
@@ -1218,9 +1218,22 @@ exports[`Results Table Should match snapshot 1`] = `
                       class="status cell"
                       role="cell"
                     >
-                       
-                      Improvement
-                       
+                      <span
+                        class="status-hint improvement"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                          data-testid="ThumbUpIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M1 21h4V9H1v12zm22-11c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 1 7.59 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2z"
+                          />
+                        </svg>
+                        Improvement
+                      </span>
                     </div>
                     <div
                       class="delta cell"
@@ -1363,7 +1376,7 @@ exports[`Results Table Should match snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="revisionRow fib0xwf fp4ugv1"
+                    class="revisionRow f1n3dbvc fp4ugv1"
                     role="row"
                   >
                     <div
@@ -1419,9 +1432,22 @@ exports[`Results Table Should match snapshot 1`] = `
                       class="status cell"
                       role="cell"
                     >
-                       
-                      Regression
-                       
+                      <span
+                        class="status-hint regression"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                          data-testid="ThumbDownIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2zm4 0v12h4V3h-4z"
+                          />
+                        </svg>
+                        Regression
+                      </span>
                     </div>
                     <div
                       class="delta cell"
@@ -1564,7 +1590,7 @@ exports[`Results Table Should match snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="revisionRow fib0xwf fp4ugv1"
+                    class="revisionRow f1n3dbvc fp4ugv1"
                     role="row"
                   >
                     <div
@@ -1621,9 +1647,11 @@ exports[`Results Table Should match snapshot 1`] = `
                       class="status cell"
                       role="cell"
                     >
-                       
-                      -
-                       
+                      <span
+                        class="status-hint "
+                      >
+                        -
+                      </span>
                     </div>
                     <div
                       class="delta cell"
@@ -1810,7 +1838,7 @@ exports[`Results Table Should match snapshot 1`] = `
                 </div>
                 <div>
                   <div
-                    class="revisionRow fib0xwf fp4ugv1"
+                    class="revisionRow f1n3dbvc fp4ugv1"
                     role="row"
                   >
                     <div
@@ -1867,9 +1895,11 @@ exports[`Results Table Should match snapshot 1`] = `
                       class="status cell"
                       role="cell"
                     >
-                       
-                      -
-                       
+                      <span
+                        class="status-hint "
+                      >
+                        -
+                      </span>
                     </div>
                     <div
                       class="delta cell"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -1161,7 +1161,7 @@ exports[`Results Table Should match snapshot 1`] = `
                 </div>
                 <div>
                   <div
-                    class="revisionRow f1n3dbvc fp4ugv1"
+                    class="revisionRow f603q1k fp4ugv1"
                     role="row"
                   >
                     <div
@@ -1219,7 +1219,7 @@ exports[`Results Table Should match snapshot 1`] = `
                       role="cell"
                     >
                       <span
-                        class="status-hint improvement"
+                        class="status-hint status-hint-improvement"
                       >
                         <svg
                           aria-hidden="true"
@@ -1376,7 +1376,7 @@ exports[`Results Table Should match snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="revisionRow f1n3dbvc fp4ugv1"
+                    class="revisionRow f603q1k fp4ugv1"
                     role="row"
                   >
                     <div
@@ -1433,7 +1433,7 @@ exports[`Results Table Should match snapshot 1`] = `
                       role="cell"
                     >
                       <span
-                        class="status-hint regression"
+                        class="status-hint status-hint-regression"
                       >
                         <svg
                           aria-hidden="true"
@@ -1590,7 +1590,7 @@ exports[`Results Table Should match snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="revisionRow f1n3dbvc fp4ugv1"
+                    class="revisionRow f603q1k fp4ugv1"
                     role="row"
                   >
                     <div
@@ -1838,7 +1838,7 @@ exports[`Results Table Should match snapshot 1`] = `
                 </div>
                 <div>
                   <div
-                    class="revisionRow f1n3dbvc fp4ugv1"
+                    class="revisionRow f603q1k fp4ugv1"
                     role="row"
                   >
                     <div

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -402,7 +402,7 @@ exports[`Results View The table should match snapshot and other elements should 
     </div>
     <div>
       <div
-        class="revisionRow fib0xwf fp4ugv1"
+        class="revisionRow f1n3dbvc fp4ugv1"
         role="row"
       >
         <div
@@ -459,9 +459,22 @@ exports[`Results View The table should match snapshot and other elements should 
           class="status cell"
           role="cell"
         >
-           
-          Improvement
-           
+          <span
+            class="status-hint improvement"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+              data-testid="ThumbUpIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M1 21h4V9H1v12zm22-11c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 1 7.59 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2z"
+              />
+            </svg>
+            Improvement
+          </span>
         </div>
         <div
           class="delta cell"
@@ -604,7 +617,7 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="revisionRow fib0xwf fp4ugv1"
+        class="revisionRow f1n3dbvc fp4ugv1"
         role="row"
       >
         <div
@@ -660,9 +673,22 @@ exports[`Results View The table should match snapshot and other elements should 
           class="status cell"
           role="cell"
         >
-           
-          Regression
-           
+          <span
+            class="status-hint regression"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+              data-testid="ThumbDownIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2zm4 0v12h4V3h-4z"
+              />
+            </svg>
+            Regression
+          </span>
         </div>
         <div
           class="delta cell"
@@ -805,7 +831,7 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="revisionRow fib0xwf fp4ugv1"
+        class="revisionRow f1n3dbvc fp4ugv1"
         role="row"
       >
         <div
@@ -862,9 +888,11 @@ exports[`Results View The table should match snapshot and other elements should 
           class="status cell"
           role="cell"
         >
-           
-          -
-           
+          <span
+            class="status-hint "
+          >
+            -
+          </span>
         </div>
         <div
           class="delta cell"
@@ -1007,7 +1035,7 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="revisionRow fib0xwf fp4ugv1"
+        class="revisionRow f1n3dbvc fp4ugv1"
         role="row"
       >
         <div
@@ -1064,9 +1092,11 @@ exports[`Results View The table should match snapshot and other elements should 
           class="status cell"
           role="cell"
         >
-           
-          -
-           
+          <span
+            class="status-hint "
+          >
+            -
+          </span>
         </div>
         <div
           class="delta cell"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -402,7 +402,7 @@ exports[`Results View The table should match snapshot and other elements should 
     </div>
     <div>
       <div
-        class="revisionRow f1n3dbvc fp4ugv1"
+        class="revisionRow f603q1k fp4ugv1"
         role="row"
       >
         <div
@@ -460,7 +460,7 @@ exports[`Results View The table should match snapshot and other elements should 
           role="cell"
         >
           <span
-            class="status-hint improvement"
+            class="status-hint status-hint-improvement"
           >
             <svg
               aria-hidden="true"
@@ -617,7 +617,7 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="revisionRow f1n3dbvc fp4ugv1"
+        class="revisionRow f603q1k fp4ugv1"
         role="row"
       >
         <div
@@ -674,7 +674,7 @@ exports[`Results View The table should match snapshot and other elements should 
           role="cell"
         >
           <span
-            class="status-hint regression"
+            class="status-hint status-hint-regression"
           >
             <svg
               aria-hidden="true"
@@ -831,7 +831,7 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="revisionRow f1n3dbvc fp4ugv1"
+        class="revisionRow f603q1k fp4ugv1"
         role="row"
       >
         <div
@@ -1035,7 +1035,7 @@ exports[`Results View The table should match snapshot and other elements should 
         </div>
       </div>
       <div
-        class="revisionRow f1n3dbvc fp4ugv1"
+        class="revisionRow f603q1k fp4ugv1"
         role="row"
       >
         <div

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -3,6 +3,8 @@ import { useState, type ReactNode } from 'react';
 import AppleIcon from '@mui/icons-material/Apple';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ThumbDownIcon from '@mui/icons-material/ThumbDown';
+import ThumbUpIcon from '@mui/icons-material/ThumbUp';
 import TimelineIcon from '@mui/icons-material/Timeline';
 import { IconButton } from '@mui/material';
 import Tooltip from '@mui/material/Tooltip';
@@ -102,6 +104,28 @@ const stylesLight = {
       '.expand-button': {
         backgroundColor: Colors.Background300,
       },
+      '.status-hint': {
+        display: 'inline-flex',
+        gap: '6px',
+        borderRadius: '4px',
+        padding: '4px 10px',
+      },
+      '.status-hint.regression': {
+        backgroundColor: '#FFE8E8',
+      },
+      '.status-hint.improvement': {
+        backgroundColor: '#D8EEDC',
+      },
+      '.status-hint .MuiSvgIcon-root': {
+        height: '16px',
+      },
+      '.status-hint.improvement .MuiSvgIcon-root': {
+        color: '#017A40',
+      },
+      '.status-hint.regression .MuiSvgIcon-root': {
+        marginTop: '2px',
+        color: '#D7264C',
+      },
     },
   }),
   typography: style({
@@ -174,6 +198,29 @@ const stylesDark = {
       '.expand-button': {
         backgroundColor: Colors.Background100Dark,
       },
+      '.status-hint': {
+        display: 'inline-flex',
+        gap: '4px',
+        borderRadius: '4px',
+        padding: '4px 10px',
+      },
+      '.status-hint.regression': {
+        backgroundColor: '#690F22',
+      },
+      '.status-hint.improvement': {
+        backgroundColor: '#004725',
+        marginTop: '2px',
+      },
+      '.status-hint .MuiSvgIcon-root': {
+        height: '16px',
+      },
+      '.status-hint.improvement .MuiSvgIcon-root': {
+        color: '#4DBC87',
+      },
+      '.status-hint.regression .MuiSvgIcon-root': {
+        marginTop: '2px',
+        color: '#F37F98',
+      },
     },
   }),
   typography: style({
@@ -187,6 +234,12 @@ function determineStatus(improvement: boolean, regression: boolean) {
   if (improvement) return 'Improvement';
   if (regression) return 'Regression';
   return '-';
+}
+
+function determineStatusHintStyle(improvement: boolean, regression: boolean) {
+  if (improvement) return 'improvement';
+  if (regression) return 'regression';
+  return '';
 }
 
 function determineSign(baseMedianValue: number, newMedianValue: number) {
@@ -310,8 +363,16 @@ function RevisionRow(props: RevisionRowProps) {
           {newMedianValue} {newUnit}
         </div>
         <div className='status cell' role='cell'>
-          {' '}
-          {determineStatus(improvement, regression)}{' '}
+          <span
+            className={`status-hint ${determineStatusHintStyle(
+              improvement,
+              regression,
+            )}`}
+          >
+            {improvement ? <ThumbUpIcon /> : null}
+            {regression ? <ThumbDownIcon /> : null}
+            {determineStatus(improvement, regression)}
+          </span>
         </div>
         <div className='delta cell' role='cell'>
           {' '}

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -110,19 +110,20 @@ const stylesLight = {
         borderRadius: '4px',
         padding: '4px 10px',
       },
-      '.status-hint.regression': {
-        backgroundColor: '#FFE8E8',
-      },
-      '.status-hint.improvement': {
+      '.status-hint-improvement': {
         backgroundColor: '#D8EEDC',
+      },
+      '.status-hint-regression': {
+        backgroundColor: '#FFE8E8',
       },
       '.status-hint .MuiSvgIcon-root': {
         height: '16px',
       },
-      '.status-hint.improvement .MuiSvgIcon-root': {
+      '.status-hint-improvement .MuiSvgIcon-root': {
         color: '#017A40',
       },
-      '.status-hint.regression .MuiSvgIcon-root': {
+      '.status-hint-regression .MuiSvgIcon-root': {
+        // We need to move the icon a bit lower so that it _looks_ centered.
         marginTop: '2px',
         color: '#D7264C',
       },
@@ -204,20 +205,21 @@ const stylesDark = {
         borderRadius: '4px',
         padding: '4px 10px',
       },
-      '.status-hint.regression': {
-        backgroundColor: '#690F22',
-      },
-      '.status-hint.improvement': {
+      '.status-hint-improvement': {
         backgroundColor: '#004725',
         marginTop: '2px',
+      },
+      '.status-hint-regression': {
+        backgroundColor: '#690F22',
       },
       '.status-hint .MuiSvgIcon-root': {
         height: '16px',
       },
-      '.status-hint.improvement .MuiSvgIcon-root': {
+      '.status-hint-improvement .MuiSvgIcon-root': {
         color: '#4DBC87',
       },
-      '.status-hint.regression .MuiSvgIcon-root': {
+      '.status-hint-regression .MuiSvgIcon-root': {
+        // We need to move the icon a bit lower so that it _looks_ centered.
         marginTop: '2px',
         color: '#F37F98',
       },
@@ -236,9 +238,9 @@ function determineStatus(improvement: boolean, regression: boolean) {
   return '-';
 }
 
-function determineStatusHintStyle(improvement: boolean, regression: boolean) {
-  if (improvement) return 'improvement';
-  if (regression) return 'regression';
+function determineStatusHintClass(improvement: boolean, regression: boolean) {
+  if (improvement) return 'status-hint-improvement';
+  if (regression) return 'status-hint-regression';
   return '';
 }
 
@@ -364,7 +366,7 @@ function RevisionRow(props: RevisionRowProps) {
         </div>
         <div className='status cell' role='cell'>
           <span
-            className={`status-hint ${determineStatusHintStyle(
+            className={`status-hint ${determineStatusHintClass(
               improvement,
               regression,
             )}`}


### PR DESCRIPTION
Fixes [Bug 1913290](https://bugzilla.mozilla.org/show_bug.cgi?id=1913290).

This PR adds background colors and svg icons to the "Improvement" and "Regression" labels in the results table.

Before:
<img width="1182" alt="Screenshot 2024-08-15 at 3 16 44 PM" src="https://github.com/user-attachments/assets/359c18ea-2a76-4604-a767-199ed2a644c8">

After:
<img width="1194" alt="Screenshot 2024-08-15 at 3 16 01 PM" src="https://github.com/user-attachments/assets/138c35f9-9040-4081-8226-d401a452139b">

Dark mode:

<img width="1174" alt="Screenshot 2024-08-15 at 3 30 54 PM" src="https://github.com/user-attachments/assets/697b1b07-9139-44bb-ae78-cab8d1988e6b">
