### PR TITLE
Redesign the landing page after the taskcluster signin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^8.0.2",
-        "react-router-dom": "^6.18.0",
+        "react-router-dom": "^6.26.2",
         "react-virtuoso": "^4.9.0",
         "redux": "^4.2.0",
         "run": "^1.4.0",
@@ -3997,9 +3997,10 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.11.0.tgz",
-      "integrity": "sha512-BHdhcWgeiudl91HvVa2wxqZjSHbheSgIiDvxrF1VjFzBzpTtuDPkOdOi3Iqvc08kXtFkLjhbS+ML9aM8mJS+wQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.2.tgz",
+      "integrity": "sha512-baiMx18+IMuD1yyvOGaHM9QrVUPGGG0jC+z+IPHnRJWUAUvaKuWKyE8gjDj2rzv3sz9zOGoRSPgeBVHRhZnBlA==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -15174,11 +15175,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.18.0.tgz",
-      "integrity": "sha512-vk2y7Dsy8wI02eRRaRmOs9g2o+aE72YCx5q9VasT1N9v+lrdB79tIqrjMfByHiY5+6aYkH2rUa5X839nwWGPDg==",
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.2.tgz",
+      "integrity": "sha512-tvN1iuT03kHgOFnLPfLJ8V95eijteveqdOSk+srqfePtQvqCExB8eHOYnlilbOcyJyKnYkr1vJvf7YqotAJu1A==",
+      "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.11.0"
+        "@remix-run/router": "1.19.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -15188,12 +15190,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.18.0.tgz",
-      "integrity": "sha512-Ubrue4+Ercc/BoDkFQfc6og5zRQ4A8YxSO3Knsne+eRbZ+IepAsK249XBH/XaFuOYOYr3L3r13CXTLvYt5JDjw==",
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.2.tgz",
+      "integrity": "sha512-z7YkaEW0Dy35T3/QKPYB1LjMK2R1fxnHO8kWpUMTBdfVzZrWOiY9a7CtN8HqdWtDUWd5FY6Dl8HFsqVwH4uOtQ==",
+      "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.11.0",
-        "react-router": "6.18.0"
+        "@remix-run/router": "1.19.2",
+        "react-router": "6.26.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -20830,9 +20833,9 @@
       }
     },
     "@remix-run/router": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.11.0.tgz",
-      "integrity": "sha512-BHdhcWgeiudl91HvVa2wxqZjSHbheSgIiDvxrF1VjFzBzpTtuDPkOdOi3Iqvc08kXtFkLjhbS+ML9aM8mJS+wQ=="
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.2.tgz",
+      "integrity": "sha512-baiMx18+IMuD1yyvOGaHM9QrVUPGGG0jC+z+IPHnRJWUAUvaKuWKyE8gjDj2rzv3sz9zOGoRSPgeBVHRhZnBlA=="
     },
     "@rushstack/eslint-patch": {
       "version": "1.1.4",
@@ -29088,20 +29091,20 @@
       "dev": true
     },
     "react-router": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.18.0.tgz",
-      "integrity": "sha512-vk2y7Dsy8wI02eRRaRmOs9g2o+aE72YCx5q9VasT1N9v+lrdB79tIqrjMfByHiY5+6aYkH2rUa5X839nwWGPDg==",
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.2.tgz",
+      "integrity": "sha512-tvN1iuT03kHgOFnLPfLJ8V95eijteveqdOSk+srqfePtQvqCExB8eHOYnlilbOcyJyKnYkr1vJvf7YqotAJu1A==",
       "requires": {
-        "@remix-run/router": "1.11.0"
+        "@remix-run/router": "1.19.2"
       }
     },
     "react-router-dom": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.18.0.tgz",
-      "integrity": "sha512-Ubrue4+Ercc/BoDkFQfc6og5zRQ4A8YxSO3Knsne+eRbZ+IepAsK249XBH/XaFuOYOYr3L3r13CXTLvYt5JDjw==",
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.2.tgz",
+      "integrity": "sha512-z7YkaEW0Dy35T3/QKPYB1LjMK2R1fxnHO8kWpUMTBdfVzZrWOiY9a7CtN8HqdWtDUWd5FY6Dl8HFsqVwH4uOtQ==",
       "requires": {
-        "@remix-run/router": "1.11.0",
-        "react-router": "6.18.0"
+        "@remix-run/router": "1.19.2",
+        "react-router": "6.26.2"
       }
     },
     "react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.2",
