### PR TITLE
PCF-425 Add colors and icons for the confidence information

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -552,26 +552,18 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="confidence cell"
                   role="cell"
                 >
-                  <div
-                    class="confidence-icon"
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-vsehry-MuiSvgIcon-root"
+                    data-testid="KeyboardArrowDownIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-vsehry-MuiSvgIcon-root"
-                      data-testid="KeyboardArrowDownIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
-                      />
-                    </svg>
-                  </div>
-                  <div
-                    class="confidence-text"
-                  >
-                    Low
-                  </div>
+                    <path
+                      d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                    />
+                  </svg>
+                  Low
                 </div>
                 <div
                   class="total-runs cell"
@@ -783,26 +775,18 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="confidence cell"
                   role="cell"
                 >
-                  <div
-                    class="confidence-icon"
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o6fkbf-MuiSvgIcon-root"
+                    data-testid="DragHandleIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o6fkbf-MuiSvgIcon-root"
-                      data-testid="DragHandleIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M20 9H4v2h16V9zM4 15h16v-2H4v2z"
-                      />
-                    </svg>
-                  </div>
-                  <div
-                    class="confidence-text"
-                  >
-                    Medium
-                  </div>
+                    <path
+                      d="M20 9H4v2h16V9zM4 15h16v-2H4v2z"
+                    />
+                  </svg>
+                  Medium
                 </div>
                 <div
                   class="total-runs cell"
@@ -1004,26 +988,18 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="confidence cell"
                   role="cell"
                 >
-                  <div
-                    class="confidence-icon"
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-18c6igo-MuiSvgIcon-root"
+                    data-testid="KeyboardArrowUpIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-18c6igo-MuiSvgIcon-root"
-                      data-testid="KeyboardArrowUpIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M7.41 15.41 12 10.83l4.59 4.58L18 14l-6-6-6 6z"
-                      />
-                    </svg>
-                  </div>
-                  <div
-                    class="confidence-text"
-                  >
-                    High
-                  </div>
+                    <path
+                      d="M7.41 15.41 12 10.83l4.59 4.58L18 14l-6-6-6 6z"
+                    />
+                  </svg>
+                  High
                 </div>
                 <div
                   class="total-runs cell"
@@ -1224,14 +1200,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 <div
                   class="confidence cell"
                   role="cell"
-                >
-                  <div
-                    class="confidence-icon"
-                  />
-                  <div
-                    class="confidence-text"
-                  />
-                </div>
+                />
                 <div
                   class="total-runs cell"
                   role="cell"

