### PR TITLE
feat: added standard deviation columns to results table

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -249,7 +249,7 @@ exports[`Results View The table should match snapshot and other elements should 
       </div>
     </div>
     <div
-      class="f1wqnr25 fr2n4tx"
+      class="fqnq6uq fr2n4tx"
       data-testid="table-header"
       role="row"
     >
@@ -299,6 +299,22 @@ exports[`Results View The table should match snapshot and other elements should 
         role="columnheader"
       >
         New
+      </div>
+      <div
+        class="cell baseStandardDeviation-header"
+        role="columnheader"
+      >
+        Base Standard Deviation
+      </div>
+      <div
+        class="cell comparisonSignStandardDeviation-header"
+        role="columnheader"
+      />
+      <div
+        class="cell newStandardDeviation-header"
+        role="columnheader"
+      >
+        New Standard Deviation
       </div>
       <div
         class="cell status-header"
@@ -465,7 +481,7 @@ exports[`Results View The table should match snapshot and other elements should 
             </div>
             <div>
               <div
-                class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+                class="revisionRow f1o1ur8i fp4ugv1 MuiBox-root css-p80lp4"
                 role="row"
               >
                 <div
@@ -517,6 +533,26 @@ exports[`Results View The table should match snapshot and other elements should 
                   712.44
                    
                   ms
+                </div>
+                <div
+                  class="base-standard-deviation-value cell"
+                  role="cell"
+                >
+                   
+                  0
+                   
+                </div>
+                <div
+                  class="comparison-sign-standard-deviation cell"
+                  role="cell"
+                />
+                <div
+                  class="new-standard-deviation-value cell"
+                  role="cell"
+                >
+                   
+                  0
+                   
                 </div>
                 <div
                   class="status cell"
@@ -689,7 +725,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+                class="revisionRow f1o1ur8i fp4ugv1 MuiBox-root css-p80lp4"
                 role="row"
               >
                 <div
@@ -740,6 +776,26 @@ exports[`Results View The table should match snapshot and other elements should 
                   791.34
                    
                   ms
+                </div>
+                <div
+                  class="base-standard-deviation-value cell"
+                  role="cell"
+                >
+                   
+                  0
+                   
+                </div>
+                <div
+                  class="comparison-sign-standard-deviation cell"
+                  role="cell"
+                />
+                <div
+                  class="new-standard-deviation-value cell"
+                  role="cell"
+                >
+                   
+                  0
+                   
                 </div>
                 <div
                   class="status cell"
@@ -912,7 +968,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+                class="revisionRow f1o1ur8i fp4ugv1 MuiBox-root css-p80lp4"
                 role="row"
               >
                 <div
@@ -964,6 +1020,26 @@ exports[`Results View The table should match snapshot and other elements should 
                   628.09
                    
                   ms
+                </div>
+                <div
+                  class="base-standard-deviation-value cell"
+                  role="cell"
+                >
+                   
+                  0
+                   
+                </div>
+                <div
+                  class="comparison-sign-standard-deviation cell"
+                  role="cell"
+                />
+                <div
+                  class="new-standard-deviation-value cell"
+                  role="cell"
+                >
+                   
+                  0
+                   
                 </div>
                 <div
                   class="status cell"
@@ -1125,7 +1201,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+                class="revisionRow f1o1ur8i fp4ugv1 MuiBox-root css-p80lp4"
                 role="row"
               >
                 <div
@@ -1177,6 +1253,26 @@ exports[`Results View The table should match snapshot and other elements should 
                   628.09
                    
                   ms
+                </div>
+                <div
+                  class="base-standard-deviation-value cell"
+                  role="cell"
+                >
+                   
+                  0
+                   
+                </div>
+                <div
+                  class="comparison-sign-standard-deviation cell"
+                  role="cell"
+                />
+                <div
+                  class="new-standard-deviation-value cell"
+                  role="cell"
+                >
+                   
+                  0
+                   
                 </div>
                 <div
                   class="status cell"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -971,7 +971,7 @@ exports[`Results Table Should match snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="f1wqnr25 fr2n4tx"
+                  class="fqnq6uq fr2n4tx"
                   data-testid="table-header"
                   role="row"
                 >
@@ -1021,6 +1021,22 @@ exports[`Results Table Should match snapshot 1`] = `
                     role="columnheader"
                   >
                     New
+                  </div>
+                  <div
+                    class="cell baseStandardDeviation-header"
+                    role="columnheader"
+                  >
+                    Base Standard Deviation
+                  </div>
+                  <div
+                    class="cell comparisonSignStandardDeviation-header"
+                    role="columnheader"
+                  />
+                  <div
+                    class="cell newStandardDeviation-header"
+                    role="columnheader"
+                  >
+                    New Standard Deviation
                   </div>
                   <div
                     class="cell status-header"
@@ -1187,7 +1203,7 @@ exports[`Results Table Should match snapshot 1`] = `
                         </div>
                         <div>
                           <div
-                            class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+                            class="revisionRow f1o1ur8i fp4ugv1 MuiBox-root css-p80lp4"
                             role="row"
                           >
                             <div
@@ -1239,6 +1255,26 @@ exports[`Results Table Should match snapshot 1`] = `
                               712.44
                                
                               ms
+                            </div>
+                            <div
+                              class="base-standard-deviation-value cell"
+                              role="cell"
+                            >
+                               
+                              0
+                               
+                            </div>
+                            <div
+                              class="comparison-sign-standard-deviation cell"
+                              role="cell"
+                            />
+                            <div
+                              class="new-standard-deviation-value cell"
+                              role="cell"
+                            >
+                               
+                              0
+                               
                             </div>
                             <div
                               class="status cell"
@@ -1411,7 +1447,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </div>
                           </div>
                           <div
-                            class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+                            class="revisionRow f1o1ur8i fp4ugv1 MuiBox-root css-p80lp4"
                             role="row"
                           >
                             <div
@@ -1462,6 +1498,26 @@ exports[`Results Table Should match snapshot 1`] = `
                               791.34
                                
                               ms
+                            </div>
+                            <div
+                              class="base-standard-deviation-value cell"
+                              role="cell"
+                            >
+                               
+                              0
+                               
+                            </div>
+                            <div
+                              class="comparison-sign-standard-deviation cell"
+                              role="cell"
+                            />
+                            <div
+                              class="new-standard-deviation-value cell"
+                              role="cell"
+                            >
+                               
+                              0
+                               
                             </div>
                             <div
                               class="status cell"
@@ -1634,7 +1690,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </div>
                           </div>
                           <div
-                            class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+                            class="revisionRow f1o1ur8i fp4ugv1 MuiBox-root css-p80lp4"
                             role="row"
                           >
                             <div
@@ -1686,6 +1742,26 @@ exports[`Results Table Should match snapshot 1`] = `
                               628.09
                                
                               ms
+                            </div>
+                            <div
+                              class="base-standard-deviation-value cell"
+                              role="cell"
+                            >
+                               
+                              0
+                               
+                            </div>
+                            <div
+                              class="comparison-sign-standard-deviation cell"
+                              role="cell"
+                            />
+                            <div
+                              class="new-standard-deviation-value cell"
+                              role="cell"
+                            >
+                               
+                              0
+                               
                             </div>
                             <div
                               class="status cell"
@@ -1898,7 +1974,7 @@ exports[`Results Table Should match snapshot 1`] = `
                         </div>
                         <div>
                           <div
-                            class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+                            class="revisionRow f1o1ur8i fp4ugv1 MuiBox-root css-p80lp4"
                             role="row"
                           >
                             <div
@@ -1950,6 +2026,26 @@ exports[`Results Table Should match snapshot 1`] = `
                               628.09
                                
                               ms
+                            </div>
+                            <div
+                              class="base-standard-deviation-value cell"
+                              role="cell"
+                            >
+                               
+                              0
+                               
+                            </div>
+                            <div
+                              class="comparison-sign-standard-deviation cell"
+                              role="cell"
+                            />
+                            <div
+                              class="new-standard-deviation-value cell"
+                              role="cell"
+                            >
+                               
+                              0
+                               
                             </div>
                             <div
                               class="status cell"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -912,7 +912,7 @@ exports[`Results View The table should match snapshot and other elements should 
       </div>
     </div>
     <div
-      class="f1wqnr25 fr2n4tx"
+      class="fqnq6uq fr2n4tx"
       data-testid="table-header"
       role="row"
     >
@@ -962,6 +962,22 @@ exports[`Results View The table should match snapshot and other elements should 
         role="columnheader"
       >
         New
+      </div>
+      <div
+        class="cell baseStandardDeviation-header"
+        role="columnheader"
+      >
+        Base Standard Deviation
+      </div>
+      <div
+        class="cell comparisonSignStandardDeviation-header"
+        role="columnheader"
+      />
+      <div
+        class="cell newStandardDeviation-header"
+        role="columnheader"
+      >
+        New Standard Deviation
       </div>
       <div
         class="cell status-header"
@@ -1128,7 +1144,7 @@ exports[`Results View The table should match snapshot and other elements should 
             </div>
             <div>
               <div
-                class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+                class="revisionRow f1o1ur8i fp4ugv1 MuiBox-root css-p80lp4"
                 role="row"
               >
                 <div
@@ -1180,6 +1196,26 @@ exports[`Results View The table should match snapshot and other elements should 
                   712.44
                    
                   ms
+                </div>
+                <div
+                  class="base-standard-deviation-value cell"
+                  role="cell"
+                >
+                   
+                  0
+                   
+                </div>
+                <div
+                  class="comparison-sign-standard-deviation cell"
+                  role="cell"
+                />
+                <div
+                  class="new-standard-deviation-value cell"
+                  role="cell"
+                >
+                   
+                  0
+                   
                 </div>
                 <div
                   class="status cell"
@@ -1352,7 +1388,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+                class="revisionRow f1o1ur8i fp4ugv1 MuiBox-root css-p80lp4"
                 role="row"
               >
                 <div
@@ -1403,6 +1439,26 @@ exports[`Results View The table should match snapshot and other elements should 
                   791.34
                    
                   ms
+                </div>
+                <div
+                  class="base-standard-deviation-value cell"
+                  role="cell"
+                >
+                   
+                  0
+                   
+                </div>
+                <div
+                  class="comparison-sign-standard-deviation cell"
+                  role="cell"
+                />
+                <div
+                  class="new-standard-deviation-value cell"
+                  role="cell"
+                >
+                   
+                  0
+                   
                 </div>
                 <div
                   class="status cell"
@@ -1575,7 +1631,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+                class="revisionRow f1o1ur8i fp4ugv1 MuiBox-root css-p80lp4"
                 role="row"
               >
                 <div
@@ -1627,6 +1683,26 @@ exports[`Results View The table should match snapshot and other elements should 
                   628.09
                    
                   ms
+                </div>
+                <div
+                  class="base-standard-deviation-value cell"
+                  role="cell"
+                >
+                   
+                  0
+                   
+                </div>
+                <div
+                  class="comparison-sign-standard-deviation cell"
+                  role="cell"
+                />
+                <div
+                  class="new-standard-deviation-value cell"
+                  role="cell"
+                >
+                   
+                  0
+                   
                 </div>
                 <div
                   class="status cell"
@@ -1788,7 +1864,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+                class="revisionRow f1o1ur8i fp4ugv1 MuiBox-root css-p80lp4"
                 role="row"
               >
                 <div
@@ -1840,6 +1916,26 @@ exports[`Results View The table should match snapshot and other elements should 
                   628.09
                    
                   ms
+                </div>
+                <div
+                  class="base-standard-deviation-value cell"
+                  role="cell"
+                >
+                   
+                  0
+                   
+                </div>
+                <div
+                  class="comparison-sign-standard-deviation cell"
+                  role="cell"
+                />
+                <div
+                  class="new-standard-deviation-value cell"
+                  role="cell"
+                >
+                   
+                  0
+                   
                 </div>
                 <div
                   class="status cell"

--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -36,13 +36,25 @@ const cellsConfiguration: CompareResultsTableConfig[] = [
   },
   {
     key: 'comparisonSign',
-
     gridWidth: '0.2fr',
   },
   {
     name: 'New',
     key: 'new',
-
+    gridWidth: '1fr',
+  },
+  {
+    name: 'Base Standard Deviation',
+    key: 'baseStandardDeviation',
+    gridWidth: '1fr',
+  },
+  {
+    key: 'comparisonSignStandardDeviation',
+    gridWidth: '0.2fr',
+  },
+  {
+    name: 'New Standard Deviation',
+    key: 'newStandardDeviation',
     gridWidth: '1fr',
   },
   {

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -18,6 +18,7 @@ import { useAppSelector } from '../../hooks/app';
 import { Strings } from '../../resources/Strings';
 import { Colors, Spacing, ExpandableRowStyles } from '../../styles';
 import type { CompareResultsItem, PlatformShortName } from '../../types/state';
+import { determineStandardDeviationSign } from '../../utils/helpers';
 import { getPlatformShortName } from '../../utils/platform';
 import AndroidIcon from '../Shared/Icons/AndroidIcon';
 import LinuxIcon from '../Shared/Icons/LinuxIcon';
@@ -47,6 +48,9 @@ const stylesLight = {
       '.base-value': {
         backgroundColor: Colors.Background200,
       },
+      '.base-standard-deviation-value': {
+        backgroundColor: Colors.Background200,
+      },
       '.cell': {
         display: 'flex',
         alignItems: 'center',
@@ -61,6 +65,9 @@ const stylesLight = {
       '.comparison-sign': {
         backgroundColor: Colors.Background200,
       },
+      '.comparison-sign-standard-deviation': {
+        backgroundColor: Colors.Background200,
+      },
       '.delta': {
         backgroundColor: Colors.Background200,
       },
@@ -68,6 +75,9 @@ const stylesLight = {
         justifyContent: 'right',
       },
       '.new-value': {
+        backgroundColor: Colors.Background200,
+      },
+      '.new-standard-deviation-value': {
         backgroundColor: Colors.Background200,
       },
       '.platform': {
@@ -145,6 +155,9 @@ const stylesDark = {
       '.base-value': {
         backgroundColor: Colors.Background200Dark,
       },
+      '.base-standard-deviation-value': {
+        backgroundColor: Colors.Background200Dark,
+      },
       '.cell': {
         display: 'flex',
         alignItems: 'center',
@@ -159,6 +172,9 @@ const stylesDark = {
       '.comparison-sign': {
         backgroundColor: Colors.Background200Dark,
       },
+      '.comparison-sign-standard-deviation': {
+        backgroundColor: Colors.Background200Dark,
+      },
       '.delta': {
         backgroundColor: Colors.Background200Dark,
       },
@@ -166,6 +182,9 @@ const stylesDark = {
         justifyContent: 'right',
       },
       '.new-value': {
+        backgroundColor: Colors.Background200Dark,
+      },
+      '.new-standard-deviation-value': {
         backgroundColor: Colors.Background200Dark,
       },
       '.platform': {
@@ -331,6 +350,8 @@ function RevisionRow(props: RevisionRowProps) {
     base_runs: baseRuns,
     new_runs: newRuns,
     graphs_link: graphLink,
+    base_stddev: baseStandardDeviation,
+    new_stddev: newStandardDeviation,
   } = result;
 
   const platformShortName = getPlatformShortName(platform);
@@ -377,6 +398,20 @@ function RevisionRow(props: RevisionRowProps) {
         <div className='new-value cell' role='cell'>
           {' '}
           {newMedianValue} {newUnit}
+        </div>
+        <div className='base-standard-deviation-value cell' role='cell'>
+          {' '}
+          {baseStandardDeviation}{' '}
+        </div>
+        <div className='comparison-sign-standard-deviation cell' role='cell'>
+          {determineStandardDeviationSign(
+            baseStandardDeviation,
+            newStandardDeviation,
+          )}
+        </div>
+        <div className='new-standard-deviation-value cell' role='cell'>
+          {' '}
+          {newStandardDeviation}{' '}
         </div>
         <div className='status cell' role='cell'>
           <span

--- a/src/components/CompareResults/SubtestsResults/SubtestsResultsTable.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsResultsTable.tsx
@@ -65,6 +65,21 @@ const cellsConfiguration: CompareResultsTableConfig[] = [
     gridWidth: '1fr',
   },
   {
+    name: 'Base Standard Deviation',
+    key: 'baseStandardDeviation',
+    gridWidth: '1fr',
+  },
+  {
+    key: 'comparisonSignStandardDeviation',
+    gridWidth: '0.2fr',
+  },
+  {
+    name: 'New Standard Deviation',
+    key: 'newStandardDeviation',
+
+    gridWidth: '1fr',
+  },
+  {
     name: 'Status',
     disable: true,
     filter: true,

--- a/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
@@ -15,6 +15,7 @@ import { useAppSelector } from '../../../hooks/app';
 import { Strings } from '../../../resources/Strings';
 import { Colors, Spacing, ExpandableRowStyles } from '../../../styles';
 import type { CompareResultsItem } from '../../../types/state';
+import { determineStandardDeviationSign } from '../../../utils/helpers';
 import RevisionRowExpandable from '.././RevisionRowExpandable';
 
 const revisionsRow = {
@@ -43,6 +44,9 @@ function getStyles(themeMode: string) {
         '.base-value': {
           backgroundColor: mainBackgroundColor,
         },
+        '.base-standard-deviation-value': {
+          backgroundColor: mainBackgroundColor,
+        },
         '.cell': {
           display: 'flex',
           alignItems: 'center',
@@ -57,6 +61,9 @@ function getStyles(themeMode: string) {
         '.comparison-sign': {
           backgroundColor: mainBackgroundColor,
         },
+        '.comparison-sign-standard-deviation': {
+          backgroundColor: mainBackgroundColor,
+        },
         '.delta': {
           backgroundColor: mainBackgroundColor,
         },
@@ -64,6 +71,9 @@ function getStyles(themeMode: string) {
           justifyContent: 'right',
         },
         '.new-value': {
+          backgroundColor: mainBackgroundColor,
+        },
+        '.new-standard-deviation-value': {
           backgroundColor: mainBackgroundColor,
         },
         '.subtests': {
@@ -174,6 +184,8 @@ function SubtestsRevisionRow(props: RevisionRowProps) {
     base_runs: baseRuns,
     new_runs: newRuns,
     graphs_link: graphLink,
+    base_stddev: baseStandardDeviation,
+    new_stddev: newStandardDeviation,
   } = result;
 
   const [expanded, setExpanded] = useState(false);
@@ -204,6 +216,20 @@ function SubtestsRevisionRow(props: RevisionRowProps) {
         <div className='new-value cell' role='cell'>
           {' '}
           {newMedianValue} {newUnit}
+        </div>
+        <div className='base-standard-deviation-value cell' role='cell'>
+          {' '}
+          {baseStandardDeviation}{' '}
+        </div>
+        <div className='comparison-sign-standard-deviation cell' role='cell'>
+          {determineStandardDeviationSign(
+            baseStandardDeviation,
+            newStandardDeviation,
+          )}
+        </div>
+        <div className='new-standard-deviation-value cell' role='cell'>
+          {' '}
+          {newStandardDeviation}{' '}
         </div>
         <div className='status cell' role='cell'>
           <span

--- a/src/components/CompareResults/TableHeader.tsx
+++ b/src/components/CompareResults/TableHeader.tsx
@@ -125,6 +125,7 @@ function TableHeader({
       borderRadius: '4px',
       padding: Spacing.Small,
       marginTop: Spacing.Medium,
+      textAlign: 'center',
       $nest: {
         '.cell': {
           borderBottom: 'none',

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -116,6 +116,15 @@ const swapArrayElements = <T>(
   return array;
 };
 
+const determineStandardDeviationSign = (
+  baseStandardDeviation: number,
+  newStandardDeviation: number,
+) => {
+  if (baseStandardDeviation > newStandardDeviation) return '>';
+  if (baseStandardDeviation < newStandardDeviation) return '<';
+  return '';
+};
+
 export {
   formatDate,
   getLatestCommitMessage,
@@ -124,4 +133,5 @@ export {
   swapArrayElements,
   truncateHash,
   getDocsURL,
+  determineStandardDeviationSign,
 };


### PR DESCRIPTION
Features: #771  
### Overview
This commit introduces new columns to the results table to display the standard deviations for both the base and new datasets. These additions enhance the table's ability to provide statistical insights for performance comparisons.

### Changes Made
- **ResultsTable.tsx**:
  - Added new columns for Base Standard Deviation (`basestandarddeviation`) and New Standard Deviation (`newstandarddeviation`). 
 Light Mode - 
![ Light Mode ](https://github.com/user-attachments/assets/3bc5de10-549e-4ee6-b504-5a343b5b9d57)

Dark Mode -
![Dark Mode ](https://github.com/user-attachments/assets/decc316a-cd15-4690-94c9-63dd2508a38b)


  - Updated the grid configuration to accommodate the new columns.

- **RevisionRow.tsx**:
  - Implemented styles for the new standard deviation values to maintain a consistent look with existing values.
  - Added logic to determine the comparison sign between base and new standard deviations.

- **SubtestsRevisionRow.tsx**:
  - Extended functionality to include standard deviation comparisons for subtest results.

### Impact
- The results table will now display both median values and their corresponding standard deviations, allowing for a better understanding of variability in performance results.

### Testing
- Manual testing was performed to ensure the new columns display correctly and integrate seamlessly with existing functionalities.

closes #771 