### PR TITLE
Add colors to subtests and small layout changes

### DIFF
--- a/src/__tests__/CompareResults/RevisionRow.test.tsx
+++ b/src/__tests__/CompareResults/RevisionRow.test.tsx
@@ -60,7 +60,13 @@ describe('<RevisionRow>', () => {
       } = getTestData();
 
       rowData.platform = platform as Platform;
-      renderWithRoute(<RevisionRow result={rowData} view={compareView} />);
+      renderWithRoute(
+        <RevisionRow
+          result={rowData}
+          view={compareView}
+          gridTemplateColumns='none'
+        />,
+      );
       const shortNameNode = await screen.findByText(shortName);
       expect(shortNameNode).toBeInTheDocument();
       const previousNode = shortNameNode.previousSibling;

--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Results View The table should match snapshot and other elements should 
   role="table"
 >
   <div
-    class="f6frt4b fr2n4tx"
+    class="f1qjwvwg fr2n4tx"
     data-testid="table-header"
     role="row"
   >
@@ -222,7 +222,7 @@ exports[`Results View The table should match snapshot and other elements should 
             </div>
             <div>
               <div
-                class="revisionRow flfn61v fp4ugv1"
+                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-izu99y"
                 role="row"
               >
                 <div
@@ -437,7 +437,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow flfn61v fp4ugv1"
+                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-izu99y"
                 role="row"
               >
                 <div
@@ -651,7 +651,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow flfn61v fp4ugv1"
+                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-izu99y"
                 role="row"
               >
                 <div
@@ -855,7 +855,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow flfn61v fp4ugv1"
+                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-izu99y"
                 role="row"
               >
                 <div

--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Results View The table should match snapshot and other elements should 
   role="table"
 >
   <div
-    class="f1qjwvwg fr2n4tx"
+    class="f6frt4b fr2n4tx"
     data-testid="table-header"
     role="row"
   >
@@ -222,7 +222,7 @@ exports[`Results View The table should match snapshot and other elements should 
             </div>
             <div>
               <div
-                class="revisionRow f603q1k fp4ugv1"
+                class="revisionRow flfn61v fp4ugv1"
                 role="row"
               >
                 <div
@@ -437,7 +437,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f603q1k fp4ugv1"
+                class="revisionRow flfn61v fp4ugv1"
                 role="row"
               >
                 <div
@@ -651,7 +651,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f603q1k fp4ugv1"
+                class="revisionRow flfn61v fp4ugv1"
                 role="row"
               >
                 <div
@@ -855,7 +855,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f603q1k fp4ugv1"
+                class="revisionRow flfn61v fp4ugv1"
                 role="row"
               >
                 <div

--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Results View The table should match snapshot and other elements should 
   role="table"
 >
   <div
-    class="f1qjwvwg fr2n4tx"
+    class="f6frt4b fr2n4tx"
     data-testid="table-header"
     role="row"
   >
@@ -222,7 +222,7 @@ exports[`Results View The table should match snapshot and other elements should 
             </div>
             <div>
               <div
-                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-izu99y"
+                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-1am90bh"
                 role="row"
               >
                 <div
@@ -437,7 +437,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-izu99y"
+                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-1am90bh"
                 role="row"
               >
                 <div
@@ -651,7 +651,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-izu99y"
+                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-1am90bh"
                 role="row"
               >
                 <div
@@ -855,7 +855,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-izu99y"
+                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-1am90bh"
                 role="row"
               >
                 <div

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -964,7 +964,7 @@ exports[`Results Table Should match snapshot 1`] = `
               role="table"
             >
               <div
-                class="f6frt4b fr2n4tx"
+                class="f1qjwvwg fr2n4tx"
                 data-testid="table-header"
                 role="row"
               >
@@ -1179,7 +1179,7 @@ exports[`Results Table Should match snapshot 1`] = `
                         </div>
                         <div>
                           <div
-                            class="revisionRow flfn61v fp4ugv1"
+                            class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-izu99y"
                             role="row"
                           >
                             <div
@@ -1394,7 +1394,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </div>
                           </div>
                           <div
-                            class="revisionRow flfn61v fp4ugv1"
+                            class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-izu99y"
                             role="row"
                           >
                             <div
@@ -1608,7 +1608,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </div>
                           </div>
                           <div
-                            class="revisionRow flfn61v fp4ugv1"
+                            class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-izu99y"
                             role="row"
                           >
                             <div
@@ -1863,7 +1863,7 @@ exports[`Results Table Should match snapshot 1`] = `
                         </div>
                         <div>
                           <div
-                            class="revisionRow flfn61v fp4ugv1"
+                            class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-izu99y"
                             role="row"
                           >
                             <div

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -964,7 +964,7 @@ exports[`Results Table Should match snapshot 1`] = `
               role="table"
             >
               <div
-                class="f1qjwvwg fr2n4tx"
+                class="f6frt4b fr2n4tx"
                 data-testid="table-header"
                 role="row"
               >
@@ -1179,7 +1179,7 @@ exports[`Results Table Should match snapshot 1`] = `
                         </div>
                         <div>
                           <div
-                            class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-izu99y"
+                            class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-1am90bh"
                             role="row"
                           >
                             <div
@@ -1394,7 +1394,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </div>
                           </div>
                           <div
-                            class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-izu99y"
+                            class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-1am90bh"
                             role="row"
                           >
                             <div
@@ -1608,7 +1608,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </div>
                           </div>
                           <div
-                            class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-izu99y"
+                            class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-1am90bh"
                             role="row"
                           >
                             <div
@@ -1863,7 +1863,7 @@ exports[`Results Table Should match snapshot 1`] = `
                         </div>
                         <div>
                           <div
-                            class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-izu99y"
+                            class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-1am90bh"
                             role="row"
                           >
                             <div

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -964,7 +964,7 @@ exports[`Results Table Should match snapshot 1`] = `
               role="table"
             >
               <div
-                class="f1qjwvwg fr2n4tx"
+                class="f6frt4b fr2n4tx"
                 data-testid="table-header"
                 role="row"
               >
@@ -1179,7 +1179,7 @@ exports[`Results Table Should match snapshot 1`] = `
                         </div>
                         <div>
                           <div
-                            class="revisionRow f603q1k fp4ugv1"
+                            class="revisionRow flfn61v fp4ugv1"
                             role="row"
                           >
                             <div
@@ -1394,7 +1394,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </div>
                           </div>
                           <div
-                            class="revisionRow f603q1k fp4ugv1"
+                            class="revisionRow flfn61v fp4ugv1"
                             role="row"
                           >
                             <div
@@ -1608,7 +1608,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </div>
                           </div>
                           <div
-                            class="revisionRow f603q1k fp4ugv1"
+                            class="revisionRow flfn61v fp4ugv1"
                             role="row"
                           >
                             <div
@@ -1863,7 +1863,7 @@ exports[`Results Table Should match snapshot 1`] = `
                         </div>
                         <div>
                           <div
-                            class="revisionRow f603q1k fp4ugv1"
+                            class="revisionRow flfn61v fp4ugv1"
                             role="row"
                           >
                             <div

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -670,7 +670,7 @@ exports[`Results View The table should match snapshot and other elements should 
   role="table"
 >
   <div
-    class="f1qjwvwg fr2n4tx"
+    class="f6frt4b fr2n4tx"
     data-testid="table-header"
     role="row"
   >
@@ -885,7 +885,7 @@ exports[`Results View The table should match snapshot and other elements should 
             </div>
             <div>
               <div
-                class="revisionRow f603q1k fp4ugv1"
+                class="revisionRow flfn61v fp4ugv1"
                 role="row"
               >
                 <div
@@ -1100,7 +1100,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f603q1k fp4ugv1"
+                class="revisionRow flfn61v fp4ugv1"
                 role="row"
               >
                 <div
@@ -1314,7 +1314,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f603q1k fp4ugv1"
+                class="revisionRow flfn61v fp4ugv1"
                 role="row"
               >
                 <div
@@ -1518,7 +1518,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f603q1k fp4ugv1"
+                class="revisionRow flfn61v fp4ugv1"
                 role="row"
               >
                 <div

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -670,7 +670,7 @@ exports[`Results View The table should match snapshot and other elements should 
   role="table"
 >
   <div
-    class="f6frt4b fr2n4tx"
+    class="f1qjwvwg fr2n4tx"
     data-testid="table-header"
     role="row"
   >
@@ -885,7 +885,7 @@ exports[`Results View The table should match snapshot and other elements should 
             </div>
             <div>
               <div
-                class="revisionRow flfn61v fp4ugv1"
+                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-izu99y"
                 role="row"
               >
                 <div
@@ -1100,7 +1100,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow flfn61v fp4ugv1"
+                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-izu99y"
                 role="row"
               >
                 <div
@@ -1314,7 +1314,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow flfn61v fp4ugv1"
+                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-izu99y"
                 role="row"
               >
                 <div
@@ -1518,7 +1518,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow flfn61v fp4ugv1"
+                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-izu99y"
                 role="row"
               >
                 <div

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -670,7 +670,7 @@ exports[`Results View The table should match snapshot and other elements should 
   role="table"
 >
   <div
-    class="f1qjwvwg fr2n4tx"
+    class="f6frt4b fr2n4tx"
     data-testid="table-header"
     role="row"
   >
@@ -885,7 +885,7 @@ exports[`Results View The table should match snapshot and other elements should 
             </div>
             <div>
               <div
-                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-izu99y"
+                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-1am90bh"
                 role="row"
               >
                 <div
@@ -1100,7 +1100,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-izu99y"
+                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-1am90bh"
                 role="row"
               >
                 <div
@@ -1314,7 +1314,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-izu99y"
+                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-1am90bh"
                 role="row"
               >
                 <div
@@ -1518,7 +1518,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-izu99y"
+                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-1am90bh"
                 role="row"
               >
                 <div

--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -63,8 +63,8 @@ const cellsConfiguration: CompareResultsTableConfig[] = [
     disable: true,
     filter: true,
     key: 'platform',
-    possibleValues: ['Windows', 'OSX', 'Linux', 'Android'],
     gridWidth: '2fr',
+    possibleValues: ['Windows', 'OSX', 'Linux', 'Android'],
     matchesFunction: (result: CompareResultsItem, value: string) => {
       const platformName = getPlatformShortName(result.platform);
       return platformName === value;
@@ -73,14 +73,25 @@ const cellsConfiguration: CompareResultsTableConfig[] = [
   {
     name: 'Base',
     key: 'base',
+    gridWidth: '1fr',
   },
-  { key: 'comparisonSign' },
-  { name: 'New', key: 'new' },
+  {
+    key: 'comparisonSign',
+
+    gridWidth: '0.2fr',
+  },
+  {
+    name: 'New',
+    key: 'new',
+
+    gridWidth: '1fr',
+  },
   {
     name: 'Status',
     disable: true,
     filter: true,
     key: 'status',
+    gridWidth: '1fr',
     possibleValues: ['No changes', 'Improvement', 'Regression'],
     matchesFunction: (result: CompareResultsItem, value: string) => {
       switch (value) {
@@ -96,19 +107,26 @@ const cellsConfiguration: CompareResultsTableConfig[] = [
   {
     name: 'Delta(%)',
     key: 'delta',
+    gridWidth: '1fr',
   },
   {
     name: 'Confidence',
     disable: true,
     filter: true,
     key: 'confidence',
+    gridWidth: '1fr',
     possibleValues: ['Low', 'Medium', 'High'],
     matchesFunction: (result: CompareResultsItem, value: string) =>
       result.confidence_text === value,
   },
-  { name: 'Total Runs', key: 'runs' },
-  { key: 'buttons' },
-  { key: 'expand' },
+  {
+    name: 'Total Runs',
+    key: 'runs',
+
+    gridWidth: '1fr',
+  },
+  { key: 'buttons', gridWidth: '2fr' },
+  { key: 'expand', gridWidth: '0.2fr' },
 ];
 
 function resultMatchesSearchTerm(
@@ -226,6 +244,10 @@ function ResultsTable({
     });
   };
 
+  const rowGridTemplateColumns = cellsConfiguration
+    .map((config) => config.gridWidth)
+    .join(' ');
+
   return (
     <Box
       data-testid='results-table'
@@ -257,6 +279,7 @@ function ResultsTable({
             header={res.revisionHeader}
             results={res.value}
             view={view}
+            rowGridTemplateColumns={rowGridTemplateColumns}
           />
         )}
       />

--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -91,7 +91,7 @@ const cellsConfiguration: CompareResultsTableConfig[] = [
     disable: true,
     filter: true,
     key: 'status',
-    gridWidth: '1fr',
+    gridWidth: '1.5fr',
     possibleValues: ['No changes', 'Improvement', 'Regression'],
     matchesFunction: (result: CompareResultsItem, value: string) => {
       switch (value) {

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -6,7 +6,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ThumbDownIcon from '@mui/icons-material/ThumbDown';
 import ThumbUpIcon from '@mui/icons-material/ThumbUp';
 import TimelineIcon from '@mui/icons-material/Timeline';
-import { IconButton } from '@mui/material';
+import { IconButton, Box } from '@mui/material';
 import Tooltip from '@mui/material/Tooltip';
 import { style } from 'typestyle';
 
@@ -27,8 +27,6 @@ const revisionsRow = {
   borderRadius: '4px 0px 0px 4px',
   display: 'grid',
   margin: `${Spacing.Small}px 0px`,
-  // Should be kept in sync with the gridTemplateColumns from TableHeader
-  gridTemplateColumns: '2fr 1fr 0.2fr 1fr 1fr 1fr 1fr 1fr 2fr 0.2fr',
 };
 
 const typography = {
@@ -304,7 +302,7 @@ const getSubtestsCompareOverTimeLink = (result: CompareResultsItem) => {
 };
 
 function RevisionRow(props: RevisionRowProps) {
-  const { result, view } = props;
+  const { result, view, gridTemplateColumns } = props;
   const {
     platform,
     base_median_value: baseMedianValue,
@@ -341,8 +339,9 @@ function RevisionRow(props: RevisionRowProps) {
 
   return (
     <>
-      <div
+      <Box
         className={`revisionRow ${styles.revisionRow} ${styles.typography}`}
+        sx={{ gridTemplateColumns }}
         role='row'
       >
         <div className='platform cell' role='cell'>
@@ -453,7 +452,7 @@ function RevisionRow(props: RevisionRowProps) {
             </IconButton>
           </div>
         </div>
-      </div>
+      </Box>
       {expanded && (
         <div
           className={`content-row ${stylesCard.container}`}
@@ -468,6 +467,7 @@ function RevisionRow(props: RevisionRowProps) {
 
 interface RevisionRowProps {
   result: CompareResultsItem;
+  gridTemplateColumns: string;
   view: typeof compareView | typeof compareOverTimeView;
 }
 

--- a/src/components/CompareResults/SubtestsResults/SubtestsResultsTable.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsResultsTable.tsx
@@ -69,7 +69,7 @@ const cellsConfiguration: CompareResultsTableConfig[] = [
     disable: true,
     filter: true,
     key: 'status',
-    gridWidth: '1fr',
+    gridWidth: '1.5fr',
     possibleValues: ['No changes', 'Improvement', 'Regression'],
     matchesFunction: (result: CompareResultsItem, value: string) => {
       switch (value) {
@@ -98,7 +98,7 @@ const cellsConfiguration: CompareResultsTableConfig[] = [
       result.confidence_text === value,
   },
   { name: 'Total Runs', key: 'runs', gridWidth: '1fr' },
-  { key: 'buttons', gridWidth: '2fr' },
+  { key: 'buttons', gridWidth: '1fr' },
   { key: 'expand', gridWidth: '0.2fr' },
 ];
 

--- a/src/components/CompareResults/SubtestsResults/SubtestsResultsTable.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsResultsTable.tsx
@@ -51,14 +51,25 @@ const cellsConfiguration: CompareResultsTableConfig[] = [
   {
     name: 'Base',
     key: 'base',
+    gridWidth: '1fr',
   },
-  { key: 'comparisonSign' },
-  { name: 'New', key: 'new' },
+  {
+    key: 'comparisonSign',
+
+    gridWidth: '0.2fr',
+  },
+  {
+    name: 'New',
+    key: 'new',
+
+    gridWidth: '1fr',
+  },
   {
     name: 'Status',
     disable: true,
     filter: true,
     key: 'status',
+    gridWidth: '1fr',
     possibleValues: ['No changes', 'Improvement', 'Regression'],
     matchesFunction: (result: CompareResultsItem, value: string) => {
       switch (value) {
@@ -74,19 +85,21 @@ const cellsConfiguration: CompareResultsTableConfig[] = [
   {
     name: 'Delta(%)',
     key: 'delta',
+    gridWidth: '1fr',
   },
   {
     name: 'Confidence',
     disable: true,
     filter: true,
     key: 'confidence',
+    gridWidth: '1fr',
     possibleValues: ['Low', 'Medium', 'High'],
     matchesFunction: (result: CompareResultsItem, value: string) =>
       result.confidence_text === value,
   },
-  { name: 'Total Runs', key: 'runs' },
-  { key: 'buttons' },
-  { key: 'expand' },
+  { name: 'Total Runs', key: 'runs', gridWidth: '1fr' },
+  { key: 'buttons', gridWidth: '2fr' },
+  { key: 'expand', gridWidth: '0.2fr' },
 ];
 
 function resultMatchesSearchTerm(
@@ -181,6 +194,10 @@ function SubtestsResultsTable({
     });
   };
 
+  const rowGridTemplateColumns = cellsConfiguration
+    .map((config) => config.gridWidth)
+    .join(' ');
+
   return (
     <Box
       data-testid='subtests-results-table'
@@ -199,6 +216,7 @@ function SubtestsResultsTable({
           key={res.key}
           identifier={res.key}
           results={res.value}
+          rowGridTemplateColumns={rowGridTemplateColumns}
         />
       ))}
 

--- a/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
@@ -124,6 +124,11 @@ function getStyles(themeMode: string) {
   };
 }
 
+const styles = {
+  light: getStyles('light'),
+  dark: getStyles('dark'),
+};
+
 const stylesCard = ExpandableRowStyles();
 
 function determineStatus(improvement: boolean, regression: boolean) {
@@ -169,12 +174,10 @@ function SubtestsRevisionRow(props: RevisionRowProps) {
 
   const themeMode = useAppSelector((state) => state.theme.mode);
 
-  const styles = getStyles(themeMode);
-
   return (
     <>
       <div
-        className={`revisionRow ${styles.revisionRow} ${styles.typography}`}
+        className={`revisionRow ${styles[themeMode].revisionRow} ${styles[themeMode].typography}`}
         role='row'
       >
         <div className='subtests cell' role='cell'>

--- a/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ThumbDownIcon from '@mui/icons-material/ThumbDown';
+import ThumbUpIcon from '@mui/icons-material/ThumbUp';
 import TimelineIcon from '@mui/icons-material/Timeline';
 import { IconButton } from '@mui/material';
 import { style } from 'typestyle';
@@ -93,6 +95,29 @@ function getStyles(themeMode: string) {
         '.expand-button': {
           backgroundColor: backgroundColorExpandButton,
         },
+        '.status-hint': {
+          display: 'inline-flex',
+          gap: '6px',
+          borderRadius: '4px',
+          padding: '4px 10px',
+        },
+        '.status-hint-improvement': {
+          backgroundColor: '#D8EEDC',
+        },
+        '.status-hint-regression': {
+          backgroundColor: '#FFE8E8',
+        },
+        '.status-hint .MuiSvgIcon-root': {
+          height: '16px',
+        },
+        '.status-hint-improvement .MuiSvgIcon-root': {
+          color: '#017A40',
+        },
+        '.status-hint-regression .MuiSvgIcon-root': {
+          // We need to move the icon a bit lower so that it _looks_ centered.
+          marginTop: '2px',
+          color: '#D7264C',
+        },
       },
     }),
     typography: typography,
@@ -105,6 +130,12 @@ function determineStatus(improvement: boolean, regression: boolean) {
   if (improvement) return 'Improvement';
   if (regression) return 'Regression';
   return '-';
+}
+
+function determineStatusHintClass(improvement: boolean, regression: boolean) {
+  if (improvement) return 'status-hint-improvement';
+  if (regression) return 'status-hint-regression';
+  return '';
 }
 
 function determineSign(baseMedianValue: number, newMedianValue: number) {
@@ -161,8 +192,16 @@ function SubtestsRevisionRow(props: RevisionRowProps) {
           {newMedianValue} {newUnit}
         </div>
         <div className='status cell' role='cell'>
-          {' '}
-          {determineStatus(improvement, regression)}{' '}
+          <span
+            className={`status-hint ${determineStatusHintClass(
+              improvement,
+              regression,
+            )}`}
+          >
+            {improvement ? <ThumbUpIcon /> : null}
+            {regression ? <ThumbDownIcon /> : null}
+            {determineStatus(improvement, regression)}
+          </span>
         </div>
         <div className='delta cell' role='cell'>
           {' '}

--- a/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
@@ -5,7 +5,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ThumbDownIcon from '@mui/icons-material/ThumbDown';
 import ThumbUpIcon from '@mui/icons-material/ThumbUp';
 import TimelineIcon from '@mui/icons-material/Timeline';
-import { IconButton } from '@mui/material';
+import { IconButton, Box } from '@mui/material';
 import { style } from 'typestyle';
 
 import { useAppSelector } from '../../../hooks/app';
@@ -18,8 +18,6 @@ const revisionsRow = {
   borderRadius: '4px 0px 0px 4px',
   display: 'grid',
   margin: `${Spacing.Small}px 0px`,
-  // Should be kept in sync with the gridTemplateColumns from TableHeader
-  gridTemplateColumns: '4fr 1fr 0.2fr 1fr 1fr 1fr 1fr 1fr 2fr 0.2fr',
 };
 
 const typography = style({
@@ -150,7 +148,7 @@ function determineSign(baseMedianValue: number, newMedianValue: number) {
 }
 
 function SubtestsRevisionRow(props: RevisionRowProps) {
-  const { result } = props;
+  const { result, gridTemplateColumns } = props;
   const {
     test,
     base_median_value: baseMedianValue,
@@ -176,8 +174,9 @@ function SubtestsRevisionRow(props: RevisionRowProps) {
 
   return (
     <>
-      <div
+      <Box
         className={`revisionRow ${styles[themeMode].revisionRow} ${styles[themeMode].typography}`}
+        sx={{ gridTemplateColumns }}
         role='row'
       >
         <div className='subtests cell' role='cell'>
@@ -258,7 +257,7 @@ function SubtestsRevisionRow(props: RevisionRowProps) {
             </IconButton>
           </div>
         </div>
-      </div>
+      </Box>
       {expanded && (
         <div
           className={`content-row ${stylesCard.container}`}
@@ -273,6 +272,7 @@ function SubtestsRevisionRow(props: RevisionRowProps) {
 
 interface RevisionRowProps {
   result: CompareResultsItem;
+  gridTemplateColumns: string;
 }
 
 export default SubtestsRevisionRow;

--- a/src/components/CompareResults/SubtestsResults/SubtestsTableContent.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsTableContent.tsx
@@ -11,7 +11,7 @@ const styles = {
 };
 
 function SubtestsTableContent(props: SubtestsTableContentProps) {
-  const { results, identifier } = props;
+  const { results, identifier, rowGridTemplateColumns } = props;
 
   return (
     <div className={styles.tableBody} role='rowgroup'>
@@ -21,6 +21,7 @@ function SubtestsTableContent(props: SubtestsTableContentProps) {
             <SubtestsRevisionRow
               key={identifier + result.platform}
               result={result}
+              gridTemplateColumns={rowGridTemplateColumns}
             />
           ))}
       </div>
@@ -31,6 +32,7 @@ function SubtestsTableContent(props: SubtestsTableContentProps) {
 interface SubtestsTableContentProps {
   results: CompareResultsItem[];
   identifier: string;
+  rowGridTemplateColumns: string;
 }
 
 export default SubtestsTableContent;

--- a/src/components/CompareResults/TableContent.tsx
+++ b/src/components/CompareResults/TableContent.tsx
@@ -13,7 +13,7 @@ const styles = {
 };
 
 function TableContent(props: TableContentProps) {
-  const { results, header, identifier, view } = props;
+  const { results, header, identifier, view, rowGridTemplateColumns } = props;
 
   return (
     <div className={styles.tableBody} role='rowgroup'>
@@ -25,6 +25,7 @@ function TableContent(props: TableContentProps) {
               key={identifier + result.platform}
               result={result}
               view={view}
+              gridTemplateColumns={rowGridTemplateColumns}
             />
           ))}
       </div>
@@ -36,6 +37,7 @@ interface TableContentProps {
   results: CompareResultsItem[];
   header: RevisionsHeader;
   identifier: string;
+  rowGridTemplateColumns: string;
   view: typeof compareView | typeof compareOverTimeView;
 }
 

--- a/src/components/CompareResults/TableHeader.tsx
+++ b/src/components/CompareResults/TableHeader.tsx
@@ -134,20 +134,13 @@ function TableHeader({
           margin: 0,
           fontWeight: 700,
         },
-        '.platform-header, .subtests-header, .confidence-header': {
-          width: '120px',
+        '& .runs-header, & .platform-header': {
+          justifySelf: 'left',
+          marginLeft: 8,
         },
-        '.status-header': {
-          width: '110px',
-        },
-        '.base-header, .new-header, .delta-header': {
-          width: '85px',
-        },
-        '.confidence-header': {
-          width: '140px',
-        },
-        '.runs-header': {
-          textAlign: 'left',
+        '.subtests-header': {
+          justifySelf: 'left',
+          marginLeft: 24,
         },
       },
     }),

--- a/src/components/CompareResults/TableHeader.tsx
+++ b/src/components/CompareResults/TableHeader.tsx
@@ -112,13 +112,14 @@ function TableHeader({
   onToggleFilter,
   onClearFilter,
 }: TableHeaderProps) {
-  const gridWidthFirstCell = cellsConfiguration[0].gridWidth as string;
   const themeMode = useAppSelector((state) => state.theme.mode);
   const styles = {
     tableHeader: style({
       display: 'grid',
       // Should be kept in sync with the gridTemplateColumns from RevisionRow
-      gridTemplateColumns: `${gridWidthFirstCell} 1fr 0.2fr 1fr 1fr 1fr 1fr 1fr 2fr 0.2fr`,
+      gridTemplateColumns: cellsConfiguration
+        .map((config) => config.gridWidth)
+        .join(' '),
       background:
         themeMode == 'light' ? Colors.Background100 : Colors.Background300Dark,
       borderRadius: '4px',


### PR DESCRIPTION
This PR has 4 commits:
1. adds colors to the subtests view.
2. a small performance-related change about how we deal with the dark and light styles in the subtests page.
3. change how the grid's columns are configured -- instead of an hardcoded value, it comes from the cellsConfiguration. This makes it easier to do different adjustments in the subtests view vs the main view.
4. adjusts a little bit the layout of the results table so that the columns look more aligned.

I did all these changes here because without these changes, the color boxes in the subtests view was moving everything and this wasn't nice at all.

[Production](https://perf.compare/compare-results?baseRev=3cb77efac4ded0c08c36473cf7fac371ad39eaf8&baseRepo=try&newRev=90a817d001629308f4d5acdc2b6317c0e39a82da&newRepo=try&framework=12) / [Deploy preview](https://deploy-preview-751--mozilla-perfcompare.netlify.app/compare-results?baseRev=3cb77efac4ded0c08c36473cf7fac371ad39eaf8&baseRepo=try&newRev=90a817d001629308f4d5acdc2b6317c0e39a82da&newRepo=try&framework=12)

## subtests page:
Before:

![image](https://github.com/user-attachments/assets/c410584c-92d6-497e-92d6-a6d31ca7265f)


After:
![image](https://github.com/user-attachments/assets/fc8e9c59-0ee2-47e3-81a6-a71497a900f2)


## main page with no changes
Before:
![image](https://github.com/user-attachments/assets/f10470c9-e689-4dcb-a04c-2aedb0ea7f13)

After:
![image](https://github.com/user-attachments/assets/0677b87f-d1a2-43b8-9dc5-a9a924b88f36)

## main page with improvements
Before:
![image](https://github.com/user-attachments/assets/25540980-ea0f-4495-81f9-aa011fc498a1)

After:
![image](https://github.com/user-attachments/assets/5978bad6-c046-4fac-98db-8cf1796c03b1)
