### PR TITLE
Persist the search term in the url

### DIFF
--- a/src/__tests__/CompareResults/SearchInput.test.tsx
+++ b/src/__tests__/CompareResults/SearchInput.test.tsx
@@ -170,4 +170,41 @@ describe('Search by title/test name', () => {
     await user.click(clearButton);
     expect(screen.getByText('spam')).toBeInTheDocument();
   });
+
+  it('should update the url search params properly', async () => {
+    await setupAndRenderComponent();
+
+    const searchInput = await screen.findByRole('textbox', {
+      name: /Search by title/,
+    });
+
+    // set delay to null to prevent test time-out due to useFakeTimers
+    const user = userEvent.setup({ delay: null });
+
+    // With the mock setup in this test, there are 2 results with different
+    // properties. In this test we make each of the input show and disappear in
+    // an alternance, by searching for the values in the different properties.
+    await user.type(searchInput, 'glvideo');
+    await waitFor(() =>
+      expect(screen.queryByText('a11yr')).not.toBeInTheDocument(),
+    );
+    // Make sure that the search params are updated properly.
+    expect(window.location.search).toContain('&search=glvideo');
+
+    await user.clear(searchInput);
+    expect(await screen.findByText('a11yr')).toBeInTheDocument();
+    // Clearing the search should remove the search param.
+    expect(window.location.search).not.toContain('&search');
+
+    await user.type(searchInput, 'a11yr{Enter}');
+    // With enter the update should happen instantly.
+    expect(window.location.search).toContain('&search=a11yr');
+
+    const clearButton = screen.getByRole('button', {
+      name: 'Clear the search input',
+    });
+    await user.click(clearButton);
+    // Clearing the search through button should also remove the search param.
+    expect(window.location.search).not.toContain('&search');
+  });
 });

--- a/src/components/CompareResults/ResultsMain.tsx
+++ b/src/components/CompareResults/ResultsMain.tsx
@@ -11,6 +11,7 @@ import { Await, useLoaderData } from 'react-router-dom';
 import { style } from 'typestyle';
 
 import { useAppSelector } from '../../hooks/app';
+import useRawSearchParams from '../../hooks/useRawSearchParams';
 import { Colors, Spacing } from '../../styles';
 import type { CompareResultsItem } from '../../types/state';
 import { Framework } from '../../types/types';
