### PR TITLE
Fix SelectList item active and selector background colors on dark mode

### DIFF
--- a/src/styles/SelectList.ts
+++ b/src/styles/SelectList.ts
@@ -100,13 +100,13 @@ export const SelectListRaw = {
             borderRadius: '4px',
           },
           '&:active': {
-            backgroundColor: Colors.SecondaryActive,
+            backgroundColor: Colors.SecondaryActiveDark,
             borderRadius: '4px',
           },
         },
       },
       '.item-selected': {
-        backgroundColor: Colors.SecondaryHover,
+        backgroundColor: Colors.SecondaryHoverDark,
         borderRadius: '4px',
       },
       '.revision-hash': {


### PR DESCRIPTION
This fixes [Bug 1913699](https://bugzilla.mozilla.org/show_bug.cgi?id=1913699).

Please see the STR that I mentioned in the bug. `SelectList` selected item active and selected background colors on dark mode were still using the light mode's color and that's why they were hard to read on a white text. This PR fixes those colors so it's easier to read them, and the UI colors are more consistent on dark mode.

Before:
<img width="920" alt="Screenshot 2024-08-19 at 11 35 54 AM" src="https://github.com/user-attachments/assets/709b4f1c-8318-49b3-a0ab-83bea691013a">

After:
<img width="877" alt="Screenshot 2024-08-19 at 11 46 20 AM" src="https://github.com/user-attachments/assets/7a1f1a11-b29e-44e1-abb1-96d9c7039f1c">
