### PR TITLE
Persist Column Filters in URL (#765)

### DIFF
--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -124,32 +124,27 @@ export default function ResultsTable() {
   }, [rawSearchParams]);
 
   const onClearFilter = (columnId: string) => {
+    rawSearchParams.delete(`filter_${columnId}`);
+    updateRawSearchParams(rawSearchParams);
+
     setTableFilters((oldFilters) => {
       const newFilters = new Map(oldFilters);
       newFilters.delete(columnId);
-
-      rawSearchParams.delete(`filter_${columnId}`);
-      updateRawSearchParams(rawSearchParams);
-
       return newFilters;
     });
   };
 
   const onToggleFilter = (columnId: string, filters: Set<string>) => {
+    if (filters.size > 0) {
+      rawSearchParams.set(`filter_${columnId}`, Array.from(filters).join(','));
+    } else {
+      rawSearchParams.delete(`filter_${columnId}`);
+    }
+    updateRawSearchParams(rawSearchParams);
+
     setTableFilters((oldFilters) => {
       const newFilters = new Map(oldFilters);
       newFilters.set(columnId, filters);
-
-      if (filters.size > 0) {
-        rawSearchParams.set(
-          `filter_${columnId}`,
-          Array.from(filters).join(','),
-        );
-      } else {
-        rawSearchParams.delete(`filter_${columnId}`);
-      }
-      updateRawSearchParams(rawSearchParams);
-
       return newFilters;
     });
   };

--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -110,46 +110,41 @@ export default function ResultsTable() {
   useEffect(() => {
     const filters = Array.from(rawSearchParams.entries())
       .filter(([key]) => key.startsWith('filter'))
-      .reduce((acc: Map<string, Set<string>>, [key, value]) => {
+      .reduce((accumulator: Map<string, Set<string>>, [key, value]) => {
         const columnId = key.split('_')[1];
-        if (!acc.has(columnId)) {
-          acc.set(columnId, new Set());
+        if (!accumulator.has(columnId)) {
+          accumulator.set(columnId, new Set());
         }
         const valuesArray = value.split(',').map((item) => item.trim());
-        valuesArray.forEach((item) => acc.get(columnId)?.add(item));
-        return acc;
+        valuesArray.forEach((item) => accumulator.get(columnId)?.add(item));
+        return accumulator;
       }, new Map<string, Set<string>>());
 
     setTableFilters(filters);
   }, [rawSearchParams]);
 
   const onClearFilter = (columnId: string) => {
+    rawSearchParams.delete(`filter_${columnId}`);
+    updateRawSearchParams(rawSearchParams);
+
     setTableFilters((oldFilters) => {
       const newFilters = new Map(oldFilters);
       newFilters.delete(columnId);
-
-      rawSearchParams.delete(`filter_${columnId}`);
-      updateRawSearchParams(rawSearchParams);
-
       return newFilters;
     });
   };
 
   const onToggleFilter = (columnId: string, filters: Set<string>) => {
+    if (filters.size > 0) {
+      rawSearchParams.set(`filter_${columnId}`, Array.from(filters).join(','));
+    } else {
+      rawSearchParams.delete(`filter_${columnId}`);
+    }
+
+    updateRawSearchParams(rawSearchParams);
     setTableFilters((oldFilters) => {
       const newFilters = new Map(oldFilters);
       newFilters.set(columnId, filters);
-
-      if (filters.size > 0) {
-        rawSearchParams.set(
-          `filter_${columnId}`,
-          Array.from(filters).join(','),
-        );
-      } else {
-        rawSearchParams.delete(`filter_${columnId}`);
-      }
-      updateRawSearchParams(rawSearchParams);
-
       return newFilters;
     });
   };

--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -124,27 +124,32 @@ export default function ResultsTable() {
   }, [rawSearchParams]);
 
   const onClearFilter = (columnId: string) => {
-    rawSearchParams.delete(`filter_${columnId}`);
-    updateRawSearchParams(rawSearchParams);
-
     setTableFilters((oldFilters) => {
       const newFilters = new Map(oldFilters);
       newFilters.delete(columnId);
+
+      rawSearchParams.delete(`filter_${columnId}`);
+      updateRawSearchParams(rawSearchParams);
+
       return newFilters;
     });
   };
 
   const onToggleFilter = (columnId: string, filters: Set<string>) => {
-    if (filters.size > 0) {
-      rawSearchParams.set(`filter_${columnId}`, Array.from(filters).join(','));
-    } else {
-      rawSearchParams.delete(`filter_${columnId}`);
-    }
-    updateRawSearchParams(rawSearchParams);
-
     setTableFilters((oldFilters) => {
       const newFilters = new Map(oldFilters);
       newFilters.set(columnId, filters);
+
+      if (filters.size > 0) {
+        rawSearchParams.set(
+          `filter_${columnId}`,
+          Array.from(filters).join(','),
+        );
+      } else {
+        rawSearchParams.delete(`filter_${columnId}`);
+      }
+      updateRawSearchParams(rawSearchParams);
+
       return newFilters;
     });
   };

--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -140,8 +140,8 @@ export default function ResultsTable() {
     } else {
       rawSearchParams.delete(`filter_${columnId}`);
     }
-
     updateRawSearchParams(rawSearchParams);
+
     setTableFilters((oldFilters) => {
       const newFilters = new Map(oldFilters);
       newFilters.set(columnId, filters);

--- a/src/components/CompareResults/TableHeader.tsx
+++ b/src/components/CompareResults/TableHeader.tsx
@@ -154,7 +154,6 @@ function TableHeader({
       lineHeight: '16px',
     }),
   };
-
   return (
     <div
       className={`${styles.tableHeader} ${styles.typography}`}

--- a/src/components/CompareResults/TableHeader.tsx
+++ b/src/components/CompareResults/TableHeader.tsx
@@ -154,6 +154,7 @@ function TableHeader({
       lineHeight: '16px',
     }),
   };
+
   return (
     <div
       className={`${styles.tableHeader} ${styles.typography}`}


### PR DESCRIPTION
### **Overview**: 

This pull request implements functionality to persist column filters in the URL. Users can now refresh the page and maintain their selected filters, improving the overall user experience. This fixes issue #765.

### **Changes Made**:

1. **Filters Persist in the URL**

Implemented the useEffect hook that reads the filter parameters from the URL when the component mounts, ensuring that the selected filters are applied even after a page refresh.

- _Before_

https://github.com/user-attachments/assets/346bc010-2855-4e3b-9c44-feac5235947a

- _After_

https://github.com/user-attachments/assets/3cf763ad-90f0-4ac4-8eb6-f62208f88f91

2. **Shared Filtered View URL**

Update the URL with the applied filters in the existing _onToggleFilter_ method, allowing users to share the URL and they will see the same filtered results.

- _Before_

https://github.com/user-attachments/assets/5632152f-db30-4f26-b5c0-0739e3b69dad

- _After_

https://github.com/user-attachments/assets/1be944b7-acf5-4f67-a52d-433d1473e2d0

3. **URL Updates as Filters are Applied or Removed**

This functionality is implemented in the existing  _onToggleFilter_ and _onClearFilter_ methods, where parameters are dynamically added or deleted. I utilised the existing **_useRawSearchParams_** custom hook to prevent unnecessary page re-rendering. This ensures that the URL dynamically updates as filters are added or removed.

- _Before_

https://github.com/user-attachments/assets/e62c9ed8-f1b4-495b-a0ef-f8fca199659e

- _After_

https://github.com/user-attachments/assets/4ad43c32-7981-4dde-be01-d11327b4076e