### PR TITLE
Increase range of the kde graph and other tweaks

### DIFF
--- a/src/components/CompareResults/CommonGraph.tsx
+++ b/src/components/CompareResults/CommonGraph.tsx
@@ -16,9 +16,12 @@ const styles = {
   }),
 };
 
-function CommonGraph(props: CommonGraphProps) {
-  const { baseRevisionRuns, newRevisionRuns, min, max } = props;
-
+function CommonGraph({
+  baseRevisionRuns,
+  newRevisionRuns,
+  min,
+  max,
+}: CommonGraphProps) {
   const options = {
     plugins: {
       legend: {
@@ -85,6 +88,10 @@ function CommonGraph(props: CommonGraphProps) {
   // Arbitrary value that seems to work OK.
   // In the future we'll want to compute a better value, see
   // https://bugzilla.mozilla.org/show_bug.cgi?id=1901248 for some ideas.
+  if (max === min) {
+    min = max - 15;
+    max = max + 15;
+  }
   const bandwidth = (max - min) / 15;
   const baseRunsDensity = Array.from(
     kde.density1d(baseRevisionRuns.values, {

--- a/src/components/CompareResults/CommonGraph.tsx
+++ b/src/components/CompareResults/CommonGraph.tsx
@@ -89,13 +89,13 @@ function CommonGraph(props: CommonGraphProps) {
   const baseRunsDensity = Array.from(
     kde.density1d(baseRevisionRuns.values, {
       bandwidth,
-      extent: [min, max],
+      extent: [min - bandwidth, max + bandwidth],
     }),
   );
   const newRunsDensity = Array.from(
     kde.density1d(newRevisionRuns.values, {
       bandwidth,
-      extent: [min, max],
+      extent: [min - bandwidth, max + bandwidth],
     }),
   );
 


### PR DESCRIPTION
This was bothering me for some time.

The problems:
* to compute the KDE graph, I was using the prop "min and max". The problem is that then we don't see well the contributions of the leaf most or right most points. This is more visible after #734 but was already visible before.
* when there's just one point (such as when looking at just one revision that has just one run), the graph doesn't show up, I think because the bandwidth is 0. This is visible after #734.

So this patch fixes both these issues.

Here are some before/after:

Before / After
[beta branch](https://beta--mozilla-perfcompare.netlify.app/compare-results?baseRev=d5b7f825041b9d72eaadd25d879034d1c121e449&baseRepo=mozilla-central&framework=1) / [deploy preview](https://deploy-preview-740--mozilla-perfcompare.netlify.app/compare-results?baseRev=d5b7f825041b9d72eaadd25d879034d1c121e449&baseRepo=mozilla-central&framework=1)
![image](https://github.com/user-attachments/assets/6db6e3c6-cb32-40ac-8a8e-7a4a6a478f7a)
![image](https://github.com/user-attachments/assets/0485494f-2e3e-43b7-8503-1360c4eef9ef)


Before / After
[beta branch](https://beta--mozilla-perfcompare.netlify.app/compare-results?baseRev=d5b7f825041b9d72eaadd25d879034d1c121e449&baseRepo=mozilla-central&newRev=6656395babf485be63cbe5ea3214a16abdb1953c&newRepo=mozilla-central&framework=1) / [deploy preview](https://deploy-preview-740--mozilla-perfcompare.netlify.app/compare-results?baseRev=d5b7f825041b9d72eaadd25d879034d1c121e449&baseRepo=mozilla-central&newRev=6656395babf485be63cbe5ea3214a16abdb1953c&newRepo=mozilla-central&framework=1)
![image](https://github.com/user-attachments/assets/2ba993a7-4ea9-4bd5-8975-4db58331c157)
![image](https://github.com/user-attachments/assets/63a25750-ccfe-402e-8e29-d23b6c3f85a4)

Before / after
[beta branch](https://beta--mozilla-perfcompare.netlify.app/compare-results?baseRev=45a23d311b9cdd59a5199d4c208cb418a019975a&baseRepo=try&newRev=a57db09ea197256d14a5032cebbbed7dd59e7f6f&newRepo=try&newRev=438b2d56d91adf16e165d04a0b32af829d22f7b2&newRepo=try&framework=1) / [deploy preview](https://deploy-preview-740--mozilla-perfcompare.netlify.app/compare-results?baseRev=45a23d311b9cdd59a5199d4c208cb418a019975a&baseRepo=try&newRev=a57db09ea197256d14a5032cebbbed7dd59e7f6f&newRepo=try&newRev=438b2d56d91adf16e165d04a0b32af829d22f7b2&newRepo=try&framework=1)
![image](https://github.com/user-attachments/assets/94040833-3f6a-48a6-b383-c29eb6c21a35)
![image](https://github.com/user-attachments/assets/41e3548c-536b-46cf-9aae-0ac1ba5e0ea2)