@@ -29,8 +30,11 @@ function ResultsMain() {
 
   const themeMode = useAppSelector((state) => state.theme.mode);
   const [searchParams, setSearchParams] = useSearchParams();
-  const [searchTerm, setSearchTerm] = useState('');
 
+  // This is our custom hook that updates the search params without a rerender.
+  const [rawSearchParams, updateRawSearchParams] = useRawSearchParams();
+  const initialSearchTerm = rawSearchParams.get('search') ?? '';
+  const [searchTerm, setSearchTerm] = useState(initialSearchTerm);
   const [frameworkIdVal, setFrameworkIdVal] = useState(frameworkId);
 
   const themeColor100 =
@@ -61,13 +65,26 @@ function ResultsMain() {
     setSearchParams(searchParams);
   };
 
+  const onSearchTermChange = (newSearchTerm: string) => {
+    setSearchTerm(newSearchTerm);
+    if (newSearchTerm) {
+      rawSearchParams.set('search', newSearchTerm);
+    } else {
+      rawSearchParams.delete('search');
+    }
+    updateRawSearchParams(rawSearchParams);
+  };
+
   return (
     <Container className={styles.container} data-testid='results-main'>
       <header>
         <div className={styles.title}>Results</div>
         <Grid container className={styles.content} spacing={2}>
           <Grid item md={6} xs={12}>
-            <SearchInput onChange={setSearchTerm} />
+            <SearchInput
+              defaultValue={initialSearchTerm}
+              onChange={onSearchTermChange}
+            />
           </Grid>
           <Grid item xs>
             <FormControl sx={{ width: '100%' }}>

--- a/src/components/CompareResults/SearchInput.tsx
+++ b/src/components/CompareResults/SearchInput.tsx
@@ -8,10 +8,11 @@ import { Strings } from '../../resources/Strings';
 import { simpleDebounce } from '../../utils/simple-debounce';
 
 interface SearchInputProps {
+  defaultValue?: string;
   onChange: (searchTerm: string) => unknown;
 }
-function SearchInput({ onChange }: SearchInputProps) {
-  const [searchTerm, setSearchTerm] = useState('');
+function SearchInput({ defaultValue, onChange }: SearchInputProps) {
+  const [searchTerm, setSearchTerm] = useState(defaultValue ?? '');
 
   // By using useCallback, we ensure that we always have the same instance of
   // onDebouncedChange, so that when calling `clear` the timeout will always be

--- a/src/components/CompareResults/SubtestsResults/SubtestsResultsMain.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsResultsMain.tsx
@@ -7,6 +7,7 @@ import { style } from 'typestyle';
 
 import { subtestsView, subtestsOverTimeView } from '../../../common/constants';
 import { useAppSelector } from '../../../hooks/app';
+import useRawSearchParams from '../../../hooks/useRawSearchParams';
 import { Colors, Spacing } from '../../../styles';
 import type { SubtestsRevisionsHeader } from '../../../types/state';
 import DownloadButton from '.././DownloadButton';
@@ -28,7 +29,11 @@ function SubtestsResultsMain({ view }: SubtestsResultsMainProps) {
     | OvertimeLoaderReturnValue;
 
   const themeMode = useAppSelector((state) => state.theme.mode);
-  const [searchTerm, setSearchTerm] = useState('');
+
+  // This is our custom hook that updates the search params without a rerender.
+  const [rawSearchParams, updateRawSearchParams] = useRawSearchParams();
+  const initialSearchTerm = rawSearchParams.get('search') ?? '';
+  const [searchTerm, setSearchTerm] = useState(initialSearchTerm);
 
   const subtestsHeader: SubtestsRevisionsHeader = {
     suite: results[0].suite,
@@ -56,6 +61,16 @@ function SubtestsResultsMain({ view }: SubtestsResultsMainProps) {
     }),
   };
 
+  const onSearchTermChange = (newSearchTerm: string) => {
+    setSearchTerm(newSearchTerm);
+    if (newSearchTerm) {
+      rawSearchParams.set('search', newSearchTerm);
+    } else {
+      rawSearchParams.delete('search');
+    }
+    updateRawSearchParams(rawSearchParams);
+  };
+
   return (
     <Container className={styles.container} data-testid='subtests-main'>
       <header>
@@ -63,7 +78,10 @@ function SubtestsResultsMain({ view }: SubtestsResultsMainProps) {
         <SubtestsRevisionHeader header={subtestsHeader} />
         <Grid container spacing={1}>
           <Grid item xs={12} md={6} sx={{ marginInlineEnd: 'auto' }}>
-            <SearchInput onChange={setSearchTerm} />
+            <SearchInput
+              defaultValue={initialSearchTerm}
+              onChange={onSearchTermChange}
+            />
           </Grid>
           <Grid item xs='auto'>
             <DownloadButton resultsPromise={[results]} />

--- a/src/hooks/useRawSearchParams.ts
+++ b/src/hooks/useRawSearchParams.ts
@@ -1,0 +1,44 @@
+import { useMemo } from 'react';
+
+type UpdateRawSearchParamsOptions = {
+  method?: 'replace' | 'push';
+};
+
+type UpdateRawSearchParams = (
+  newSearchParams: URLSearchParams,
+  options?: UpdateRawSearchParamsOptions,
+) => void;
+
+type RawSearchParams = [URLSearchParams, UpdateRawSearchParams];
+
+/**
+ * This hook provides an `updateSearchParams` function that can update the
+ * search parameters _without_ creating a re-render on the router level.
+ */
+const useRawSearchParams = (): RawSearchParams => {
+  // Memoize the current search parameters to avoid unnecessary recalculations
+  const searchParams = useMemo(() => {
+    return new URLSearchParams(window.location.search);
+  }, [window.location.search]);
+
+  // This function updates the search params without causing a re-render
+  // and provides flexibility to use either pushState or replaceState.
+  const updateSearchParams: UpdateRawSearchParams = (
+    newSearchParams,
+    options = { method: 'replace' },
+  ) => {
+    const newUrl = `?${newSearchParams.toString()}`;
+
+    // Depending on the method, use either pushState or replaceState
+    // to update the URL without causing a component re-render.
+    if (options.method === 'push') {
+      window.history.pushState(null, '', newUrl);
+    } else {
+      window.history.replaceState(null, '', newUrl);
+    }
+  };
+
+  return [searchParams, updateSearchParams];
+};
+
+export default useRawSearchParams;


### PR DESCRIPTION
I tried to make it possible to update the URL search parameters without re-rendering the whole page. Unfortunately because of the limitation of react-router, it's not possible on that level. 

I added a custom hook to handle this behavior instead of their hook. I only added it for the search term in this PR, but the other filtering options can be added similarly.

There are a few things to consider though:
- Since the browser navigation still handled by react-router, browser back/forward navigation still re-renders stuff. But that's maybe okay?
- Using `pushState`/`replaceState` while using react-router is not recommended usually by this library. But I'm not worried about this tbh, I think the first item is more important.
- I'm using `pushState` now, but the hook also supports `replaceState`. I'm leaning towards pushState but unsure, would `replaceState` be better for this case?
- There are no tests yet! I can write some if we choose to go with this approach.

Let me know what you think! Happy to get some feedback.