### PR TITLE
Increase the maximum amount of possible retriggers to 9

### DIFF
--- a/src/components/CompareResults/Retrigger/RetriggerConfigModal.tsx
+++ b/src/components/CompareResults/Retrigger/RetriggerConfigModal.tsx
@@ -30,12 +30,11 @@ function RetriggerCountSelect({
         label={label}
         sx={{ height: 32 }}
       >
-        <MenuItem value={0}>0</MenuItem>
-        <MenuItem value={1}>1</MenuItem>
-        <MenuItem value={2}>2</MenuItem>
-        <MenuItem value={3}>3</MenuItem>
-        <MenuItem value={4}>4</MenuItem>
-        <MenuItem value={5}>5</MenuItem>
+        {Array.from({ length: 10 }).map((_, count) => (
+          <MenuItem key={count} value={count}>
+            {count}
+          </MenuItem>
+        ))}
       </Select>
     </FormControl>
   );


### PR DESCRIPTION
As requested by @acreskeyMoz!
![image](https://github.com/user-attachments/assets/bb3dc6a5-9621-419d-ba3e-8475a0d74e10)

I tried using a native select so that you wouldn't have to open the select before selecting the value with the keyboard but I couldn't style it quickly properly, so I kept MUI's version for now.