### PR TITLE
Add date range to time range dropdown

### DIFF
--- a/src/__tests__/Search/CompareOverTime.test.tsx
+++ b/src/__tests__/Search/CompareOverTime.test.tsx
@@ -234,13 +234,13 @@ describe('Compare Over Time', () => {
     ).not.toBeInTheDocument();
 
     const timeRangeDropdown = screen.getByRole('button', {
-      name: 'Time range Last day',
+      name: /Time range Last day/i,
     });
 
     await user.click(timeRangeDropdown);
     expect(screen.getByRole('listbox')).toMatchSnapshot();
     const last2daysItem = screen.getByRole('option', {
-      name: 'Last 2 days',
+      name: /Last 2 days/i,
     });
 
     await user.click(last2daysItem);
@@ -450,7 +450,7 @@ describe('Compare Over Time', () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByRole('button', { name: 'Time range Last day' }),
+      screen.getByRole('button', { name: /Time range Last day/i }),
     ).toBeInTheDocument();
 
     // The new repo dropdown and search input should be visible
@@ -541,11 +541,11 @@ describe('Compare Over Time', () => {
 
     //change time range
     const timeRangeDropdown = screen.getByRole('button', {
-      name: 'Time range Last day',
+      name: /Time range Last day/i,
     });
     await user.click(timeRangeDropdown);
     const last2daysItem = screen.getByRole('option', {
-      name: 'Last 2 days',
+      name: /Last 2 days/i,
     });
     await user.click(last2daysItem);
 

--- a/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
@@ -156,6 +156,11 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
               tabindex="0"
             >
               Last day
+              <span
+                class="f7opyze f1np4cs0"
+              >
+                 (10/01/2024 - 10/02/2024)
+              </span>
             </div>
             <input
               aria-hidden="true"
@@ -711,6 +716,11 @@ exports[`Compare Over Time selects and displays new time range when clicked 1`] 
   >
     Last day
     <span
+      class="f7opyze f1np4cs0"
+    >
+       (10/01/2024 - 10/02/2024)
+    </span>
+    <span
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
   </li>
@@ -722,6 +732,11 @@ exports[`Compare Over Time selects and displays new time range when clicked 1`] 
     tabindex="-1"
   >
     Last 2 days
+    <span
+      class="f7opyze f1np4cs0"
+    >
+       (09/30/2024 - 10/02/2024)
+    </span>
     <span
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
@@ -735,6 +750,11 @@ exports[`Compare Over Time selects and displays new time range when clicked 1`] 
   >
     Last 7 days
     <span
+      class="f7opyze f1np4cs0"
+    >
+       (09/25/2024 - 10/02/2024)
+    </span>
+    <span
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
   </li>
@@ -746,6 +766,11 @@ exports[`Compare Over Time selects and displays new time range when clicked 1`] 
     tabindex="-1"
   >
     Last 14 days
+    <span
+      class="f7opyze f1np4cs0"
+    >
+       (09/18/2024 - 10/02/2024)
+    </span>
     <span
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
@@ -759,6 +784,11 @@ exports[`Compare Over Time selects and displays new time range when clicked 1`] 
   >
     Last 30 days
     <span
+      class="f7opyze f1np4cs0"
+    >
+       (09/02/2024 - 10/02/2024)
+    </span>
+    <span
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
   </li>
@@ -770,6 +800,11 @@ exports[`Compare Over Time selects and displays new time range when clicked 1`] 
     tabindex="-1"
   >
     Last 60 days
+    <span
+      class="f7opyze f1np4cs0"
+    >
+       (08/03/2024 - 10/02/2024)
+    </span>
     <span
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
@@ -783,6 +818,11 @@ exports[`Compare Over Time selects and displays new time range when clicked 1`] 
   >
     Last 90 days
     <span
+      class="f7opyze f1np4cs0"
+    >
+       (07/04/2024 - 10/02/2024)
+    </span>
+    <span
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
   </li>
@@ -794,6 +834,11 @@ exports[`Compare Over Time selects and displays new time range when clicked 1`] 
     tabindex="-1"
   >
     Last year
+    <span
+      class="f7opyze f1np4cs0"
+    >
+       (10/03/2023 - 10/02/2024)
+    </span>
     <span
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
@@ -966,6 +1011,11 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
               tabindex="0"
             >
               Last day
+              <span
+                class="f7opyze f1np4cs0"
+              >
+                 (10/01/2024 - 10/02/2024)
+              </span>
             </div>
             <input
               aria-hidden="true"
@@ -1731,6 +1781,11 @@ exports[`Compare Over Time should remove the checked revision once X button is c
               tabindex="0"
             >
               Last day
+              <span
+                class="f7opyze f1np4cs0"
+              >
+                 (10/01/2024 - 10/02/2024)
+              </span>
             </div>
             <input
               aria-hidden="true"
@@ -2569,6 +2624,11 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
               tabindex="0"
             >
               Last day
+              <span
+                class="f7opyze f1np4cs0"
+              >
+                 (10/01/2024 - 10/02/2024)
+              </span>
             </div>
             <input
               aria-hidden="true"

--- a/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
@@ -162,7 +162,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
                 <div
                   class="f7opyze MuiBox-root css-7d9gin"
                 >
-                   (Oct 8, 2024 - Oct 9, 2024)
+                  (Oct 8, 2024 - Oct 9, 2024)
                 </div>
               </div>
             </div>
@@ -518,11 +518,20 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  flie9py css-1t7ybvx-MuiGrid-root"
         style="max-width: 415px;"
       >
-        <span
-          class="MuiTypography-root MuiTypography-body2 css-11g6e76-MuiTypography-root"
+        <div
+          style="display: flex; justify-content: space-between;"
         >
-          Last day
-        </span>
+          <span
+            class="MuiTypography-root MuiTypography-body2 css-11g6e76-MuiTypography-root"
+          >
+            Last day
+          </span>
+          <div
+            class="f7opyze MuiBox-root css-7d9gin"
+          >
+            (Oct 8, 2024 - Oct 9, 2024)
+          </div>
+        </div>
       </div>
     </div>
     <div
@@ -725,7 +734,7 @@ exports[`Compare Over Time selects and displays new time range when clicked 1`] 
       <div
         class="f7opyze MuiBox-root css-7d9gin"
       >
-         (Oct 8, 2024 - Oct 9, 2024)
+        (Oct 8, 2024 - Oct 9, 2024)
       </div>
     </div>
     <span
@@ -746,7 +755,7 @@ exports[`Compare Over Time selects and displays new time range when clicked 1`] 
       <div
         class="f7opyze MuiBox-root css-7d9gin"
       >
-         (Oct 7, 2024 - Oct 9, 2024)
+        (Oct 7, 2024 - Oct 9, 2024)
       </div>
     </div>
     <span
@@ -767,7 +776,7 @@ exports[`Compare Over Time selects and displays new time range when clicked 1`] 
       <div
         class="f7opyze MuiBox-root css-7d9gin"
       >
-         (Oct 2, 2024 - Oct 9, 2024)
+        (Oct 2, 2024 - Oct 9, 2024)
       </div>
     </div>
     <span
@@ -788,7 +797,7 @@ exports[`Compare Over Time selects and displays new time range when clicked 1`] 
       <div
         class="f7opyze MuiBox-root css-7d9gin"
       >
-         (Sep 25, 2024 - Oct 9, 2024)
+        (Sep 25, 2024 - Oct 9, 2024)
       </div>
     </div>
     <span
@@ -809,7 +818,7 @@ exports[`Compare Over Time selects and displays new time range when clicked 1`] 
       <div
         class="f7opyze MuiBox-root css-7d9gin"
       >
-         (Sep 9, 2024 - Oct 9, 2024)
+        (Sep 9, 2024 - Oct 9, 2024)
       </div>
     </div>
     <span
@@ -830,7 +839,7 @@ exports[`Compare Over Time selects and displays new time range when clicked 1`] 
       <div
         class="f7opyze MuiBox-root css-7d9gin"
       >
-         (Aug 10, 2024 - Oct 9, 2024)
+        (Aug 10, 2024 - Oct 9, 2024)
       </div>
     </div>
     <span
@@ -851,7 +860,7 @@ exports[`Compare Over Time selects and displays new time range when clicked 1`] 
       <div
         class="f7opyze MuiBox-root css-7d9gin"
       >
-         (Jul 11, 2024 - Oct 9, 2024)
+        (Jul 11, 2024 - Oct 9, 2024)
       </div>
     </div>
     <span
@@ -872,7 +881,7 @@ exports[`Compare Over Time selects and displays new time range when clicked 1`] 
       <div
         class="f7opyze MuiBox-root css-7d9gin"
       >
-         (Oct 10, 2023 - Oct 9, 2024)
+        (Oct 10, 2023 - Oct 9, 2024)
       </div>
     </div>
     <span
@@ -1053,7 +1062,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
                 <div
                   class="f7opyze MuiBox-root css-7d9gin"
                 >
-                   (Oct 8, 2024 - Oct 9, 2024)
+                  (Oct 8, 2024 - Oct 9, 2024)
                 </div>
               </div>
             </div>
@@ -1479,11 +1488,20 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  flie9py css-1t7ybvx-MuiGrid-root"
         style="max-width: 415px;"
       >
-        <span
-          class="MuiTypography-root MuiTypography-body2 css-11g6e76-MuiTypography-root"
+        <div
+          style="display: flex; justify-content: space-between;"
         >
-          Last day
-        </span>
+          <span
+            class="MuiTypography-root MuiTypography-body2 css-11g6e76-MuiTypography-root"
+          >
+            Last day
+          </span>
+          <div
+            class="f7opyze MuiBox-root css-7d9gin"
+          >
+            (Oct 8, 2024 - Oct 9, 2024)
+          </div>
+        </div>
       </div>
     </div>
     <div
@@ -1827,7 +1845,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
                 <div
                   class="f7opyze MuiBox-root css-7d9gin"
                 >
-                   (Oct 8, 2024 - Oct 9, 2024)
+                  (Oct 8, 2024 - Oct 9, 2024)
                 </div>
               </div>
             </div>
@@ -2192,11 +2210,20 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  flie9py css-1t7ybvx-MuiGrid-root"
         style="max-width: 415px;"
       >
-        <span
-          class="MuiTypography-root MuiTypography-body2 css-11g6e76-MuiTypography-root"
+        <div
+          style="display: flex; justify-content: space-between;"
         >
-          Last 2 days
-        </span>
+          <span
+            class="MuiTypography-root MuiTypography-body2 css-11g6e76-MuiTypography-root"
+          >
+            Last 2 days
+          </span>
+          <div
+            class="f7opyze MuiBox-root css-7d9gin"
+          >
+            (Oct 7, 2024 - Oct 9, 2024)
+          </div>
+        </div>
       </div>
     </div>
     <div
@@ -2674,7 +2701,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                 <div
                   class="f7opyze MuiBox-root css-7d9gin"
                 >
-                   (Oct 8, 2024 - Oct 9, 2024)
+                  (Oct 8, 2024 - Oct 9, 2024)
                 </div>
               </div>
             </div>
@@ -3100,11 +3127,20 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  flie9py css-1t7ybvx-MuiGrid-root"
         style="max-width: 415px;"
       >
-        <span
-          class="MuiTypography-root MuiTypography-body2 css-11g6e76-MuiTypography-root"
+        <div
+          style="display: flex; justify-content: space-between;"
         >
-          Last day
-        </span>
+          <span
+            class="MuiTypography-root MuiTypography-body2 css-11g6e76-MuiTypography-root"
+          >
+            Last day
+          </span>
+          <div
+            class="f7opyze MuiBox-root css-7d9gin"
+          >
+            (Oct 8, 2024 - Oct 9, 2024)
+          </div>
+        </div>
       </div>
     </div>
     <div

--- a/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
@@ -155,12 +155,16 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
               role="button"
               tabindex="0"
             >
-              Last day
-              <span
-                class="f7opyze f1np4cs0"
+              <div
+                class="f1ubk0hm"
               >
-                 (10/01/2024 - 10/02/2024)
-              </span>
+                Last day
+                <div
+                  class="f7opyze MuiBox-root css-7d9gin"
+                >
+                   (Oct 8, 2024 - Oct 9, 2024)
+                </div>
+              </div>
             </div>
             <input
               aria-hidden="true"
@@ -709,136 +713,168 @@ exports[`Compare Over Time selects and displays new time range when clicked 1`] 
 >
   <li
     aria-selected="true"
-    class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-selected MuiMenuItem-root MuiMenuItem-gutters Mui-selected timerange-dropdown-item fi0qnjm css-56615l-MuiButtonBase-root-MuiMenuItem-root"
+    class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters Mui-selected MuiMenuItem-root MuiMenuItem-gutters Mui-selected timerange-dropdown-item fi0qnjm fcmecz0 css-56615l-MuiButtonBase-root-MuiMenuItem-root"
     data-value="86400"
     role="option"
     tabindex="0"
   >
-    Last day
-    <span
-      class="f7opyze f1np4cs0"
+    <div
+      class="f1ubk0hm"
     >
-       (10/01/2024 - 10/02/2024)
-    </span>
+      Last day
+      <div
+        class="f7opyze MuiBox-root css-7d9gin"
+      >
+         (Oct 8, 2024 - Oct 9, 2024)
+      </div>
+    </div>
     <span
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
   </li>
   <li
     aria-selected="false"
-    class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters timerange-dropdown-item fi0qnjm css-56615l-MuiButtonBase-root-MuiMenuItem-root"
+    class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters timerange-dropdown-item fi0qnjm fcmecz0 css-56615l-MuiButtonBase-root-MuiMenuItem-root"
     data-value="172800"
     role="option"
     tabindex="-1"
   >
-    Last 2 days
-    <span
-      class="f7opyze f1np4cs0"
+    <div
+      class="f1ubk0hm"
     >
-       (09/30/2024 - 10/02/2024)
-    </span>
+      Last 2 days
+      <div
+        class="f7opyze MuiBox-root css-7d9gin"
+      >
+         (Oct 7, 2024 - Oct 9, 2024)
+      </div>
+    </div>
     <span
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
   </li>
   <li
     aria-selected="false"
-    class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters timerange-dropdown-item fi0qnjm css-56615l-MuiButtonBase-root-MuiMenuItem-root"
+    class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters timerange-dropdown-item fi0qnjm fcmecz0 css-56615l-MuiButtonBase-root-MuiMenuItem-root"
     data-value="604800"
     role="option"
     tabindex="-1"
   >
-    Last 7 days
-    <span
-      class="f7opyze f1np4cs0"
+    <div
+      class="f1ubk0hm"
     >
-       (09/25/2024 - 10/02/2024)
-    </span>
+      Last 7 days
+      <div
+        class="f7opyze MuiBox-root css-7d9gin"
+      >
+         (Oct 2, 2024 - Oct 9, 2024)
+      </div>
+    </div>
     <span
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
   </li>
   <li
     aria-selected="false"
-    class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters timerange-dropdown-item fi0qnjm css-56615l-MuiButtonBase-root-MuiMenuItem-root"
+    class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters timerange-dropdown-item fi0qnjm fcmecz0 css-56615l-MuiButtonBase-root-MuiMenuItem-root"
     data-value="1209600"
     role="option"
     tabindex="-1"
   >
-    Last 14 days
-    <span
-      class="f7opyze f1np4cs0"
+    <div
+      class="f1ubk0hm"
     >
-       (09/18/2024 - 10/02/2024)
-    </span>
+      Last 14 days
+      <div
+        class="f7opyze MuiBox-root css-7d9gin"
+      >
+         (Sep 25, 2024 - Oct 9, 2024)
+      </div>
+    </div>
     <span
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
   </li>
   <li
     aria-selected="false"
-    class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters timerange-dropdown-item fi0qnjm css-56615l-MuiButtonBase-root-MuiMenuItem-root"
+    class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters timerange-dropdown-item fi0qnjm fcmecz0 css-56615l-MuiButtonBase-root-MuiMenuItem-root"
     data-value="2592000"
     role="option"
     tabindex="-1"
   >
-    Last 30 days
-    <span
-      class="f7opyze f1np4cs0"
+    <div
+      class="f1ubk0hm"
     >
-       (09/02/2024 - 10/02/2024)
-    </span>
+      Last 30 days
+      <div
+        class="f7opyze MuiBox-root css-7d9gin"
+      >
+         (Sep 9, 2024 - Oct 9, 2024)
+      </div>
+    </div>
     <span
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
   </li>
   <li
     aria-selected="false"
-    class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters timerange-dropdown-item fi0qnjm css-56615l-MuiButtonBase-root-MuiMenuItem-root"
+    class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters timerange-dropdown-item fi0qnjm fcmecz0 css-56615l-MuiButtonBase-root-MuiMenuItem-root"
     data-value="5184000"
     role="option"
     tabindex="-1"
   >
-    Last 60 days
-    <span
-      class="f7opyze f1np4cs0"
+    <div
+      class="f1ubk0hm"
     >
-       (08/03/2024 - 10/02/2024)
-    </span>
+      Last 60 days
+      <div
+        class="f7opyze MuiBox-root css-7d9gin"
+      >
+         (Aug 10, 2024 - Oct 9, 2024)
+      </div>
+    </div>
     <span
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
   </li>
   <li
     aria-selected="false"
-    class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters timerange-dropdown-item fi0qnjm css-56615l-MuiButtonBase-root-MuiMenuItem-root"
+    class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters timerange-dropdown-item fi0qnjm fcmecz0 css-56615l-MuiButtonBase-root-MuiMenuItem-root"
     data-value="7776000"
     role="option"
     tabindex="-1"
   >
-    Last 90 days
-    <span
-      class="f7opyze f1np4cs0"
+    <div
+      class="f1ubk0hm"
     >
-       (07/04/2024 - 10/02/2024)
-    </span>
+      Last 90 days
+      <div
+        class="f7opyze MuiBox-root css-7d9gin"
+      >
+         (Jul 11, 2024 - Oct 9, 2024)
+      </div>
+    </div>
     <span
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
   </li>
   <li
     aria-selected="false"
-    class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters timerange-dropdown-item fi0qnjm css-56615l-MuiButtonBase-root-MuiMenuItem-root"
+    class="MuiButtonBase-root MuiMenuItem-root MuiMenuItem-gutters MuiMenuItem-root MuiMenuItem-gutters timerange-dropdown-item fi0qnjm fcmecz0 css-56615l-MuiButtonBase-root-MuiMenuItem-root"
     data-value="31536000"
     role="option"
     tabindex="-1"
   >
-    Last year
-    <span
-      class="f7opyze f1np4cs0"
+    <div
+      class="f1ubk0hm"
     >
-       (10/03/2023 - 10/02/2024)
-    </span>
+      Last year
+      <div
+        class="f7opyze MuiBox-root css-7d9gin"
+      >
+         (Oct 10, 2023 - Oct 9, 2024)
+      </div>
+    </div>
     <span
       class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
     />
@@ -1010,12 +1046,16 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
               role="button"
               tabindex="0"
             >
-              Last day
-              <span
-                class="f7opyze f1np4cs0"
+              <div
+                class="f1ubk0hm"
               >
-                 (10/01/2024 - 10/02/2024)
-              </span>
+                Last day
+                <div
+                  class="f7opyze MuiBox-root css-7d9gin"
+                >
+                   (Oct 8, 2024 - Oct 9, 2024)
+                </div>
+              </div>
             </div>
             <input
               aria-hidden="true"
@@ -1780,12 +1820,16 @@ exports[`Compare Over Time should remove the checked revision once X button is c
               role="button"
               tabindex="0"
             >
-              Last day
-              <span
-                class="f7opyze f1np4cs0"
+              <div
+                class="f1ubk0hm"
               >
-                 (10/01/2024 - 10/02/2024)
-              </span>
+                Last day
+                <div
+                  class="f7opyze MuiBox-root css-7d9gin"
+                >
+                   (Oct 8, 2024 - Oct 9, 2024)
+                </div>
+              </div>
             </div>
             <input
               aria-hidden="true"
@@ -2623,12 +2667,16 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
               role="button"
               tabindex="0"
             >
-              Last day
-              <span
-                class="f7opyze f1np4cs0"
+              <div
+                class="f1ubk0hm"
               >
-                 (10/01/2024 - 10/02/2024)
-              </span>
+                Last day
+                <div
+                  class="f7opyze MuiBox-root css-7d9gin"
+                >
+                   (Oct 8, 2024 - Oct 9, 2024)
+                </div>
+              </div>
             </div>
             <input
               aria-hidden="true"

--- a/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
@@ -4282,6 +4282,11 @@ exports[`Compare With Base should remove the checked revision once X button is c
                           tabindex="0"
                         >
                           Last day
+                          <span
+                            class="f7opyze f1np4cs0"
+                          >
+                             (10/01/2024 - 10/02/2024)
+                          </span>
                         </div>
                         <input
                           aria-hidden="true"

--- a/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
@@ -4281,12 +4281,16 @@ exports[`Compare With Base should remove the checked revision once X button is c
                           role="button"
                           tabindex="0"
                         >
-                          Last day
-                          <span
-                            class="f7opyze f1np4cs0"
+                          <div
+                            class="f1ubk0hm"
                           >
-                             (10/01/2024 - 10/02/2024)
-                          </span>
+                            Last day
+                            <div
+                              class="f7opyze MuiBox-root css-7d9gin"
+                            >
+                               (Oct 8, 2024 - Oct 9, 2024)
+                            </div>
+                          </div>
                         </div>
                         <input
                           aria-hidden="true"

--- a/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
@@ -4288,7 +4288,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                             <div
                               class="f7opyze MuiBox-root css-7d9gin"
                             >
-                               (Oct 8, 2024 - Oct 9, 2024)
+                              (Oct 8, 2024 - Oct 9, 2024)
                             </div>
                           </div>
                         </div>

--- a/src/__tests__/Search/__snapshots__/SearchContainer.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchContainer.test.tsx.snap
@@ -632,6 +632,11 @@ exports[`Search Containter should match snapshot 1`] = `
                         tabindex="0"
                       >
                         Last day
+                        <span
+                          class="f7opyze f1np4cs0"
+                        >
+                           (10/01/2024 - 10/02/2024)
+                        </span>
                       </div>
                       <input
                         aria-hidden="true"

--- a/src/__tests__/Search/__snapshots__/SearchContainer.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchContainer.test.tsx.snap
@@ -638,7 +638,7 @@ exports[`Search Containter should match snapshot 1`] = `
                           <div
                             class="f7opyze MuiBox-root css-7d9gin"
                           >
-                             (Oct 8, 2024 - Oct 9, 2024)
+                            (Oct 8, 2024 - Oct 9, 2024)
                           </div>
                         </div>
                       </div>

--- a/src/__tests__/Search/__snapshots__/SearchContainer.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchContainer.test.tsx.snap
@@ -631,12 +631,16 @@ exports[`Search Containter should match snapshot 1`] = `
                         role="button"
                         tabindex="0"
                       >
-                        Last day
-                        <span
-                          class="f7opyze f1np4cs0"
+                        <div
+                          class="f1ubk0hm"
                         >
-                           (10/01/2024 - 10/02/2024)
-                        </span>
+                          Last day
+                          <div
+                            class="f7opyze MuiBox-root css-7d9gin"
+                          >
+                             (Oct 8, 2024 - Oct 9, 2024)
+                          </div>
+                        </div>
                       </div>
                       <input
                         aria-hidden="true"

--- a/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
@@ -1833,12 +1833,16 @@ exports[`SearchResultsList should match snapshot 1`] = `
                           role="button"
                           tabindex="0"
                         >
-                          Last day
-                          <span
-                            class="f7opyze f1np4cs0"
+                          <div
+                            class="f1ubk0hm"
                           >
-                             (10/01/2024 - 10/02/2024)
-                          </span>
+                            Last day
+                            <div
+                              class="f7opyze MuiBox-root css-7d9gin"
+                            >
+                               (Oct 8, 2024 - Oct 9, 2024)
+                            </div>
+                          </div>
                         </div>
                         <input
                           aria-hidden="true"

--- a/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
@@ -1840,7 +1840,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                             <div
                               class="f7opyze MuiBox-root css-7d9gin"
                             >
-                               (Oct 8, 2024 - Oct 9, 2024)
+                              (Oct 8, 2024 - Oct 9, 2024)
                             </div>
                           </div>
                         </div>

--- a/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
@@ -1834,6 +1834,11 @@ exports[`SearchResultsList should match snapshot 1`] = `
                           tabindex="0"
                         >
                           Last day
+                          <span
+                            class="f7opyze f1np4cs0"
+                          >
+                             (10/01/2024 - 10/02/2024)
+                          </span>
                         </div>
                         <input
                           aria-hidden="true"

--- a/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
@@ -710,12 +710,16 @@ exports[`Search View renders correctly when there are no results 1`] = `
                           role="button"
                           tabindex="0"
                         >
-                          Last day
-                          <span
-                            class="f7opyze f1np4cs0"
+                          <div
+                            class="f1ubk0hm"
                           >
-                             (10/01/2024 - 10/02/2024)
-                          </span>
+                            Last day
+                            <div
+                              class="f7opyze MuiBox-root css-7d9gin"
+                            >
+                               (Oct 8, 2024 - Oct 9, 2024)
+                            </div>
+                          </div>
                         </div>
                         <input
                           aria-hidden="true"
@@ -1126,12 +1130,16 @@ exports[`With search parameters both search components are populated as expected
               role="button"
               tabindex="0"
             >
-              Last day
-              <span
-                class="f7opyze f1np4cs0"
+              <div
+                class="f1ubk0hm"
               >
-                 (10/01/2024 - 10/02/2024)
-              </span>
+                Last day
+                <div
+                  class="f7opyze MuiBox-root css-7d9gin"
+                >
+                   (Oct 8, 2024 - Oct 9, 2024)
+                </div>
+              </div>
             </div>
             <input
               aria-hidden="true"
@@ -2176,12 +2184,16 @@ exports[`With search parameters both search components are populated as expected
               role="button"
               tabindex="0"
             >
-              Last day
-              <span
-                class="f7opyze f1np4cs0"
+              <div
+                class="f1ubk0hm"
               >
-                 (10/01/2024 - 10/02/2024)
-              </span>
+                Last day
+                <div
+                  class="f7opyze MuiBox-root css-7d9gin"
+                >
+                   (Oct 8, 2024 - Oct 9, 2024)
+                </div>
+              </div>
             </div>
             <input
               aria-hidden="true"
@@ -3226,12 +3238,16 @@ exports[`With search parameters displays the default value for framework if the 
               role="button"
               tabindex="0"
             >
-              Last day
-              <span
-                class="f7opyze f1np4cs0"
+              <div
+                class="f1ubk0hm"
               >
-                 (10/01/2024 - 10/02/2024)
-              </span>
+                Last day
+                <div
+                  class="f7opyze MuiBox-root css-7d9gin"
+                >
+                   (Oct 8, 2024 - Oct 9, 2024)
+                </div>
+              </div>
             </div>
             <input
               aria-hidden="true"
@@ -4276,12 +4292,16 @@ exports[`With search parameters displays the default values if some values are b
               role="button"
               tabindex="0"
             >
-              Last day
-              <span
-                class="f7opyze f1np4cs0"
+              <div
+                class="f1ubk0hm"
               >
-                 (10/01/2024 - 10/02/2024)
-              </span>
+                Last day
+                <div
+                  class="f7opyze MuiBox-root css-7d9gin"
+                >
+                   (Oct 8, 2024 - Oct 9, 2024)
+                </div>
+              </div>
             </div>
             <input
               aria-hidden="true"

--- a/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
@@ -717,7 +717,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                             <div
                               class="f7opyze MuiBox-root css-7d9gin"
                             >
-                               (Oct 8, 2024 - Oct 9, 2024)
+                              (Oct 8, 2024 - Oct 9, 2024)
                             </div>
                           </div>
                         </div>
@@ -1137,7 +1137,7 @@ exports[`With search parameters both search components are populated as expected
                 <div
                   class="f7opyze MuiBox-root css-7d9gin"
                 >
-                   (Oct 8, 2024 - Oct 9, 2024)
+                  (Oct 8, 2024 - Oct 9, 2024)
                 </div>
               </div>
             </div>
@@ -2191,7 +2191,7 @@ exports[`With search parameters both search components are populated as expected
                 <div
                   class="f7opyze MuiBox-root css-7d9gin"
                 >
-                   (Oct 8, 2024 - Oct 9, 2024)
+                  (Oct 8, 2024 - Oct 9, 2024)
                 </div>
               </div>
             </div>
@@ -3245,7 +3245,7 @@ exports[`With search parameters displays the default value for framework if the 
                 <div
                   class="f7opyze MuiBox-root css-7d9gin"
                 >
-                   (Oct 8, 2024 - Oct 9, 2024)
+                  (Oct 8, 2024 - Oct 9, 2024)
                 </div>
               </div>
             </div>
@@ -4299,7 +4299,7 @@ exports[`With search parameters displays the default values if some values are b
                 <div
                   class="f7opyze MuiBox-root css-7d9gin"
                 >
-                   (Oct 8, 2024 - Oct 9, 2024)
+                  (Oct 8, 2024 - Oct 9, 2024)
                 </div>
               </div>
             </div>

--- a/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
@@ -711,6 +711,11 @@ exports[`Search View renders correctly when there are no results 1`] = `
                           tabindex="0"
                         >
                           Last day
+                          <span
+                            class="f7opyze f1np4cs0"
+                          >
+                             (10/01/2024 - 10/02/2024)
+                          </span>
                         </div>
                         <input
                           aria-hidden="true"
@@ -1122,6 +1127,11 @@ exports[`With search parameters both search components are populated as expected
               tabindex="0"
             >
               Last day
+              <span
+                class="f7opyze f1np4cs0"
+              >
+                 (10/01/2024 - 10/02/2024)
+              </span>
             </div>
             <input
               aria-hidden="true"
@@ -2167,6 +2177,11 @@ exports[`With search parameters both search components are populated as expected
               tabindex="0"
             >
               Last day
+              <span
+                class="f7opyze f1np4cs0"
+              >
+                 (10/01/2024 - 10/02/2024)
+              </span>
             </div>
             <input
               aria-hidden="true"
@@ -3212,6 +3227,11 @@ exports[`With search parameters displays the default value for framework if the 
               tabindex="0"
             >
               Last day
+              <span
+                class="f7opyze f1np4cs0"
+              >
+                 (10/01/2024 - 10/02/2024)
+              </span>
             </div>
             <input
               aria-hidden="true"
@@ -4257,6 +4277,11 @@ exports[`With search parameters displays the default values if some values are b
               tabindex="0"
             >
               Last day
+              <span
+                class="f7opyze f1np4cs0"
+              >
+                 (10/01/2024 - 10/02/2024)
+              </span>
             </div>
             <input
               aria-hidden="true"

--- a/src/__tests__/utils/setupTests.ts
+++ b/src/__tests__/utils/setupTests.ts
@@ -98,7 +98,7 @@ beforeEach(function () {
 });
 
 beforeEach(() => {
-  jest.useFakeTimers();
+  jest.useFakeTimers({ now: new Date('Wed, 09 Oct 2024 12:45:17 GMT') });
   store = createStore();
 });
 

--- a/src/components/Search/SearchOverTime.tsx
+++ b/src/components/Search/SearchOverTime.tsx
@@ -3,6 +3,7 @@ import Grid from '@mui/material/Grid';
 import InputLabel from '@mui/material/InputLabel';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
+import { Box } from '@mui/system';
 import { style } from 'typestyle';
 
 import { compareOverTimeView, timeRanges } from '../../common/constants';
@@ -13,9 +14,11 @@ import {
   //SearchStyles can be found in CompareCards.ts
   SearchStyles,
   Colors,
+  FontSize,
 } from '../../styles';
 import { Changeset, Repository } from '../../types/state';
 import { TimeRange } from '../../types/types';
+import { formatDateRange } from '../../utils/format';
 import SearchDropdown from './SearchDropdown';
 import SearchInputAndResults from './SearchInputAndResults';
 import SelectedRevisions from './SelectedRevisions';
@@ -148,14 +151,22 @@ export default function SearchOverTime({
             style={{ maxWidth: hasEditButton ? '415px' : '365px' }}
             className={`new-search-dropdown  ${readOnlyStyles}`}
           >
-            <Typography
-              component='span'
-              variant='body2'
-              color='text.primary'
-              alignItems='center'
-            >
-              {timeRangeText}
-            </Typography>
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <Typography
+                component='span'
+                variant='body2'
+                color='text.primary'
+                alignItems='center'
+              >
+                {timeRangeText}
+              </Typography>
+              <Box sx={{ color: 'text.secondary' }} className={FontSize.Small}>
+                {`(${formatDateRange(
+                  new Date(Date.now() - Number(timeRangeValue) * 1000),
+                  new Date(),
+                )})`}
+              </Box>
+            </div>
           </Grid>
         </Grid>
       )}

--- a/src/components/Search/TimeRangeDropdown.tsx
+++ b/src/components/Search/TimeRangeDropdown.tsx
@@ -56,11 +56,9 @@ function TimeRangeDropdown({
       month: '2-digit',
       day: '2-digit',
     };
-    const fromDate = new Date(Date.now() - value * 1000).toLocaleDateString(
-      'en-US',
-      options,
-    );
-    const toDate = new Date(Date.now()).toLocaleDateString('en-US', options);
+    const dateFormatter = new Intl.DateTimeFormat('en-US', options);
+    const fromDate = dateFormatter.format(new Date(Date.now() - value * 1000));
+    const toDate = dateFormatter.format(new Date());
     return ` (${fromDate} - ${toDate})`;
   };
 

--- a/src/components/Search/TimeRangeDropdown.tsx
+++ b/src/components/Search/TimeRangeDropdown.tsx
@@ -1,6 +1,7 @@
 import FormControl from '@mui/material/FormControl';
 import MenuItem from '@mui/material/MenuItem';
 import Select, { SelectChangeEvent } from '@mui/material/Select';
+import { Box } from '@mui/system';
 import { style } from 'typestyle';
 
 import { timeRangeMap } from '../../common/constants';
@@ -10,7 +11,6 @@ import {
   ButtonsLightRaw,
   ButtonsDarkRaw,
   DropDownItems,
-  DateRange,
   FontSize,
 } from '../../styles';
 import type { TimeRange } from '../../types/types';
@@ -40,6 +40,13 @@ function TimeRangeDropdown({
         },
       },
     }),
+    menuItem: style({
+      display: 'block',
+    }),
+    dateRange: style({
+      display: 'flex',
+      justifyContent: 'space-between',
+    }),
   };
 
   const handleTimeRangeSelect = async (event: SelectChangeEvent) => {
@@ -48,7 +55,6 @@ function TimeRangeDropdown({
   };
   const menuItemStyles =
     mode === 'light' ? DropDownItems.Light : DropDownItems.Dark;
-  const dateRangeStyles = mode === 'light' ? DateRange.Light : DateRange.Dark;
 
   const displayDateRange = (value: number) => {
     const options: Intl.DateTimeFormatOptions = {
@@ -82,12 +88,17 @@ function TimeRangeDropdown({
             <MenuItem
               value={value}
               key={value}
-              className={`timerange-dropdown-item ${menuItemStyles}`}
+              className={`timerange-dropdown-item ${menuItemStyles} ${styles.menuItem}`}
             >
-              {text}
-              <span className={`${FontSize.Small} ${dateRangeStyles}`}>
-                {displayDateRange(Number(value))}
-              </span>
+              <div className={styles.dateRange}>
+                {text}
+                <Box
+                  sx={{ color: 'text.secondary' }}
+                  className={`${FontSize.Small}`}
+                >
+                  {displayDateRange(Number(value))}
+                </Box>
+              </div>
             </MenuItem>
           ))}
         </Select>

--- a/src/components/Search/TimeRangeDropdown.tsx
+++ b/src/components/Search/TimeRangeDropdown.tsx
@@ -14,6 +14,7 @@ import {
   FontSize,
 } from '../../styles';
 import type { TimeRange } from '../../types/types';
+import { formatDateRange } from '../../utils/format';
 
 const strings = Strings.components.searchDefault.overTime.collapsed.timeRange;
 
@@ -56,16 +57,6 @@ function TimeRangeDropdown({
   const menuItemStyles =
     mode === 'light' ? DropDownItems.Light : DropDownItems.Dark;
 
-  const displayDateRange = (value: number) => {
-    const options: Intl.DateTimeFormatOptions = {
-      dateStyle: 'medium',
-    };
-    const dateFormatter = new Intl.DateTimeFormat('en-US', options);
-    const fromDate = dateFormatter.format(new Date(Date.now() - value * 1000));
-    const toDate = dateFormatter.format(new Date());
-    return ` (${fromDate} - ${toDate})`;
-  };
-
   return (
     <>
       <FormControl className={`timerange-dropdown ${styles.container}`}>
@@ -94,9 +85,12 @@ function TimeRangeDropdown({
                 {text}
                 <Box
                   sx={{ color: 'text.secondary' }}
-                  className={`${FontSize.Small}`}
+                  className={FontSize.Small}
                 >
-                  {displayDateRange(Number(value))}
+                  {`(${formatDateRange(
+                    new Date(Date.now() - Number(value) * 1000),
+                    new Date(),
+                  )})`}
                 </Box>
               </div>
             </MenuItem>

--- a/src/components/Search/TimeRangeDropdown.tsx
+++ b/src/components/Search/TimeRangeDropdown.tsx
@@ -50,15 +50,16 @@ function TimeRangeDropdown({
     mode === 'light' ? DropDownItems.Light : DropDownItems.Dark;
   const dateRangeStyles = mode === 'light' ? DateRange.Light : DateRange.Dark;
 
-  const displayDateRange = (value: string) => {
+  const displayDateRange = (value: number) => {
     const options: Intl.DateTimeFormatOptions = {
       year: 'numeric',
       month: '2-digit',
       day: '2-digit',
     };
-    const fromDate = new Date(
-      Date.now() - Number(value) * 1000,
-    ).toLocaleDateString('en-US', options);
+    const fromDate = new Date(Date.now() - value * 1000).toLocaleDateString(
+      'en-US',
+      options,
+    );
     const toDate = new Date(Date.now()).toLocaleDateString('en-US', options);
     return ` (${fromDate} - ${toDate})`;
   };
@@ -89,7 +90,7 @@ function TimeRangeDropdown({
             >
               {text}
               <span className={`${FontSize.Small} ${dateRangeStyles}`}>
-                {displayDateRange(value)}
+                {displayDateRange(Number(value))}
               </span>
             </MenuItem>
           ))}

--- a/src/components/Search/TimeRangeDropdown.tsx
+++ b/src/components/Search/TimeRangeDropdown.tsx
@@ -6,7 +6,13 @@ import { style } from 'typestyle';
 import { timeRangeMap } from '../../common/constants';
 import { useAppSelector } from '../../hooks/app';
 import { Strings } from '../../resources/Strings';
-import { ButtonsLightRaw, ButtonsDarkRaw, DropDownItems } from '../../styles';
+import {
+  ButtonsLightRaw,
+  ButtonsDarkRaw,
+  DropDownItems,
+  DateRange,
+  FontSize,
+} from '../../styles';
 import type { TimeRange } from '../../types/types';
 
 const strings = Strings.components.searchDefault.overTime.collapsed.timeRange;
@@ -42,6 +48,20 @@ function TimeRangeDropdown({
   };
   const menuItemStyles =
     mode === 'light' ? DropDownItems.Light : DropDownItems.Dark;
+  const dateRangeStyles = mode === 'light' ? DateRange.Light : DateRange.Dark;
+
+  const displayDateRange = (value: string) => {
+    const options: Intl.DateTimeFormatOptions = {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    };
+    const fromDate = new Date(
+      Date.now() - Number(value) * 1000,
+    ).toLocaleDateString('en-US', options);
+    const toDate = new Date(Date.now()).toLocaleDateString('en-US', options);
+    return ` (${fromDate} - ${toDate})`;
+  };
 
   return (
     <>
@@ -68,6 +88,9 @@ function TimeRangeDropdown({
               className={`timerange-dropdown-item ${menuItemStyles}`}
             >
               {text}
+              <span className={`${FontSize.Small} ${dateRangeStyles}`}>
+                {displayDateRange(value)}
+              </span>
             </MenuItem>
           ))}
         </Select>

--- a/src/components/Search/TimeRangeDropdown.tsx
+++ b/src/components/Search/TimeRangeDropdown.tsx
@@ -44,6 +44,9 @@ function TimeRangeDropdown({
     menuItem: style({
       display: 'block',
     }),
+    // This extra flexible div is needed, so that the information looks the same in
+    // both the MenuItem (in the dropdown options) and the SelectedItem (in
+    // the dropdown, when the dropdown is closed).
     dateRange: style({
       display: 'flex',
       justifyContent: 'space-between',

--- a/src/components/Search/TimeRangeDropdown.tsx
+++ b/src/components/Search/TimeRangeDropdown.tsx
@@ -52,9 +52,7 @@ function TimeRangeDropdown({
 
   const displayDateRange = (value: number) => {
     const options: Intl.DateTimeFormatOptions = {
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
+      dateStyle: 'medium',
     };
     const dateFormatter = new Intl.DateTimeFormat('en-US', options);
     const fromDate = dateFormatter.format(new Date(Date.now() - value * 1000));

--- a/src/styles/DropDownMenu.ts
+++ b/src/styles/DropDownMenu.ts
@@ -19,29 +19,6 @@ const sharedListStyles = {
   margin: `${Spacing.xSmall}px ${Spacing.Small}px`,
 };
 
-const sharedDateRangeStyles = {
-  display: 'inline-block',
-  position: 'absolute' as const,
-  right: `3rem`,
-};
-
-export const DateRangeRaw = {
-  Light: {
-    ...sharedDateRangeStyles,
-    color: Colors.SecondaryText,
-  },
-
-  Dark: {
-    ...sharedDateRangeStyles,
-    color: Colors.SecondaryTextDark,
-  },
-};
-
-export const DateRange = {
-  Light: style(DateRangeRaw.Light),
-  Dark: style(DateRangeRaw.Dark),
-};
-
 export const DropDownMenuRaw = {
   Light: {
     ...sharedDropDownStyles,

--- a/src/styles/DropDownMenu.ts
+++ b/src/styles/DropDownMenu.ts
@@ -19,6 +19,29 @@ const sharedListStyles = {
   margin: `${Spacing.xSmall}px ${Spacing.Small}px`,
 };
 
+const sharedDateRangeStyles = {
+  display: 'inline-block',
+  position: 'absolute' as const,
+  right: `3rem`,
+};
+
+export const DateRangeRaw = {
+  Light: {
+    ...sharedDateRangeStyles,
+    color: Colors.SecondaryText,
+  },
+
+  Dark: {
+    ...sharedDateRangeStyles,
+    color: Colors.SecondaryTextDark,
+  },
+};
+
+export const DateRange = {
+  Light: style(DateRangeRaw.Light),
+  Dark: style(DateRangeRaw.Dark),
+};
+
 export const DropDownMenuRaw = {
   Light: {
     ...sharedDropDownStyles,

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,11 @@
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
+  dateStyle: 'medium',
+});
+
+export function formatDate(date: Date) {
+  return dateFormatter.format(date);
+}
+
+export function formatDateRange(date1: Date, date2: Date) {
+  return formatDate(date1) + ' - ' + formatDate(date2);
+}


### PR DESCRIPTION
 Solves [Bug 1922027](https://bugzilla.mozilla.org/show_bug.cgi?id=1922027)
## Description
  This PR enhances the existing time range dropdown in the CompareOverTime UI by displaying specific dates alongside the predefined time range options. This provides users with better clarity on the exact date ranges they are selecting.

## Changes:
Updated the time range dropdown to display specific start and end dates next to predefined options (e.g., "Last 7 days" now shows the exact dates).

## Screenshot:
![image](https://github.com/user-attachments/assets/c89a6520-aa5f-4663-adb3-332ee9c66a80)