-    "react-router-dom": "^6.18.0",
+    "react-router-dom": "^6.26.2",
     "react-virtuoso": "^4.9.0",
     "redux": "^4.2.0",
     "run": "^1.4.0",

--- a/src/__tests__/TaskclusterAuth/TaskclusterCallback.test.tsx
+++ b/src/__tests__/TaskclusterAuth/TaskclusterCallback.test.tsx
@@ -132,4 +132,34 @@ describe('Taskcluster Callback', () => {
     ).toBeInTheDocument();
     expect(document.body).toMatchSnapshot();
   });
+
+  it('should show an error if it fails to fetch', async () => {
+    // Because this test will throw an error, a lot of errors will be output to
+    // the console. Let's silence them so that the test output stays clean.
+    jest.spyOn(console, 'error').mockImplementation();
+
+    const inputCode = 'RANDOM_CODE';
+    const inputState = 'RANDOM_STATE';
+
+    setup({ inputState });
+
+    (window.fetch as FetchMockSandbox).post(
+      'https://firefox-ci-tc.services.mozilla.com/login/oauth/token',
+      {
+        status: 403,
+      },
+    );
+
+    renderWithRouter(<TaskclusterCallback />, {
+      route: '/taskcluster-auth',
+      search: `?code=${inputCode}&state=${inputState}`,
+      loader,
+    });
+
+    expect(
+      await screen.findByRole('heading', {
+        name: /Error when requesting Taskcluster: \(403\) Forbidden/,
+      }),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/__tests__/TaskclusterAuth/TaskclusterCallback.test.tsx
+++ b/src/__tests__/TaskclusterAuth/TaskclusterCallback.test.tsx
@@ -104,4 +104,32 @@ describe('Taskcluster Callback', () => {
 
     expect(window.close).toHaveBeenCalled();
   });
+
+  it('should show a spinner while waiting for the credentials', async () => {
+    const inputCode = 'RANDOM_CODE';
+    const inputState = 'RANDOM_STATE';
+    setup({ inputState });
+
+    const neverResolvedPromise = new Promise(() => {});
+
+    (window.fetch as FetchMockSandbox).post(
+      'https://firefox-ci-tc.services.mozilla.com/login/oauth/token',
+      neverResolvedPromise,
+    );
+
+    (window.fetch as FetchMockSandbox).get(
+      'begin:https://firefox-ci-tc.services.mozilla.com/login/oauth/credentials',
+      neverResolvedPromise,
+    );
+    renderWithRouter(<TaskclusterCallback />, {
+      route: '/taskcluster-auth',
+      search: `?code=${inputCode}&state=${inputState}`,
+      loader,
+    });
+
+    expect(
+      await screen.findByText(/Retrieving Taskcluster credentials.../),
+    ).toBeInTheDocument();
+    expect(document.body).toMatchSnapshot();
+  });
 });

--- a/src/__tests__/TaskclusterAuth/TaskclusterCallback.test.tsx
+++ b/src/__tests__/TaskclusterAuth/TaskclusterCallback.test.tsx
@@ -11,14 +11,34 @@ jest.mock('../../utils/location');
 const mockedGetLocationOrigin = getLocationOrigin as jest.Mock;
 
 describe('Taskcluster Callback', () => {
-  it('should fetch credentials with token bearer', async () => {
+  function setup({ inputState }: { inputState: string }) {
     // Make window.close a noop so that the component can be rendered after the
     // authentication process.
     jest.spyOn(window, 'close').mockImplementation(() => {});
+
+    sessionStorage.setItem('requestState', inputState);
+    sessionStorage.setItem(
+      'taskclusterUrl',
+      'https://firefox-ci-tc.services.mozilla.com',
+    );
+
+    mockedGetLocationOrigin.mockImplementation(() => 'http://localhost:3000');
+  }
+
+  it('should fetch credentials with token bearer', async () => {
+    const inputCode = 'dwcygG5HQNaLiRe3RcTCbQ';
+    const inputState = 'OkCrH5isZncYqeJbRDelN';
+    const returnedBearerToken = 'RnVpOGJtdDZTb3FlWW5PVUxVclprQQ==';
+    const returnedUserToken = 'jQWJVQdeRceT-YymPwTWagPh2PwJr0RmmZyL1uAfMSWg';
+    const returnedClientId =
+      'mozilla-auth0/ad|Mozilla-LDAP|ldapuser/perfcompare-localhost-3000-client-OCvzh5';
+
+    setup({ inputState });
+
     (window.fetch as FetchMockSandbox).post(
-      'begin:https://firefox-ci-tc.services.mozilla.com/login/oauth/token',
+      'https://firefox-ci-tc.services.mozilla.com/login/oauth/token',
       {
-        access_token: 'RnVpOGJtdDZTb3FlWW5PVUxVclprQQ==',
+        access_token: returnedBearerToken,
         token_type: 'Bearer',
       },
     );
@@ -28,23 +48,14 @@ describe('Taskcluster Callback', () => {
       {
         expires: '2024-05-20T14:07:40.828Z',
         credentials: {
-          clientId:
-            'mozilla-auth0/ad|Mozilla-LDAP|ldapuser/perfcompare-localhost-3000-client-OCvzh5',
-          accessToken: 'jQWJVQdeRceT-YymPwTWagPh2PwJr0RmmZyL1uAfMSWg',
+          clientId: returnedClientId,
+          accessToken: returnedUserToken,
         },
       },
     );
-    sessionStorage.setItem('requestState', 'OkCrH5isZncYqeJbRDelN');
-    sessionStorage.setItem(
-      'taskclusterUrl',
-      'https://firefox-ci-tc.services.mozilla.com',
-    );
-
-    mockedGetLocationOrigin.mockImplementation(() => 'http://localhost:3000');
-
     renderWithRouter(<TaskclusterCallback />, {
       route: '/taskcluster-auth',
-      search: '?code=dwcygG5HQNaLiRe3RcTCbQ&state=OkCrH5isZncYqeJbRDelN',
+      search: `?code=${inputCode}&state=${inputState}`,
       loader,
     });
 
@@ -54,26 +65,41 @@ describe('Taskcluster Callback', () => {
 
     expect(window.fetch).toHaveBeenCalledWith(
       'https://firefox-ci-tc.services.mozilla.com/login/oauth/token',
-      expect.objectContaining({
+      {
         method: 'POST',
-      }),
+        body: expect.any(URLSearchParams) as URLSearchParams,
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+      },
     );
+    const requestBody = Object.fromEntries(
+      (window.fetch as jest.Mock).mock.calls[0][1].body as URLSearchParams,
+    );
+
+    expect(requestBody).toEqual({
+      client_id: 'perfcompare-localhost-3000-client',
+      code: inputCode,
+      grant_type: 'authorization_code',
+      redirect_uri: 'http://localhost/taskcluster-auth',
+    });
+
     expect(window.fetch).toHaveBeenLastCalledWith(
       'https://firefox-ci-tc.services.mozilla.com/login/oauth/credentials',
       {
         headers: {
-          Authorization: 'Bearer RnVpOGJtdDZTb3FlWW5PVUxVclprQQ==',
+          Authorization: `Bearer ${returnedBearerToken}`,
           'Content-Type': 'aplication/json',
         },
       },
     );
 
     expect(localStorage.userTokens).toBe(
-      '{"https://firefox-ci-tc.services.mozilla.com":{"access_token":"RnVpOGJtdDZTb3FlWW5PVUxVclprQQ==","token_type":"Bearer"}}',
+      `{"https://firefox-ci-tc.services.mozilla.com":{"access_token":"${returnedBearerToken}","token_type":"Bearer"}}`,
     );
 
     expect(localStorage.userCredentials).toBe(
-      '{"https://firefox-ci-tc.services.mozilla.com":{"expires":"2024-05-20T14:07:40.828Z","credentials":{"clientId":"mozilla-auth0/ad|Mozilla-LDAP|ldapuser/perfcompare-localhost-3000-client-OCvzh5","accessToken":"jQWJVQdeRceT-YymPwTWagPh2PwJr0RmmZyL1uAfMSWg"}}}',
+      `{"https://firefox-ci-tc.services.mozilla.com":{"expires":"2024-05-20T14:07:40.828Z","credentials":{"clientId":"${returnedClientId}","accessToken":"${returnedUserToken}"}}}`,
     );
 
     expect(window.close).toHaveBeenCalled();

--- a/src/__tests__/TaskclusterAuth/TaskclusterCallback.test.tsx
+++ b/src/__tests__/TaskclusterAuth/TaskclusterCallback.test.tsx
@@ -11,30 +11,6 @@ jest.mock('../../utils/location');
 const mockedGetLocationOrigin = getLocationOrigin as jest.Mock;
 
 describe('Taskcluster Callback', () => {
-  it('should fetch access token bearer', () => {
-    (window.fetch as FetchMockSandbox).post(
-      'begin:https://firefox-ci-tc.services.mozilla.com/login/oauth/token',
-      {
-        access_token: 'RnVpOGJtdDZTb3FlWW5PVUxVclprQQ==',
-        token_type: 'Bearer',
-      },
-    );
-    sessionStorage.setItem('requestState', 'OkCrH5isZncYqeJbRDelN');
-    sessionStorage.setItem(
-      'taskclusterUrl',
-      'https://firefox-ci-tc.services.mozilla.com',
-    );
-
-    renderWithRouter(<TaskclusterCallback />, {
-      route: '/taskcluster-auth',
-      search: '?code=dwcygG5HQNaLiRe3RcTCbQ&state=OkCrH5isZncYqeJbRDelN',
-      loader,
-    });
-    mockedGetLocationOrigin.mockImplementation(() => 'http://localhost:3000');
-
-    expect(window.fetch).toHaveBeenCalledTimes(1);
-  });
-
   it('should fetch credentials with token bearer', async () => {
     // Make window.close a noop so that the component can be rendered after the
     // authentication process.
@@ -73,9 +49,15 @@ describe('Taskcluster Callback', () => {
     });
 
     expect(
-      await screen.findByText(/Getting Taskcluster credentials/),
+      await screen.findByText(/Credentials were found/),
     ).toBeInTheDocument();
 
+    expect(window.fetch).toHaveBeenCalledWith(
+      'https://firefox-ci-tc.services.mozilla.com/login/oauth/token',
+      expect.objectContaining({
+        method: 'POST',
+      }),
+    );
     expect(window.fetch).toHaveBeenLastCalledWith(
       'https://firefox-ci-tc.services.mozilla.com/login/oauth/credentials',
       {

--- a/src/__tests__/TaskclusterAuth/__snapshots__/TaskclusterCallback.test.tsx.snap
+++ b/src/__tests__/TaskclusterAuth/__snapshots__/TaskclusterCallback.test.tsx.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Taskcluster Callback should show a spinner while waiting for the credentials 1`] = `
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-vmdzdb"
+    >
+      <h2
+        class="MuiTypography-root MuiTypography-h2 css-15umudq-MuiTypography-root"
+      >
+        Retrieving Taskcluster credentials...
+      </h2>
+      <span
+        class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary css-zhs9ko-MuiCircularProgress-root"
+        role="progressbar"
+        style="width: 40px; height: 40px;"
+      >
+        <svg
+          class="MuiCircularProgress-svg css-1idz92c-MuiCircularProgress-svg"
+          viewBox="22 22 44 44"
+        >
+          <circle
+            class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate css-176wh8e-MuiCircularProgress-circle"
+            cx="44"
+            cy="44"
+            fill="none"
+            r="20.2"
+            stroke-width="3.6"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+</body>
+`;

--- a/src/components/TaskclusterAuth/TaskclusterCallback.tsx
+++ b/src/components/TaskclusterAuth/TaskclusterCallback.tsx
@@ -1,9 +1,49 @@
-export default function TaskclusterCallback() {
+import { Suspense } from 'react';
+
+import { Typography, Box, CircularProgress } from '@mui/material';
+import { useLoaderData, Await } from 'react-router-dom';
+
+import { LoaderReturnValue } from './loader';
+
+function WaitingForCredentials() {
   return (
-    <div className='pt-5'>
-      <h2 className='justify-content-center'>
-        <p className='lead text-center'>Getting Taskcluster credentials...</p>
-      </h2>
-    </div>
+    <Box
+      sx={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        gap: 3,
+        margin: 3,
+      }}
+    >
+      <Typography variant='h2' component='h2'>
+        Retrieving Taskcluster credentials...
+      </Typography>
+      <CircularProgress />
+    </Box>
+  );
+}
+
+function CredentialsFound() {
+  return (
+    <>
+      {/* This won't be shown because the window closes after the promise resolves,
+          but is useful for tests. */}
+      Credentials were found!
+    </>
+  );
+}
+
+export default function TaskclusterCallback() {
+  const { retrievalPromise } = useLoaderData() as LoaderReturnValue;
+
+  return (
+    <>
+      <Suspense fallback={<WaitingForCredentials />}>
+        <Await resolve={retrievalPromise}>
+          <CredentialsFound />
+        </Await>
+      </Suspense>
+    </>
   );
 }

--- a/src/components/TaskclusterAuth/loader.ts
+++ b/src/components/TaskclusterAuth/loader.ts
@@ -7,7 +7,32 @@ import {
   retrieveTaskclusterToken,
 } from '../../logic/taskcluster';
 
-export async function loader({ request }: { request: Request }) {
+async function doRetrievalAndStore({
+  rootUrl,
+  taskclusterCode,
+}: {
+  rootUrl: string;
+  taskclusterCode: string;
+}): Promise<void> {
+  const tokenResponse = await retrieveTaskclusterToken(
+    rootUrl,
+    taskclusterCode,
+  );
+
+  storeUserToken(rootUrl, tokenResponse);
+
+  // fetch access token with token Bearer
+  const userCredentials = await retrieveTaskclusterUserCredentials(
+    rootUrl,
+    tokenResponse.access_token,
+  );
+
+  storeUserCredentials(rootUrl, userCredentials);
+
+  window.close();
+}
+
+export function loader({ request }: { request: Request }) {
   const url = new URL(request.url);
 
   const taskclusterCode = url.searchParams.get('code') as string;
@@ -27,26 +52,11 @@ export async function loader({ request }: { request: Request }) {
     );
   }
 
-  const tokenResponse = await retrieveTaskclusterToken(
-    rootUrl,
-    taskclusterCode,
-  );
+  const retrievalPromise = doRetrievalAndStore({ rootUrl, taskclusterCode });
 
-  storeUserToken(rootUrl, tokenResponse);
-
-  // fetch access token with token Bearer
-  const userCredentials = await retrieveTaskclusterUserCredentials(
-    rootUrl,
-    tokenResponse.access_token,
-  );
-
-  storeUserCredentials(rootUrl, userCredentials);
-
-  window.close();
-
-  // TODO Use defer values as explained in https://reactrouter.com/en/main/guides/deferred
-  // so that the component displays while retrieving all the data
-  return userCredentials;
+  return {
+    retrievalPromise,
+  };
 }
 
-export type LoaderReturnValue = Awaited<ReturnType<typeof loader>>;
+export type LoaderReturnValue = ReturnType<typeof loader>;

--- a/src/components/TaskclusterAuth/loader.ts
+++ b/src/components/TaskclusterAuth/loader.ts
@@ -53,6 +53,11 @@ export function loader({ request }: { request: Request }) {
   }
 
   const retrievalPromise = doRetrievalAndStore({ rootUrl, taskclusterCode });
+  // If rejections are not caught here, a rejection would error a test even if
+  // it's caught by an error boundary and asserted in the test. By catching it
+  // here, even doing nothing more and still returning the original promise, the
+  // test doesn't fail anymore.
+  retrievalPromise.catch(() => {});
 
   return {
     retrievalPromise,

--- a/src/logic/taskcluster.ts
+++ b/src/logic/taskcluster.ts
@@ -140,8 +140,7 @@ export async function retrieveTaskclusterToken(rootUrl: string, code: string) {
   // fetch token Bearer
   const response = await fetch(url, options);
 
-  void checkTaskclusterResponse(response);
-
+  await checkTaskclusterResponse(response);
   return response.json() as Promise<TokenBearer>;
 }
 
@@ -161,8 +160,7 @@ export async function retrieveTaskclusterUserCredentials(
   // fetch Taskcluster credentials using token Bearer
   const response = await fetch(url, options);
 
-  void checkTaskclusterResponse(response);
-
+  await checkTaskclusterResponse(response);
   return response.json() as Promise<UserCredentials>;
 }
 


### PR DESCRIPTION
Previously, after the user signs in on taskcluster so that they can do a retrigger request, perfcompare displays a blank page while it validates the credentials. This isn't a great experience so this patch adds up some (limited) spice, especially a spinner.

![image](https://github.com/user-attachments/assets/640363d3-b807-4aba-82e2-c30736a7a400)

This also adds some more tests and fixes a bug with handling errors properly (and adds a test about that).

Commit 1: updates react-router-dom because this fixes an issue with `Await` in the test (without that there's some infinite loop).
Commit 2: make the taskcluster auth landing page asynchronous with promises and adds the spinner.
Commit 3: changes the structure of the test and simplifies it a bit so that other tests can easily be added.
Commit 4: adds a specific test for the spinner.
Commit 5: fixes the issue with handling errors (and adds a test)

Note that you can't test the taskcluster signin from the deploy preview but you can test it by applying the patch locally. I was testing [from this URL](http://localhost:3000/compare-results?baseRev=f47709f0fa48f6c03b361bebe4b2b334053e80ad&baseRepo=mozilla-central&newRev=b5de9d1c08200a7aba6845c319513e6cfc57e0a3&newRepo=mozilla-central&framework=1) (provided you started your local server on port 3000). Make sure that your `localStorage` is empty (using Devtools' Storage panel) so that the sign in process will proceed.
