### PR TITLE
Simplify the state changing of the block expansions in the home page

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -115,7 +115,7 @@ exports[`Results Table Should match snapshot 1`] = `
             />
           </div>
           <div
-            class="compare-card-container content-base content-base--expanded container_f1cct50y "
+            class="compare-card-container content-base content-base--expanded container_f1cct50y"
           >
             <hr
               class="MuiDivider-root MuiDivider-fullWidth divider css-9mgopn-MuiDivider-root"

--- a/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
@@ -4432,7 +4432,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
             />
           </div>
           <div
-            class="compare-card-container content-base content-base--expanded container_f1cct50y "
+            class="compare-card-container content-base content-base--expanded container_f1cct50y"
           >
             <hr
               class="MuiDivider-root MuiDivider-fullWidth divider css-9mgopn-MuiDivider-root"

--- a/src/__tests__/Search/__snapshots__/SearchContainer.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchContainer.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`Search Containter should match snapshot 1`] = `
           />
         </div>
         <div
-          class="compare-card-container content-base content-base--expanded container_f1cct50y "
+          class="compare-card-container content-base content-base--expanded container_f1cct50y"
         >
           <hr
             class="MuiDivider-root MuiDivider-fullWidth divider css-9mgopn-MuiDivider-root"

--- a/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
             />
           </div>
           <div
-            class="compare-card-container content-base content-base--expanded container_f1cct50y "
+            class="compare-card-container content-base content-base--expanded container_f1cct50y"
           >
             <hr
               class="MuiDivider-root MuiDivider-fullWidth divider css-9mgopn-MuiDivider-root"

--- a/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
             />
           </div>
           <div
-            class="compare-card-container content-base content-base--expanded container_f1cct50y "
+            class="compare-card-container content-base content-base--expanded container_f1cct50y"
           >
             <hr
               class="MuiDivider-root MuiDivider-fullWidth divider css-9mgopn-MuiDivider-root"

