### PR TITLE
PCF 434: Add documentation to ReadME

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Performance Comparison Tool
 
 ![screenshot](screenshot.png)
 
+## Documentation
+
+Documentation for how to use PerfCompare can be found at [PerfCompare Documentation](https://docs.google.com/document/d/1cpQEZXw0M5QjmNL2F1S9NKjWmz6A9Ks7zELVNTXLeB4/edit).
+
 ## Deployments
 
 PerfCompare is hosted on Netlify, and is updated every time commits are pushed to the following branches:


### PR DESCRIPTION
I've completed writing the documentation for PerfCompare and think it would help to add it to our README. I'd like to get input from the whole team if possible. Thanks. 

[PerfCompare Documentation](https://docs.google.com/document/d/1cpQEZXw0M5QjmNL2F1S9NKjWmz6A9Ks7zELVNTXLeB4/edit#heading=h.u62ha0d6mpxl)