### PR TITLE
Persist Filters in URL to Maintain View After Page Refresh

### DIFF
--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -116,7 +116,11 @@ export default function ResultsTable() {
       const paramsValue = rawSearchParams.get(key) ?? possibleValues.join(',');
       initialFilters.set(
         key,
-        new Set(possibleValues.filter((v) => !paramsValue.includes(v))),
+        new Set(
+          possibleValues.filter(
+            (possibleValue) => !paramsValue.includes(possibleValue),
+          ),
+        ),
       );
 
       if (!rawSearchParams.has(key)) rawSearchParams.set(key, paramsValue);
@@ -128,7 +132,7 @@ export default function ResultsTable() {
 
   const onClearFilter = (columnId: string) => {
     const possibleValues = cellsConfiguration.find(
-      (c) => c.key === columnId,
+      (cell) => cell.key === columnId,
     )?.possibleValues;
 
     if (!possibleValues) return;
@@ -140,7 +144,7 @@ export default function ResultsTable() {
 
   const onToggleFilter = (columnId: string, filters: Set<string>) => {
     const possibleValues = cellsConfiguration.find(
-      (c) => c.key === columnId,
+      (cell) => cell.key === columnId,
     )?.possibleValues;
 
     if (!possibleValues) return;
@@ -148,7 +152,9 @@ export default function ResultsTable() {
     const paramsValue =
       filters.size === possibleValues.length
         ? ''
-        : possibleValues.filter((v) => !filters.has(v)).join(',');
+        : possibleValues
+            .filter((possibleValue) => !filters.has(possibleValue))
+            .join(',');
 
     setTableFilters((prev) => new Map(prev).set(columnId, filters));
     rawSearchParams.set(columnId, paramsValue);

--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -156,7 +156,9 @@ export default function ResultsTable() {
             .filter((possibleValue) => !filters.has(possibleValue))
             .join(',');
 
-    setTableFilters((prev) => new Map(prev).set(columnId, filters));
+    setTableFilters((previousFilters) =>
+      new Map(previousFilters).set(columnId, filters),
+    );
     rawSearchParams.set(columnId, paramsValue);
     updateRawSearchParams(rawSearchParams);
   };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -7,6 +7,7 @@ export type CompareResultsTableConfig =
       key: string;
       disable?: boolean;
       gridWidth?: string;
+      possibleValues?: undefined;
     }
   | {
       name: string;


### PR DESCRIPTION
This pull request fixes [issue (#765)](https://github.com/mozilla/perfcompare/issues/765) where the filters applied to the results table were not persisted in the URL, resulting in the default view being restored upon page refresh. With this update, users can now expect the following behaviour:

- **Filters Persisted:** When filters for the platform, status, or confidence are applied, they are retained even after the page is refreshed.
- **URL Updates Dynamically:** The URL updates as filters are applied or removed, allowing users to share specific filtered views with others.
- **Consistent User Experience:** Users will see the same filtered results when navigating back to the results table or when sharing the filtered URL.

## Implementation Details

The following changes were made to implement the persistence of filters:

1. **Effect Hook for Initial Filters:**
   - The `useEffect` hook initialises the filters based on the current URL search parameters. If no parameters are found, it defaults to using the possible values for each filter.
   - The `initialFilters` state is set accordingly to reflect the current filter configuration.

2. **Filter Clearing Functionality:**
   - The `onClearFilter` function was updated to ensure that when a filter is cleared, the URL is also updated to reflect all possible values.

3. **Filter Toggling Functionality:**
   - The `onToggleFilter` function ensures that when filters are toggled, the URL parameters are updated accordingly to maintain consistency with the displayed results.

## Screenshots Showing Changes Made

### Before Changes
![beforeee](https://github.com/user-attachments/assets/5b9a6726-b8e8-44ce-99db-b9cd26cf92d1)

### After Changes
#### Platform
![platformmm](https://github.com/user-attachments/assets/2c26e005-e3d2-4080-85bd-7dfedfb8ed40)

#### Status
![statussss](https://github.com/user-attachments/assets/2396d8ce-09ee-419e-856d-44dd3133823b)

#### Confidence
![confidenceee](https://github.com/user-attachments/assets/4237e51e-fb72-4859-8025-847670d69cb8)

## Steps to Reproduce

1. Run the application
2. Compare with a base
3. Apply filters to the columns (e.g., show only improvements, regressions, by platform, or filter by confidence or platform).
4. Refresh the page.
5. Observe that the column filters are now persisted, maintaining the expected filtered view.
6.  Note that the URL should update as filters are applied or removed.