--- a/src/components/CompareResults/OverTimeResultsView.tsx
+++ b/src/components/CompareResults/OverTimeResultsView.tsx
@@ -50,8 +50,7 @@ function ResultsView(props: ResultsViewProps) {
         <CompareOverTime
           hasEditButton={true}
           newRevs={newRevsInfo ?? []}
-          isBaseSearch={true}
-          expandBaseComponent={() => null}
+          isExpanded={true}
           frameworkIdVal={frameworkId}
           intervalValue={intervalValue}
           baseRepo={baseRepo}

--- a/src/components/CompareResults/ResultsView.tsx
+++ b/src/components/CompareResults/ResultsView.tsx
@@ -47,8 +47,7 @@ function ResultsView(props: ResultsViewProps) {
           baseRev={baseRevInfo ?? null}
           newRevs={newRevsInfo ?? []}
           frameworkIdVal={frameworkId}
-          isBaseSearch={null}
-          expandBaseComponent={() => null}
+          isExpanded={true}
           baseRepo={baseRepo}
           newRepo={newRepo}
         />

--- a/src/components/Search/CompareOverTime.tsx
+++ b/src/components/Search/CompareOverTime.tsx
@@ -26,11 +26,10 @@ interface CompareWithTimeProps {
   newRevs: Changeset[] | [];
   frameworkIdVal: Framework['id'];
   intervalValue: TimeRange['value'];
-  isBaseSearch: null | boolean;
   newRepo: Repository['name'];
   baseRepo: Repository['name'];
-
-  expandBaseComponent: (expanded: boolean) => void;
+  isExpanded: boolean;
+  setIsExpanded?: () => unknown;
 }
 
 function CompareOverTime({
@@ -38,16 +37,14 @@ function CompareOverTime({
   newRevs,
   frameworkIdVal,
   intervalValue,
-  isBaseSearch,
   baseRepo,
   newRepo,
-  expandBaseComponent,
+  isExpanded,
+  setIsExpanded,
 }: CompareWithTimeProps) {
   const { enqueueSnackbar } = useSnackbar();
   const location = useLocation();
   const resultsView = location.pathname.includes(compareOverTimeView);
-  const searchView =
-    !isBaseSearch && isBaseSearch !== null ? 'expanded' : 'hidden';
 
   const [timeRangeValue, setTimeRangeValue] = useState(intervalValue);
   const [inProgressRevs, setInProgressRevs] = useState<Changeset[] | []>(
@@ -77,10 +74,6 @@ function CompareOverTime({
         variant: 'error',
       });
     }
-  };
-
-  const toggleIsExpanded = () => {
-    expandBaseComponent(false);
   };
 
   const handleCancel = () => {
@@ -146,13 +139,12 @@ function CompareOverTime({
     setInProgressRevs(newNewRevs);
   };
 
+  const expandedClass = isExpanded ? 'expanded' : 'hidden';
   return (
     <Grid className={`wrapper--overtime ${wrapperStyles.wrapper}`}>
       <div
-        className={`compare-card-container compare-card-container--${
-          resultsView ? 'expanded' : searchView
-        } ${styles.container}`}
-        onClick={toggleIsExpanded}
+        className={`compare-card-container compare-card-container--${expandedClass} ${styles.container}`}
+        onClick={setIsExpanded}
         data-testid='time-state'
       >
         <div className={`compare-card-text ${styles.cardText}`}>
@@ -167,9 +159,7 @@ function CompareOverTime({
         />
       </div>
       <div
-        className={`compare-card-container content-base content-base--${
-          resultsView ? 'expanded' : searchView
-        } ${styles.container} `}
+        className={`compare-card-container content-base content-base--${expandedClass} ${styles.container} `}
       >
         <Divider className='divider' />
         <Form

--- a/src/components/Search/CompareWithBase.tsx
+++ b/src/components/Search/CompareWithBase.tsx
@@ -28,8 +28,8 @@ interface CompareWithBaseProps {
   baseRepo: Repository['name'];
   newRepo: Repository['name'];
   frameworkIdVal: Framework['id'];
-  isBaseSearch: null | boolean;
-  expandBaseComponent: (expanded: boolean) => void | null;
+  isExpanded: boolean;
+  setIsExpanded?: () => unknown;
 }
 
 /**
@@ -71,11 +71,11 @@ function CompareWithBase({
   hasEditButton,
   baseRev,
   newRevs,
-  isBaseSearch,
   frameworkIdVal,
   baseRepo,
   newRepo,
-  expandBaseComponent,
+  isExpanded,
+  setIsExpanded,
 }: CompareWithBaseProps) {
   const { enqueueSnackbar } = useSnackbar();
 
@@ -118,10 +118,6 @@ function CompareWithBase({
         variant: 'error',
       });
     }
-  };
-
-  const toggleIsExpanded = () => {
-    expandBaseComponent(true);
   };
 
   const handleCancel = () => {
@@ -219,13 +215,12 @@ function CompareWithBase({
     setInProgressNewRevs(newNewRevs);
   };
 
+  const expandedClass = isExpanded ? 'expanded' : 'hidden';
   return (
     <Grid className={`wrapper--withbase ${wrapperStyles.wrapper}`}>
       <div
-        className={`compare-card-container compare-card-container--${
-          isBaseSearch || isBaseSearch === null ? 'expanded' : 'hidden'
-        } ${styles.container}`}
-        onClick={toggleIsExpanded}
+        className={`compare-card-container compare-card-container--${expandedClass} ${styles.container}`}
+        onClick={setIsExpanded}
         data-testid='base-state'
       >
         <div className={`compare-card-text ${styles.cardText}`}>
@@ -241,9 +236,7 @@ function CompareWithBase({
       </div>
 
       <div
-        className={`compare-card-container content-base content-base--${
-          isBaseSearch || isBaseSearch === null ? 'expanded' : 'hidden'
-        } ${styles.container} `}
+        className={`compare-card-container content-base content-base--${expandedClass} ${styles.container}`}
       >
         <Divider className='divider' />
         <Form

--- a/src/components/Search/SearchContainer.tsx
+++ b/src/components/Search/SearchContainer.tsx
@@ -14,7 +14,7 @@ const strings = Strings.components.searchDefault;
 function SearchContainer(props: SearchViewProps) {
   const themeMode = useAppSelector((state) => state.theme.mode);
   const styles = SearchContainerStyles(themeMode, /* isHome */ true);
-  const [isBaseSearch, expandBaseComponent] = useState(null as null | boolean);
+  const [isBaseSearchExpanded, setIsBaseSearchExpanded] = useState(true);
 
   return (
     <section
@@ -30,16 +30,16 @@ function SearchContainer(props: SearchViewProps) {
         hasEditButton={false}
         baseRev={null}
         newRevs={[]}
-        isBaseSearch={isBaseSearch}
-        expandBaseComponent={expandBaseComponent}
+        isExpanded={isBaseSearchExpanded}
+        setIsExpanded={() => setIsBaseSearchExpanded(true)}
         baseRepo='try'
         newRepo='try'
       />
       <CompareOverTime
         hasEditButton={false}
         newRevs={[]}
-        isBaseSearch={isBaseSearch}
-        expandBaseComponent={expandBaseComponent}
+        isExpanded={!isBaseSearchExpanded}
+        setIsExpanded={() => setIsBaseSearchExpanded(false)}
         frameworkIdVal={1 as Framework['id']}
         intervalValue={86400 as TimeRange['value']}
         baseRepo='try'


### PR DESCRIPTION
Small simplification in how the home page blocks are expanded. The goal is that the state for the "CompareWithBase" block doesn't leak into "CompareOverTime" block, so instead of having this spilled state, a simpler boolean "isExpanded" is passed to both blocks. This also simplifies how they work in the results page.

There should be no behavior change.

Tell me what you think!