--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -465,7 +465,7 @@ exports[`Results View The table should match snapshot and other elements should 
             </div>
             <div>
               <div
-                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-1am90bh"
+                class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
                 role="row"
               >
                 <div
@@ -552,9 +552,26 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="confidence cell"
                   role="cell"
                 >
-                   
-                  Low
-                   
+                  <div
+                    class="confidence-icon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-vsehry-MuiSvgIcon-root"
+                      data-testid="KeyboardArrowDownIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="confidence-text"
+                  >
+                    Low
+                  </div>
                 </div>
                 <div
                   class="total-runs cell"
@@ -680,7 +697,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-1am90bh"
+                class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
                 role="row"
               >
                 <div
@@ -766,9 +783,26 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="confidence cell"
                   role="cell"
                 >
-                   
-                  Medium
-                   
+                  <div
+                    class="confidence-icon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o6fkbf-MuiSvgIcon-root"
+                      data-testid="DragHandleIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M20 9H4v2h16V9zM4 15h16v-2H4v2z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="confidence-text"
+                  >
+                    Medium
+                  </div>
                 </div>
                 <div
                   class="total-runs cell"
@@ -894,7 +928,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-1am90bh"
+                class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
                 role="row"
               >
                 <div
@@ -970,9 +1004,26 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="confidence cell"
                   role="cell"
                 >
-                   
-                  High
-                   
+                  <div
+                    class="confidence-icon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-18c6igo-MuiSvgIcon-root"
+                      data-testid="KeyboardArrowUpIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M7.41 15.41 12 10.83l4.59 4.58L18 14l-6-6-6 6z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="confidence-text"
+                  >
+                    High
+                  </div>
                 </div>
                 <div
                   class="total-runs cell"
@@ -1098,7 +1149,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-1am90bh"
+                class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
                 role="row"
               >
                 <div
@@ -1174,8 +1225,12 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="confidence cell"
                   role="cell"
                 >
-                   
-                   
+                  <div
+                    class="confidence-icon"
+                  />
+                  <div
+                    class="confidence-text"
+                  />
                 </div>
                 <div
                   class="total-runs cell"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -1274,26 +1274,18 @@ exports[`Results Table Should match snapshot 1`] = `
                               class="confidence cell"
                               role="cell"
                             >
-                              <div
-                                class="confidence-icon"
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-vsehry-MuiSvgIcon-root"
+                                data-testid="KeyboardArrowDownIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-vsehry-MuiSvgIcon-root"
-                                  data-testid="KeyboardArrowDownIcon"
-                                  focusable="false"
-                                  viewBox="0 0 24 24"
-                                >
-                                  <path
-                                    d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
-                                  />
-                                </svg>
-                              </div>
-                              <div
-                                class="confidence-text"
-                              >
-                                Low
-                              </div>
+                                <path
+                                  d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                                />
+                              </svg>
+                              Low
                             </div>
                             <div
                               class="total-runs cell"
@@ -1505,26 +1497,18 @@ exports[`Results Table Should match snapshot 1`] = `
                               class="confidence cell"
                               role="cell"
                             >
-                              <div
-                                class="confidence-icon"
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o6fkbf-MuiSvgIcon-root"
+                                data-testid="DragHandleIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o6fkbf-MuiSvgIcon-root"
-                                  data-testid="DragHandleIcon"
-                                  focusable="false"
-                                  viewBox="0 0 24 24"
-                                >
-                                  <path
-                                    d="M20 9H4v2h16V9zM4 15h16v-2H4v2z"
-                                  />
-                                </svg>
-                              </div>
-                              <div
-                                class="confidence-text"
-                              >
-                                Medium
-                              </div>
+                                <path
+                                  d="M20 9H4v2h16V9zM4 15h16v-2H4v2z"
+                                />
+                              </svg>
+                              Medium
                             </div>
                             <div
                               class="total-runs cell"
@@ -1726,26 +1710,18 @@ exports[`Results Table Should match snapshot 1`] = `
                               class="confidence cell"
                               role="cell"
                             >
-                              <div
-                                class="confidence-icon"
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-18c6igo-MuiSvgIcon-root"
+                                data-testid="KeyboardArrowUpIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-18c6igo-MuiSvgIcon-root"
-                                  data-testid="KeyboardArrowUpIcon"
-                                  focusable="false"
-                                  viewBox="0 0 24 24"
-                                >
-                                  <path
-                                    d="M7.41 15.41 12 10.83l4.59 4.58L18 14l-6-6-6 6z"
-                                  />
-                                </svg>
-                              </div>
-                              <div
-                                class="confidence-text"
-                              >
-                                High
-                              </div>
+                                <path
+                                  d="M7.41 15.41 12 10.83l4.59 4.58L18 14l-6-6-6 6z"
+                                />
+                              </svg>
+                              High
                             </div>
                             <div
                               class="total-runs cell"
@@ -1997,14 +1973,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             <div
                               class="confidence cell"
                               role="cell"
-                            >
-                              <div
-                                class="confidence-icon"
-                              />
-                              <div
-                                class="confidence-text"
-                              />
-                            </div>
+                            />
                             <div
                               class="total-runs cell"
                               role="cell"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -1187,7 +1187,7 @@ exports[`Results Table Should match snapshot 1`] = `
                         </div>
                         <div>
                           <div
-                            class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-1am90bh"
+                            class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
                             role="row"
                           >
                             <div
@@ -1274,9 +1274,26 @@ exports[`Results Table Should match snapshot 1`] = `
                               class="confidence cell"
                               role="cell"
                             >
-                               
-                              Low
-                               
+                              <div
+                                class="confidence-icon"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-vsehry-MuiSvgIcon-root"
+                                  data-testid="KeyboardArrowDownIcon"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                                  />
+                                </svg>
+                              </div>
+                              <div
+                                class="confidence-text"
+                              >
+                                Low
+                              </div>
                             </div>
                             <div
                               class="total-runs cell"
@@ -1402,7 +1419,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </div>
                           </div>
                           <div
-                            class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-1am90bh"
+                            class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
                             role="row"
                           >
                             <div
@@ -1488,9 +1505,26 @@ exports[`Results Table Should match snapshot 1`] = `
                               class="confidence cell"
                               role="cell"
                             >
-                               
-                              Medium
-                               
+                              <div
+                                class="confidence-icon"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o6fkbf-MuiSvgIcon-root"
+                                  data-testid="DragHandleIcon"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    d="M20 9H4v2h16V9zM4 15h16v-2H4v2z"
+                                  />
+                                </svg>
+                              </div>
+                              <div
+                                class="confidence-text"
+                              >
+                                Medium
+                              </div>
                             </div>
                             <div
                               class="total-runs cell"
@@ -1616,7 +1650,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </div>
                           </div>
                           <div
-                            class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-1am90bh"
+                            class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
                             role="row"
                           >
                             <div
@@ -1692,9 +1726,26 @@ exports[`Results Table Should match snapshot 1`] = `
                               class="confidence cell"
                               role="cell"
                             >
-                               
-                              High
-                               
+                              <div
+                                class="confidence-icon"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-18c6igo-MuiSvgIcon-root"
+                                  data-testid="KeyboardArrowUpIcon"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    d="M7.41 15.41 12 10.83l4.59 4.58L18 14l-6-6-6 6z"
+                                  />
+                                </svg>
+                              </div>
+                              <div
+                                class="confidence-text"
+                              >
+                                High
+                              </div>
                             </div>
                             <div
                               class="total-runs cell"
@@ -1871,7 +1922,7 @@ exports[`Results Table Should match snapshot 1`] = `
                         </div>
                         <div>
                           <div
-                            class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-1am90bh"
+                            class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
                             role="row"
                           >
                             <div
@@ -1947,8 +1998,12 @@ exports[`Results Table Should match snapshot 1`] = `
                               class="confidence cell"
                               role="cell"
                             >
-                               
-                               
+                              <div
+                                class="confidence-icon"
+                              />
+                              <div
+                                class="confidence-text"
+                              />
                             </div>
                             <div
                               class="total-runs cell"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -1215,26 +1215,18 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="confidence cell"
                   role="cell"
                 >
-                  <div
-                    class="confidence-icon"
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-vsehry-MuiSvgIcon-root"
+                    data-testid="KeyboardArrowDownIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-vsehry-MuiSvgIcon-root"
-                      data-testid="KeyboardArrowDownIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
-                      />
-                    </svg>
-                  </div>
-                  <div
-                    class="confidence-text"
-                  >
-                    Low
-                  </div>
+                    <path
+                      d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                    />
+                  </svg>
+                  Low
                 </div>
                 <div
                   class="total-runs cell"
@@ -1446,26 +1438,18 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="confidence cell"
                   role="cell"
                 >
-                  <div
-                    class="confidence-icon"
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o6fkbf-MuiSvgIcon-root"
+                    data-testid="DragHandleIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o6fkbf-MuiSvgIcon-root"
-                      data-testid="DragHandleIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M20 9H4v2h16V9zM4 15h16v-2H4v2z"
-                      />
-                    </svg>
-                  </div>
-                  <div
-                    class="confidence-text"
-                  >
-                    Medium
-                  </div>
+                    <path
+                      d="M20 9H4v2h16V9zM4 15h16v-2H4v2z"
+                    />
+                  </svg>
+                  Medium
                 </div>
                 <div
                   class="total-runs cell"
@@ -1667,26 +1651,18 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="confidence cell"
                   role="cell"
                 >
-                  <div
-                    class="confidence-icon"
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-18c6igo-MuiSvgIcon-root"
+                    data-testid="KeyboardArrowUpIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-18c6igo-MuiSvgIcon-root"
-                      data-testid="KeyboardArrowUpIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M7.41 15.41 12 10.83l4.59 4.58L18 14l-6-6-6 6z"
-                      />
-                    </svg>
-                  </div>
-                  <div
-                    class="confidence-text"
-                  >
-                    High
-                  </div>
+                    <path
+                      d="M7.41 15.41 12 10.83l4.59 4.58L18 14l-6-6-6 6z"
+                    />
+                  </svg>
+                  High
                 </div>
                 <div
                   class="total-runs cell"
@@ -1887,14 +1863,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 <div
                   class="confidence cell"
                   role="cell"
-                >
-                  <div
-                    class="confidence-icon"
-                  />
-                  <div
-                    class="confidence-text"
-                  />
-                </div>
+                />
                 <div
                   class="total-runs cell"
                   role="cell"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -1128,7 +1128,7 @@ exports[`Results View The table should match snapshot and other elements should 
             </div>
             <div>
               <div
-                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-1am90bh"
+                class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
                 role="row"
               >
                 <div
@@ -1215,9 +1215,26 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="confidence cell"
                   role="cell"
                 >
-                   
-                  Low
-                   
+                  <div
+                    class="confidence-icon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-vsehry-MuiSvgIcon-root"
+                      data-testid="KeyboardArrowDownIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="confidence-text"
+                  >
+                    Low
+                  </div>
                 </div>
                 <div
                   class="total-runs cell"
@@ -1343,7 +1360,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-1am90bh"
+                class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
                 role="row"
               >
                 <div
@@ -1429,9 +1446,26 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="confidence cell"
                   role="cell"
                 >
-                   
-                  Medium
-                   
+                  <div
+                    class="confidence-icon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-o6fkbf-MuiSvgIcon-root"
+                      data-testid="DragHandleIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M20 9H4v2h16V9zM4 15h16v-2H4v2z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="confidence-text"
+                  >
+                    Medium
+                  </div>
                 </div>
                 <div
                   class="total-runs cell"
@@ -1557,7 +1591,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-1am90bh"
+                class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
                 role="row"
               >
                 <div
@@ -1633,9 +1667,26 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="confidence cell"
                   role="cell"
                 >
-                   
-                  High
-                   
+                  <div
+                    class="confidence-icon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-18c6igo-MuiSvgIcon-root"
+                      data-testid="KeyboardArrowUpIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M7.41 15.41 12 10.83l4.59 4.58L18 14l-6-6-6 6z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="confidence-text"
+                  >
+                    High
+                  </div>
                 </div>
                 <div
                   class="total-runs cell"
@@ -1761,7 +1812,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1b00bec fp4ugv1 MuiBox-root css-1am90bh"
+                class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
                 role="row"
               >
                 <div
@@ -1837,8 +1888,12 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="confidence cell"
                   role="cell"
                 >
-                   
-                   
+                  <div
+                    class="confidence-icon"
+                  />
+                  <div
+                    class="confidence-text"
+                  />
                 </div>
                 <div
                   class="total-runs cell"

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -1,8 +1,11 @@
 import { useState, type ReactNode } from 'react';
 
 import AppleIcon from '@mui/icons-material/Apple';
+import DragHandleIcon from '@mui/icons-material/DragHandle';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import ThumbDownIcon from '@mui/icons-material/ThumbDown';
 import ThumbUpIcon from '@mui/icons-material/ThumbUp';
 import TimelineIcon from '@mui/icons-material/Timeline';
@@ -51,6 +54,8 @@ const stylesLight = {
       },
       '.confidence': {
         backgroundColor: Colors.Background200,
+        justifyContent: 'initial',
+        paddingLeft: '36px'
       },
       '.comparison-sign': {
         backgroundColor: Colors.Background200,
@@ -256,6 +261,12 @@ const platformIcons: Record<PlatformShortName, ReactNode> = {
   Unspecified: '',
 };
 
+const confidenceIcons = {
+  Low: <KeyboardArrowDownIcon />,
+  Medium: <DragHandleIcon />,
+  High: <KeyboardArrowUpIcon />,
+};
+
 const getSubtestsCompareWithBaseLink = (result: CompareResultsItem) => {
   const params = new URLSearchParams({
     baseRev: result.base_rev,
@@ -381,6 +392,7 @@ function RevisionRow(props: RevisionRowProps) {
         </div>
         <div className='confidence cell' role='cell'>
           {' '}
+          {confidenceText && confidenceIcons[confidenceText]}
           {confidenceText}{' '}
         </div>
         <div className='total-runs cell' role='cell'>

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -265,10 +265,10 @@ const platformIcons: Record<PlatformShortName, ReactNode> = {
   Unspecified: '',
 };
 
-const confidenceIcons = {
-  Low: <KeyboardArrowDownIcon sx={{ color: '#D7264C' }} />,
-  Medium: <DragHandleIcon sx={{ color: '#5B5B66' }} />,
-  High: <KeyboardArrowUpIcon sx={{ color: '#017A40' }} />,
+const confidenceIcon = {
+  Low: <KeyboardArrowDownIcon sx={{ color: 'icons.error' }} />,
+  Medium: <DragHandleIcon sx={{ color: 'text.secondary' }} />,
+  High: <KeyboardArrowUpIcon sx={{ color: 'icons.success' }} />,
 };
 
 const getSubtestsCompareWithBaseLink = (result: CompareResultsItem) => {
@@ -395,7 +395,7 @@ function RevisionRow(props: RevisionRowProps) {
           {deltaPercent} %{' '}
         </div>
         <div className='confidence cell' role='cell'>
-          {confidenceText && confidenceIcons[confidenceText]}
+          {confidenceText && confidenceIcon[confidenceText]}
           {confidenceText}
         </div>
         <div className='total-runs cell' role='cell'>

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -55,7 +55,7 @@ const stylesLight = {
       '.confidence': {
         backgroundColor: Colors.Background200,
         justifyContent: 'initial',
-        paddingLeft: '36px'
+        paddingLeft: '36px',
       },
       '.comparison-sign': {
         backgroundColor: Colors.Background200,
@@ -262,9 +262,9 @@ const platformIcons: Record<PlatformShortName, ReactNode> = {
 };
 
 const confidenceIcons = {
-  Low: <KeyboardArrowDownIcon />,
-  Medium: <DragHandleIcon />,
-  High: <KeyboardArrowUpIcon />,
+  Low: <KeyboardArrowDownIcon sx={{ color: '#D7264C' }} />,
+  Medium: <DragHandleIcon sx={{ color: '#5B5B66' }} />,
+  High: <KeyboardArrowUpIcon sx={{ color: '#017A40' }} />,
 };
 
 const getSubtestsCompareWithBaseLink = (result: CompareResultsItem) => {

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -395,10 +395,8 @@ function RevisionRow(props: RevisionRowProps) {
           {deltaPercent} %{' '}
         </div>
         <div className='confidence cell' role='cell'>
-          <div className='confidence-icon'>
-            {confidenceText && confidenceIcons[confidenceText]}
-          </div>
-          <div className='confidence-text'>{confidenceText}</div>
+          {confidenceText && confidenceIcons[confidenceText]}
+          {confidenceText}
         </div>
         <div className='total-runs cell' role='cell'>
           <span>

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -265,7 +265,7 @@ const platformIcons: Record<PlatformShortName, ReactNode> = {
   Unspecified: '',
 };
 
-const confidenceIcon = {
+const confidenceIcons = {
   Low: <KeyboardArrowDownIcon sx={{ color: 'icons.error' }} />,
   Medium: <DragHandleIcon sx={{ color: 'text.secondary' }} />,
   High: <KeyboardArrowUpIcon sx={{ color: 'icons.success' }} />,
@@ -395,7 +395,7 @@ function RevisionRow(props: RevisionRowProps) {
           {deltaPercent} %{' '}
         </div>
         <div className='confidence cell' role='cell'>
-          {confidenceText && confidenceIcon[confidenceText]}
+          {confidenceText && confidenceIcons[confidenceText]}
           {confidenceText}
         </div>
         <div className='total-runs cell' role='cell'>

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -54,8 +54,9 @@ const stylesLight = {
       },
       '.confidence': {
         backgroundColor: Colors.Background200,
-        justifyContent: 'initial',
-        paddingLeft: '36px',
+        gap: '10px',
+        justifyContent: 'start',
+        paddingInlineStart: '15%',
       },
       '.comparison-sign': {
         backgroundColor: Colors.Background200,
@@ -151,6 +152,9 @@ const stylesDark = {
       },
       '.confidence': {
         backgroundColor: Colors.Background200Dark,
+        gap: '10px',
+        justifyContent: 'start',
+        paddingInlineStart: '15%',
       },
       '.comparison-sign': {
         backgroundColor: Colors.Background200Dark,
@@ -391,9 +395,10 @@ function RevisionRow(props: RevisionRowProps) {
           {deltaPercent} %{' '}
         </div>
         <div className='confidence cell' role='cell'>
-          {' '}
-          {confidenceText && confidenceIcons[confidenceText]}
-          {confidenceText}{' '}
+          <div className='confidence-icon'>
+            {confidenceText && confidenceIcons[confidenceText]}
+          </div>
+          <div className='confidence-text'>{confidenceText}</div>
         </div>
         <div className='total-runs cell' role='cell'>
           <span>

--- a/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
@@ -222,10 +222,8 @@ function SubtestsRevisionRow(props: RevisionRowProps) {
           {deltaPercent} %{' '}
         </div>
         <div className='confidence cell' role='cell'>
-          <div className='confidence-icon'>
-            {confidenceText && confidenceIcons[confidenceText]}
-          </div>
-          <div className='confidence-text'>{confidenceText}</div>
+          {confidenceText && confidenceIcons[confidenceText]}
+          {confidenceText}
         </div>
         <div className='total-runs cell' role='cell'>
           <span>

--- a/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
@@ -1,7 +1,10 @@
 import { useState } from 'react';
 
+import DragHandleIcon from '@mui/icons-material/DragHandle';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import ThumbDownIcon from '@mui/icons-material/ThumbDown';
 import ThumbUpIcon from '@mui/icons-material/ThumbUp';
 import TimelineIcon from '@mui/icons-material/Timeline';
@@ -47,6 +50,9 @@ function getStyles(themeMode: string) {
         },
         '.confidence': {
           backgroundColor: mainBackgroundColor,
+          gap: '10px',
+          justifyContent: 'start',
+          paddingInlineStart: '15%',
         },
         '.comparison-sign': {
           backgroundColor: mainBackgroundColor,
@@ -129,6 +135,12 @@ const styles = {
 
 const stylesCard = ExpandableRowStyles();
 
+const confidenceIcons = {
+  Low: <KeyboardArrowDownIcon sx={{ color: '#D7264C' }} />,
+  Medium: <DragHandleIcon sx={{ color: '#5B5B66' }} />,
+  High: <KeyboardArrowUpIcon sx={{ color: '#017A40' }} />,
+};
+
 function determineStatus(improvement: boolean, regression: boolean) {
   if (improvement) return 'Improvement';
   if (regression) return 'Regression';
@@ -210,8 +222,10 @@ function SubtestsRevisionRow(props: RevisionRowProps) {
           {deltaPercent} %{' '}
         </div>
         <div className='confidence cell' role='cell'>
-          {' '}
-          {confidenceText}{' '}
+          <div className='confidence-icon'>
+            {confidenceText && confidenceIcons[confidenceText]}
+          </div>
+          <div className='confidence-text'>{confidenceText}</div>
         </div>
         <div className='total-runs cell' role='cell'>
           <span>

--- a/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
@@ -136,9 +136,9 @@ const styles = {
 const stylesCard = ExpandableRowStyles();
 
 const confidenceIcons = {
-  Low: <KeyboardArrowDownIcon sx={{ color: '#D7264C' }} />,
-  Medium: <DragHandleIcon sx={{ color: '#5B5B66' }} />,
-  High: <KeyboardArrowUpIcon sx={{ color: '#017A40' }} />,
+  Low: <KeyboardArrowDownIcon sx={{ color: 'icons.error' }} />,
+  Medium: <DragHandleIcon sx={{ color: 'text.secondary' }} />,
+  High: <KeyboardArrowUpIcon sx={{ color: 'icons.success' }} />,
 };
 
 function determineStatus(improvement: boolean, regression: boolean) {

--- a/src/styles/Colors.ts
+++ b/src/styles/Colors.ts
@@ -78,9 +78,13 @@ export enum Colors {
   //icon light
   IconLight = '#5B5B66',
   IconLightSecondary = '#FBFBFE',
+  IconLightSuccess = '#017A40',
+  IconLightError = '#D7264C',
 
   //icon dark
   IconDark = '#FBFBFE',
+  IconDarkSuccess = '#4DBC87',
+  IconDarkError = '#F37F98',
 }
 
 export const background = (mode: string) => {

--- a/src/theme/protocolTheme.ts
+++ b/src/theme/protocolTheme.ts
@@ -23,6 +23,10 @@ const lightMode = {
     secondary: Colors.SecondaryText,
     disabled: Colors.TextDisabled,
   },
+  icons: {
+    success: Colors.IconLightSuccess,
+    error: Colors.IconLightError,
+  },
 };
 
 const darkMode = {
@@ -40,6 +44,10 @@ const darkMode = {
     primary: Colors.PrimaryTextDark,
     secondary: Colors.SecondaryTextDark,
     disabled: Colors.TextDisabledDark,
+  },
+  icons: {
+    success: Colors.IconDarkSuccess,
+    error: Colors.IconDarkError,
   },
 };
 


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/PCF-425)
This PR adds colorful icons to confidence column (Low, Medium, High).

[deploy link with the example](https://deploy-preview-764--mozilla-perfcompare.netlify.app/compare-over-time-results?baseRepo=mozilla-central&selectedTimeRange=1209600&newRev=9b3deb938fdd67b35a981cf1613a817dfb7eb65f&newRepo=mozilla-central&framework=1)

<img width="1272" alt="Screenshot 2024-10-08 at 4 52 33 PM" src="https://github.com/user-attachments/assets/6e84d671-dfdc-4826-85f1-ada4a64f9a3a">
