### PR TITLE
Transition subtest header to grid layout

### DIFF
--- a/src/components/CompareResults/SubtestsResults/SubtestsResultsMain.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsResultsMain.tsx
@@ -54,20 +54,6 @@ function SubtestsResultsMain({ view }: SubtestsResultsMainProps) {
       margin: 0,
       marginBottom: Spacing.Medium,
     }),
-    content: style({
-      display: 'flex',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-    }),
-    buttons: style({
-      display: 'flex',
-      justifyContent: 'flex-end',
-      $nest: {
-        '.MuiButtonBase-root:nth-child(2)': {
-          marginLeft: Spacing.Default,
-        },
-      },
-    }),
   };
 
   return (
@@ -75,12 +61,14 @@ function SubtestsResultsMain({ view }: SubtestsResultsMainProps) {
       <header>
         <SubtestsBreadcrumbs view={view} />
         <SubtestsRevisionHeader header={subtestsHeader} />
-        <Grid container className={styles.content}>
-          <Grid item md={6} xs={12}>
+        <Grid container spacing={1}>
+          <Grid item xs={12} md={6} sx={{ marginInlineEnd: 'auto' }}>
             <SearchInput onChange={setSearchTerm} />
           </Grid>
-          <Grid item className={styles.buttons} md={4}>
+          <Grid item xs='auto'>
             <DownloadButton resultsPromise={[results]} />
+          </Grid>
+          <Grid item xs='auto'>
             <RetriggerButton result={results[0]} variant='text' />
           </Grid>
         </Grid>

--- a/src/components/CompareResults/SubtestsResults/SubtestsResultsMain.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsResultsMain.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { Grid } from '@mui/material';
 import { Container } from '@mui/system';
 import { useLoaderData } from 'react-router-dom';
 import { style } from 'typestyle';
@@ -55,8 +56,17 @@ function SubtestsResultsMain({ view }: SubtestsResultsMainProps) {
     }),
     content: style({
       display: 'flex',
-      justifyContent: 'flex-end',
+      justifyContent: 'space-between',
       alignItems: 'center',
+    }),
+    buttons: style({
+      display: 'flex',
+      justifyContent: 'flex-end',
+      $nest: {
+        '.MuiButtonBase-root:nth-child(2)': {
+          marginLeft: Spacing.Default,
+        },
+      },
     }),
   };
 
@@ -65,11 +75,15 @@ function SubtestsResultsMain({ view }: SubtestsResultsMainProps) {
       <header>
         <SubtestsBreadcrumbs view={view} />
         <SubtestsRevisionHeader header={subtestsHeader} />
-        <div className={styles.content}>
-          <SearchInput onChange={setSearchTerm} />
-          <DownloadButton resultsPromise={[results]} />
-          <RetriggerButton result={results[0]} variant='text' />
-        </div>
+        <Grid container className={styles.content}>
+          <Grid item md={6} xs={12}>
+            <SearchInput onChange={setSearchTerm} />
+          </Grid>
+          <Grid item className={styles.buttons} md={4}>
+            <DownloadButton resultsPromise={[results]} />
+            <RetriggerButton result={results[0]} variant='text' />
+          </Grid>
+        </Grid>
       </header>
       <SubtestsResultsTable
         filteringSearchTerm={searchTerm}


### PR DESCRIPTION
Follow up for [adding retrigger functionality for subtests](https://github.com/mozilla/perfcompare/pull/711#pullrequestreview-2248064981)
![Screenshot 2024-08-26 at 10 21 28 AM](https://github.com/user-attachments/assets/80386f62-3d0d-4c61-a0f8-8f0ab3203f41)

