### PR TITLE
Group results by tests

### DIFF
--- a/src/__tests__/CompareResults/ResultsView.test.tsx
+++ b/src/__tests__/CompareResults/ResultsView.test.tsx
@@ -5,7 +5,7 @@ import { Bubble, ChartProps, Line } from 'react-chartjs-2';
 
 import { loader } from '../../components/CompareResults/loader';
 import ResultsView from '../../components/CompareResults/ResultsView';
-import RevisionHeader from '../../components/CompareResults/RevisionHeader';
+import TestHeader from '../../components/CompareResults/TestHeader';
 import { Strings } from '../../resources/Strings';
 import type { Repository } from '../../types/state';
 import type { Framework } from '../../types/types';
@@ -80,7 +80,7 @@ describe('Results View', () => {
       test: '3DGraphics-WebGL',
     };
 
-    renderWithRoute(<RevisionHeader result={revisionHeader} />);
+    renderWithRoute(<TestHeader result={revisionHeader} withRevision={true} />);
     const linkToSuite = await screen.findByLabelText(
       'link to suite documentation',
     );
@@ -98,7 +98,7 @@ describe('Results View', () => {
       test: '3DGraphics-WebGL',
     };
 
-    renderWithRoute(<RevisionHeader result={revisionHeader} />);
+    renderWithRoute(<TestHeader result={revisionHeader} withRevision={true} />);
     await screen.findByText(/idle-bg/);
     const linkToSuite = screen.queryByLabelText('link to suite documentation');
     expect(linkToSuite).not.toBeInTheDocument();

--- a/src/__tests__/CompareResults/ResultsView.test.tsx
+++ b/src/__tests__/CompareResults/ResultsView.test.tsx
@@ -7,7 +7,8 @@ import { loader } from '../../components/CompareResults/loader';
 import ResultsView from '../../components/CompareResults/ResultsView';
 import RevisionHeader from '../../components/CompareResults/RevisionHeader';
 import { Strings } from '../../resources/Strings';
-import { RevisionsHeader } from '../../types/state';
+import type { Repository } from '../../types/state';
+import type { Framework } from '../../types/types';
 import { getLocationOrigin } from '../../utils/location';
 import getTestData from '../utils/fixtures';
 import {
@@ -69,17 +70,17 @@ describe('Results View', () => {
   });
 
   it('Should render revision header with link to suite docs', async () => {
-    const revisionHeader: RevisionsHeader = {
+    const revisionHeader = {
       extra_options: 'e10s fission stylo webgl-ipc webrender',
-      framework_id: 1,
-      new_repo: 'mozilla-central',
+      framework_id: 1 as Framework['id'],
+      new_repository_name: 'mozilla-central' as Repository['name'],
       new_rev: 'a998c42399a8fcea623690bf65bef49de20535b4',
       option_name: 'opt',
       suite: 'allyr',
       test: '3DGraphics-WebGL',
     };
 
-    renderWithRoute(<RevisionHeader header={revisionHeader} />);
+    renderWithRoute(<RevisionHeader result={revisionHeader} />);
     const linkToSuite = await screen.findByLabelText(
       'link to suite documentation',
     );
@@ -87,17 +88,17 @@ describe('Results View', () => {
   });
 
   it('Should render revision header without link to suite docs for unsupported framework', async () => {
-    const revisionHeader: RevisionsHeader = {
+    const revisionHeader = {
       extra_options: 'e10s fission stylo webgl-ipc webrender',
-      framework_id: 10,
-      new_repo: 'mozilla-central',
+      framework_id: 10 as Framework['id'],
+      new_repository_name: 'mozilla-central' as Repository['name'],
       new_rev: 'a998c42399a8fcea623690bf65bef49de20535b4',
       option_name: 'opt',
       suite: 'idle-bg',
       test: '3DGraphics-WebGL',
     };
 
-    renderWithRoute(<RevisionHeader header={revisionHeader} />);
+    renderWithRoute(<RevisionHeader result={revisionHeader} />);
     await screen.findByText(/idle-bg/);
     const linkToSuite = screen.queryByLabelText('link to suite documentation');
     expect(linkToSuite).not.toBeInTheDocument();

--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -403,11 +403,11 @@ exports[`Results View The table should match snapshot and other elements should 
           style="overflow-anchor: none;"
         >
           <div
-            class="f1otqxop"
+            class="f1d2zsj2"
             role="rowgroup"
           >
             <div
-              class="fx9q187"
+              class="fh103jg"
             >
               <div
                 class="f897l9y"
@@ -425,7 +425,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </strong>
                  
                 <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways f897l9y css-1qhous5-MuiTypography-root-MuiLink-root"
                   href="https://treeherder.mozilla.org/jobs?repo=mozilla-central&revision=spam"
                   target="_blank"
                   title="open treeherder view for spam"
@@ -463,7 +463,9 @@ exports[`Results View The table should match snapshot and other elements should 
                 </span>
               </div>
             </div>
-            <div>
+            <div
+              class="fcdpsbx"
+            >
               <div
                 class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
                 role="row"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -2127,3 +2127,531 @@ exports[`Results Table Should match snapshot 1`] = `
   </div>
 </body>
 `;
+
+exports[`Results Table should render different blocks when rendering several revisions 1`] = `
+<div
+  class="f1d2zsj2"
+  role="rowgroup"
+>
+  <div
+    class="fh103jg"
+  >
+    <div
+      class="f897l9y"
+    >
+      <strong>
+        <a
+          aria-label="link to suite documentation"
+          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-g8z9fn-MuiTypography-root-MuiLink-root"
+          href="https://firefox-source-docs.mozilla.org/testing/perfdocs/talos.html#a11yr"
+          target="_blank"
+        >
+          a11yr
+        </a>
+         dhtml.html
+      </strong>
+    </div>
+    <div
+      class="f1oxa67k"
+    >
+      <span
+        class="f1rpr1m5"
+      >
+        opt
+      </span>
+      <span
+        class="f1rpr1m5"
+      >
+        e10s
+      </span>
+      <span
+        class="f1rpr1m5"
+      >
+        fission
+      </span>
+      <span
+        class="f1rpr1m5"
+      >
+        stylo
+      </span>
+      <span
+        class="f1rpr1m5"
+      >
+        webrender
+      </span>
+    </div>
+  </div>
+  <div
+    class="fcdpsbx"
+  >
+    <a
+      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways f897l9y css-1qhous5-MuiTypography-root-MuiLink-root"
+      href="https://treeherder.mozilla.org/jobs?repo=mozilla-central&revision=spam"
+      target="_blank"
+      title="open treeherder view for spam"
+    >
+      spam
+    </a>
+    <div
+      class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+      role="row"
+    >
+      <div
+        class="platform cell"
+        role="cell"
+      >
+        <div
+          aria-label="macosx1015-64-shippable-qr"
+          class="platform-container"
+          data-mui-internal-clone-element="true"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+            data-testid="AppleIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"
+            />
+          </svg>
+          <span>
+            OSX
+          </span>
+        </div>
+      </div>
+      <div
+        class="base-value cell"
+        role="cell"
+      >
+         
+        704.84
+         
+        ms
+         
+      </div>
+      <div
+        class="comparison-sign cell"
+        role="cell"
+      >
+        &lt;
+      </div>
+      <div
+        class="new-value cell"
+        role="cell"
+      >
+         
+        712.44
+         
+        ms
+      </div>
+      <div
+        class="status cell"
+        role="cell"
+      >
+        <span
+          class="status-hint status-hint-improvement"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+            data-testid="ThumbUpIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M1 21h4V9H1v12zm22-11c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 1 7.59 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2z"
+            />
+          </svg>
+          Improvement
+        </span>
+      </div>
+      <div
+        class="delta cell"
+        role="cell"
+      >
+         
+        1.08
+         %
+         
+      </div>
+      <div
+        class="confidence cell"
+        role="cell"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-vsehry-MuiSvgIcon-root"
+          data-testid="KeyboardArrowDownIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+          />
+        </svg>
+        Low
+      </div>
+      <div
+        class="total-runs cell"
+        role="cell"
+      >
+        <span>
+          <span
+            title="Base runs"
+          >
+            B:
+          </span>
+          <strong>
+            1
+          </strong>
+        </span>
+        <span>
+          <span
+            title="New runs"
+          >
+            N:
+          </span>
+          <strong>
+            1
+          </strong>
+        </span>
+      </div>
+      <div
+        class="row-buttons cell"
+      >
+        <div
+          class="graph"
+          role="cell"
+        >
+          <div
+            class="graph-link-button-container"
+          >
+            <a
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
+              href="https://treeherder.mozilla.org/perfherder/graphs?highlightedRevisions=1e32960788ea&highlightedRevisions=6a1f133815a1&series=mozilla-central%2C9daea6258ae244039eb2390f3eab7935994cbb0e%2C1%2C1&timerange=5184000"
+              tabindex="0"
+              target="_blank"
+              title="open the evolution graph for this job in treeherder"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                data-testid="TimelineIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
+                />
+              </svg>
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </a>
+          </div>
+        </div>
+        <div
+          class="retrigger-button"
+          data-testid="retrigger-jobs-button"
+          role="cell"
+        >
+          <div
+            class="retrigger-button-container"
+          >
+            <button
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
+              tabindex="0"
+              title="retrigger jobs"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                data-testid="RefreshOutlinedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                />
+              </svg>
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="expand-button cell"
+        role="cell"
+      >
+        <div
+          class="expand-button-container"
+          data-testid="expand-revision-button"
+        >
+          <button
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
+            tabindex="0"
+            title="expand this row"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+              data-testid="ExpandMoreIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+              />
+            </svg>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="fcdpsbx"
+  >
+    <a
+      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways f897l9y css-1qhous5-MuiTypography-root-MuiLink-root"
+      href="https://treeherder.mozilla.org/jobs?repo=mozilla-central&revision=devilrabbit"
+      target="_blank"
+      title="open treeherder view for devilrabbit"
+    >
+      devilrabbit
+    </a>
+    <div
+      class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+      role="row"
+    >
+      <div
+        class="platform cell"
+        role="cell"
+      >
+        <div
+          aria-label="macosx1015-64-shippable-qr"
+          class="platform-container"
+          data-mui-internal-clone-element="true"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+            data-testid="AppleIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"
+            />
+          </svg>
+          <span>
+            OSX
+          </span>
+        </div>
+      </div>
+      <div
+        class="base-value cell"
+        role="cell"
+      >
+         
+        704.84
+         
+        ms
+         
+      </div>
+      <div
+        class="comparison-sign cell"
+        role="cell"
+      >
+        &lt;
+      </div>
+      <div
+        class="new-value cell"
+        role="cell"
+      >
+         
+        712.44
+         
+        ms
+      </div>
+      <div
+        class="status cell"
+        role="cell"
+      >
+        <span
+          class="status-hint status-hint-improvement"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+            data-testid="ThumbUpIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M1 21h4V9H1v12zm22-11c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 1 7.59 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2z"
+            />
+          </svg>
+          Improvement
+        </span>
+      </div>
+      <div
+        class="delta cell"
+        role="cell"
+      >
+         
+        1.08
+         %
+         
+      </div>
+      <div
+        class="confidence cell"
+        role="cell"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-vsehry-MuiSvgIcon-root"
+          data-testid="KeyboardArrowDownIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+          />
+        </svg>
+        Low
+      </div>
+      <div
+        class="total-runs cell"
+        role="cell"
+      >
+        <span>
+          <span
+            title="Base runs"
+          >
+            B:
+          </span>
+          <strong>
+            1
+          </strong>
+        </span>
+        <span>
+          <span
+            title="New runs"
+          >
+            N:
+          </span>
+          <strong>
+            1
+          </strong>
+        </span>
+      </div>
+      <div
+        class="row-buttons cell"
+      >
+        <div
+          class="graph"
+          role="cell"
+        >
+          <div
+            class="graph-link-button-container"
+          >
+            <a
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
+              href="https://treeherder.mozilla.org/perfherder/graphs?highlightedRevisions=1e32960788ea&highlightedRevisions=6a1f133815a1&series=mozilla-central%2C9daea6258ae244039eb2390f3eab7935994cbb0e%2C1%2C1&timerange=5184000"
+              tabindex="0"
+              target="_blank"
+              title="open the evolution graph for this job in treeherder"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                data-testid="TimelineIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2z"
+                />
+              </svg>
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </a>
+          </div>
+        </div>
+        <div
+          class="retrigger-button"
+          data-testid="retrigger-jobs-button"
+          role="cell"
+        >
+          <div
+            class="retrigger-button-container"
+          >
+            <button
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
+              tabindex="0"
+              title="retrigger jobs"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                data-testid="RefreshOutlinedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                />
+              </svg>
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="expand-button cell"
+        role="cell"
+      >
+        <div
+          class="expand-button-container"
+          data-testid="expand-revision-button"
+        >
+          <button
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
+            tabindex="0"
+            title="expand this row"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+              data-testid="ExpandMoreIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+              />
+            </svg>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -1137,11 +1137,11 @@ exports[`Results Table Should match snapshot 1`] = `
                       style="overflow-anchor: none;"
                     >
                       <div
-                        class="f1otqxop"
+                        class="f1d2zsj2"
                         role="rowgroup"
                       >
                         <div
-                          class="fx9q187"
+                          class="fh103jg"
                         >
                           <div
                             class="f897l9y"
@@ -1159,7 +1159,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </strong>
                              
                             <a
-                              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
+                              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways f897l9y css-1qhous5-MuiTypography-root-MuiLink-root"
                               href="https://treeherder.mozilla.org/jobs?repo=mozilla-central&revision=spam"
                               target="_blank"
                               title="open treeherder view for spam"
@@ -1197,7 +1197,9 @@ exports[`Results Table Should match snapshot 1`] = `
                             </span>
                           </div>
                         </div>
-                        <div>
+                        <div
+                          class="fcdpsbx"
+                        >
                           <div
                             class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
                             role="row"
@@ -1868,11 +1870,11 @@ exports[`Results Table Should match snapshot 1`] = `
                       style="overflow-anchor: none;"
                     >
                       <div
-                        class="f1otqxop"
+                        class="f1d2zsj2"
                         role="rowgroup"
                       >
                         <div
-                          class="fx9q187"
+                          class="fh103jg"
                         >
                           <div
                             class="f897l9y"
@@ -1890,7 +1892,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </strong>
                              
                             <a
-                              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
+                              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways f897l9y css-1qhous5-MuiTypography-root-MuiLink-root"
                               href="https://treeherder.mozilla.org/jobs?repo=mozilla-central&revision=spam"
                               target="_blank"
                               title="open treeherder view for spam"
@@ -1908,7 +1910,9 @@ exports[`Results Table Should match snapshot 1`] = `
                             </span>
                           </div>
                         </div>
-                        <div>
+                        <div
+                          class="fcdpsbx"
+                        >
                           <div
                             class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
                             role="row"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -1066,11 +1066,11 @@ exports[`Results View The table should match snapshot and other elements should 
           style="overflow-anchor: none;"
         >
           <div
-            class="f1otqxop"
+            class="f1d2zsj2"
             role="rowgroup"
           >
             <div
-              class="fx9q187"
+              class="fh103jg"
             >
               <div
                 class="f897l9y"
@@ -1088,7 +1088,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </strong>
                  
                 <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways f897l9y css-1qhous5-MuiTypography-root-MuiLink-root"
                   href="https://treeherder.mozilla.org/jobs?repo=mozilla-central&revision=spam"
                   target="_blank"
                   title="open treeherder view for spam"
@@ -1126,7 +1126,9 @@ exports[`Results View The table should match snapshot and other elements should 
                 </span>
               </div>
             </div>
-            <div>
+            <div
+              class="fcdpsbx"
+            >
               <div
                 class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
                 role="row"

--- a/src/components/CompareResults/LinkToRevision.tsx
+++ b/src/components/CompareResults/LinkToRevision.tsx
@@ -1,0 +1,40 @@
+import { Link } from '@mui/material';
+import { style } from 'typestyle';
+
+import { Strings } from '../../resources/Strings';
+import type { CompareResultsItem } from '../../types/state';
+import { getTreeherderURL, truncateHash } from '../../utils/helpers';
+
+const styles = {
+  typography: style({
+    fontFamily: 'SF Pro',
+    fontStyle: 'normal',
+    fontWeight: 590,
+    fontSize: '15px',
+    lineHeight: '20px',
+  }),
+};
+
+type HeaderProperties = Pick<
+  CompareResultsItem,
+  'new_repository_name' | 'new_rev'
+>;
+
+export default function LinkToRevision(props: LinkToRevisionProps) {
+  const { result } = props;
+  const shortHash = truncateHash(result.new_rev);
+  return (
+    <Link
+      href={getTreeherderURL(result.new_rev, result.new_repository_name)}
+      target='_blank'
+      title={`${Strings.components.revisionRow.title.jobLink} ${shortHash}`}
+      className={styles.typography}
+    >
+      {shortHash}
+    </Link>
+  );
+}
+
+interface LinkToRevisionProps {
+  result: HeaderProperties;
+}

--- a/src/components/CompareResults/RevisionHeader.tsx
+++ b/src/components/CompareResults/RevisionHeader.tsx
@@ -3,7 +3,7 @@ import { style } from 'typestyle';
 
 import { Strings } from '../../resources/Strings';
 import { Colors, Spacing } from '../../styles';
-import type { RevisionsHeader } from '../../types/state';
+import type { CompareResultsItem } from '../../types/state';
 import {
   getTreeherderURL,
   truncateHash,
@@ -58,12 +58,23 @@ const styles = {
   }),
 };
 
+type HeaderProperties = Pick<
+  CompareResultsItem,
+  | 'extra_options'
+  | 'framework_id'
+  | 'new_repository_name'
+  | 'new_rev'
+  | 'option_name'
+  | 'suite'
+  | 'test'
+>;
+
 function createTitle(
-  header: RevisionsHeader,
+  result: HeaderProperties,
   docsURL: string,
   isLinkSupported: boolean,
 ) {
-  const isTestUnavailable = header.test === '' || header.suite === header.test;
+  const isTestUnavailable = result.test === '' || result.suite === result.test;
   if (isLinkSupported) {
     return (
       <>
@@ -73,13 +84,13 @@ function createTitle(
           target='_blank'
           href={docsURL}
         >
-          {header.suite}
+          {result.suite}
         </Link>
-        {isTestUnavailable ? '' : ` ${header.test}`}
+        {isTestUnavailable ? '' : ` ${result.test}`}
       </>
     );
   } else {
-    return isTestUnavailable ? header.suite : `${header.suite} ${header.test}`;
+    return isTestUnavailable ? result.suite : `${result.suite} ${result.test}`;
   }
 }
 
@@ -88,19 +99,19 @@ function getExtraOptions(extraOptions: string) {
 }
 
 function RevisionHeader(props: RevisionHeaderProps) {
-  const { header } = props;
+  const { result } = props;
   const { docsURL, isLinkSupported } = getDocsURL(
-    header.suite,
-    header.framework_id,
+    result.suite,
+    result.framework_id,
   );
-  const extraOptions = getExtraOptions(header.extra_options);
-  const shortHash = truncateHash(header.new_rev);
+  const extraOptions = getExtraOptions(result.extra_options);
+  const shortHash = truncateHash(result.new_rev);
   return (
     <div className={styles.revisionHeader}>
       <div className={styles.typography}>
-        <strong>{createTitle(header, docsURL, isLinkSupported)}</strong>{' '}
+        <strong>{createTitle(result, docsURL, isLinkSupported)}</strong>{' '}
         <Link
-          href={getTreeherderURL(header.new_rev, header.new_repo)}
+          href={getTreeherderURL(result.new_rev, result.new_repository_name)}
           target='_blank'
           title={`${Strings.components.revisionRow.title.jobLink} ${shortHash}`}
         >
@@ -108,7 +119,7 @@ function RevisionHeader(props: RevisionHeaderProps) {
         </Link>
       </div>
       <div className={styles.tagsOptions}>
-        <span className={styles.chip}>{header.option_name}</span>
+        <span className={styles.chip}>{result.option_name}</span>
         {extraOptions.map((option, index) => (
           <span className={styles.chip} key={index}>
             {option}
@@ -120,7 +131,7 @@ function RevisionHeader(props: RevisionHeaderProps) {
 }
 
 interface RevisionHeaderProps {
-  header: RevisionsHeader;
+  result: HeaderProperties;
 }
 
 export default RevisionHeader;

--- a/src/components/CompareResults/TableContent.tsx
+++ b/src/components/CompareResults/TableContent.tsx
@@ -5,7 +5,7 @@ import { Virtuoso } from 'react-virtuoso';
 import type { compareView, compareOverTimeView } from '../../common/constants';
 import { useAppSelector } from '../../hooks/app';
 import { Strings } from '../../resources/Strings';
-import type { CompareResultsItem, RevisionsHeader } from '../../types/state';
+import type { CompareResultsItem } from '../../types/state';
 import type { CompareResultsTableConfig } from '../../types/types';
 import NoResultsFound from './NoResultsFound';
 import TableRevisionContent from './TableRevisionContent';
@@ -13,7 +13,6 @@ import TableRevisionContent from './TableRevisionContent';
 type ResultsForRevision = {
   key: string;
   value: CompareResultsItem[];
-  revisionHeader: RevisionsHeader;
 };
 
 function processResults(results: CompareResultsItem[]) {
@@ -38,15 +37,6 @@ function processResults(results: CompareResultsItem[]) {
       return {
         key: rowIdentifier,
         value: result,
-        revisionHeader: {
-          suite: result[0].suite,
-          framework_id: result[0].framework_id,
-          test: result[0].test,
-          option_name: result[0].option_name,
-          extra_options: result[0].extra_options,
-          new_rev: result[0].new_rev,
-          new_repo: result[0].new_repository_name,
-        },
       };
     },
   );
@@ -191,8 +181,6 @@ function TableContent({
       computeItemKey={(_, res) => res.key}
       itemContent={(_, res) => (
         <TableRevisionContent
-          identifier={res.key}
-          header={res.revisionHeader}
           results={res.value}
           view={view}
           rowGridTemplateColumns={rowGridTemplateColumns}

--- a/src/components/CompareResults/TableContent.tsx
+++ b/src/components/CompareResults/TableContent.tsx
@@ -171,34 +171,34 @@ function TableContent({
     cellsConfiguration,
   ]);
 
-  return (
-    <>
-      <Virtuoso
-        useWindowScroll
-        totalCount={processedResults.length}
-        overscan={{
-          /* These values are pretty arbitrary. The goal is to have more rows
-           * rendered than the current viewport, so that when scrolling fast
-           * (but not too fast) the white checkerboarding doesn't appear.
-           */
-          main: 5000,
-          reverse: 5000,
-        }}
-        data={processedResults}
-        computeItemKey={(_, res) => res.key}
-        itemContent={(_, res) => (
-          <TableRevisionContent
-            identifier={res.key}
-            header={res.revisionHeader}
-            results={res.value}
-            view={view}
-            rowGridTemplateColumns={rowGridTemplateColumns}
-          />
-        )}
-      />
+  if (!processedResults.length) {
+    return <NoResultsFound />;
+  }
 
-      {processedResults.length == 0 && <NoResultsFound />}
-    </>
+  return (
+    <Virtuoso
+      useWindowScroll
+      totalCount={processedResults.length}
+      overscan={{
+        /* These values are pretty arbitrary. The goal is to have more rows
+         * rendered than the current viewport, so that when scrolling fast
+         * (but not too fast) the white checkerboarding doesn't appear.
+         */
+        main: 5000,
+        reverse: 5000,
+      }}
+      data={processedResults}
+      computeItemKey={(_, res) => res.key}
+      itemContent={(_, res) => (
+        <TableRevisionContent
+          identifier={res.key}
+          header={res.revisionHeader}
+          results={res.value}
+          view={view}
+          rowGridTemplateColumns={rowGridTemplateColumns}
+        />
+      )}
+    />
   );
 }
 

--- a/src/components/CompareResults/TableRevisionContent.tsx
+++ b/src/components/CompareResults/TableRevisionContent.tsx
@@ -19,6 +19,11 @@ const styles = {
 
 function TableRevisionContent(props: Props) {
   const { results, view, rowGridTemplateColumns } = props;
+
+  if (!results.length) {
+    return null;
+  }
+
   // All results are for the same test, so any results hould generate the same
   // header appropriately.
   // Here we use the first result for the first revision.
@@ -28,24 +33,27 @@ function TableRevisionContent(props: Props) {
   //                                            |  |  |
   //                                            v  v  v
   const representativeResultForHeader = results[0][1][0];
+  const hasMoreThanOneNewRev = results.length > 1;
 
   return (
     <div className={styles.testBlock} role='rowgroup'>
-      <TestHeader result={representativeResultForHeader} />
-      {results.length > 0 &&
-        results.map(([revision, listOfResults]) => (
-          <div className={styles.revisionBlock} key={revision}>
-            <LinkToRevision result={listOfResults[0]} />
-            {listOfResults.map((result) => (
-              <RevisionRow
-                key={result.platform}
-                result={result}
-                view={view}
-                gridTemplateColumns={rowGridTemplateColumns}
-              />
-            ))}
-          </div>
-        ))}
+      <TestHeader
+        result={representativeResultForHeader}
+        withRevision={!hasMoreThanOneNewRev}
+      />
+      {results.map(([revision, listOfResults]) => (
+        <div className={styles.revisionBlock} key={revision}>
+          {hasMoreThanOneNewRev && <LinkToRevision result={listOfResults[0]} />}
+          {listOfResults.map((result) => (
+            <RevisionRow
+              key={result.platform}
+              result={result}
+              view={view}
+              gridTemplateColumns={rowGridTemplateColumns}
+            />
+          ))}
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/components/CompareResults/TableRevisionContent.tsx
+++ b/src/components/CompareResults/TableRevisionContent.tsx
@@ -3,36 +3,49 @@ import { style } from 'typestyle';
 import type { compareView, compareOverTimeView } from '../../common/constants';
 import { Spacing } from '../../styles';
 import type { CompareResultsItem } from '../../types/state';
-import RevisionHeader from './RevisionHeader';
+import LinkToRevision from './LinkToRevision';
 import RevisionRow from './RevisionRow';
+import TestHeader from './TestHeader';
 
+// We're using typestyle styles on purpose, to avoid the performance impact of
+// MUI's sx prop for these numerous elements.
 const styles = {
-  tableBody: style({
-    marginTop: Spacing.Large,
+  testBlock: style({
+    /* Note that this margin will be merged with the margin below */
+    marginTop: Spacing.xLarge,
   }),
+  revisionBlock: style({ marginBottom: Spacing.Large }),
 };
 
 function TableRevisionContent(props: Props) {
   const { results, view, rowGridTemplateColumns } = props;
+  // All results are for the same test, so any results hould generate the same
+  // header appropriately.
+  // Here we use the first result for the first revision.
+  //                                         First result
+  //                               Value of the tuple |
+  //                                First revision |  |
+  //                                            |  |  |
+  //                                            v  v  v
+  const representativeResultForHeader = results[0][1][0];
 
   return (
-    <div className={styles.tableBody} role='rowgroup'>
-      {/* TODO change this to a test header */}
-      <RevisionHeader result={results[0][1][0]} />
-      <div>
-        {results.length > 0 &&
-          results.map(([, listOfResults]) =>
-            // TODO add a revision header
-            listOfResults.map((result) => (
+    <div className={styles.testBlock} role='rowgroup'>
+      <TestHeader result={representativeResultForHeader} />
+      {results.length > 0 &&
+        results.map(([revision, listOfResults]) => (
+          <div className={styles.revisionBlock} key={revision}>
+            <LinkToRevision result={listOfResults[0]} />
+            {listOfResults.map((result) => (
               <RevisionRow
                 key={result.platform}
                 result={result}
                 view={view}
                 gridTemplateColumns={rowGridTemplateColumns}
               />
-            )),
-          )}
-      </div>
+            ))}
+          </div>
+        ))}
     </div>
   );
 }

--- a/src/components/CompareResults/TableRevisionContent.tsx
+++ b/src/components/CompareResults/TableRevisionContent.tsx
@@ -2,7 +2,7 @@ import { style } from 'typestyle';
 
 import type { compareView, compareOverTimeView } from '../../common/constants';
 import { Spacing } from '../../styles';
-import type { CompareResultsItem, RevisionsHeader } from '../../types/state';
+import type { CompareResultsItem } from '../../types/state';
 import RevisionHeader from './RevisionHeader';
 import RevisionRow from './RevisionRow';
 
@@ -13,16 +13,16 @@ const styles = {
 };
 
 function TableRevisionContent(props: Props) {
-  const { results, header, identifier, view, rowGridTemplateColumns } = props;
+  const { results, view, rowGridTemplateColumns } = props;
 
   return (
     <div className={styles.tableBody} role='rowgroup'>
-      <RevisionHeader header={header} />
+      <RevisionHeader result={results[0]} />
       <div>
         {results.length > 0 &&
           results.map((result) => (
             <RevisionRow
-              key={identifier + result.platform}
+              key={result.platform}
               result={result}
               view={view}
               gridTemplateColumns={rowGridTemplateColumns}
@@ -35,8 +35,6 @@ function TableRevisionContent(props: Props) {
 
 interface Props {
   results: CompareResultsItem[];
-  header: RevisionsHeader;
-  identifier: string;
   rowGridTemplateColumns: string;
   view: typeof compareView | typeof compareOverTimeView;
 }

--- a/src/components/CompareResults/TableRevisionContent.tsx
+++ b/src/components/CompareResults/TableRevisionContent.tsx
@@ -17,24 +17,33 @@ function TableRevisionContent(props: Props) {
 
   return (
     <div className={styles.tableBody} role='rowgroup'>
-      <RevisionHeader result={results[0]} />
+      {/* TODO change this to a test header */}
+      <RevisionHeader result={results[0][1][0]} />
       <div>
         {results.length > 0 &&
-          results.map((result) => (
-            <RevisionRow
-              key={result.platform}
-              result={result}
-              view={view}
-              gridTemplateColumns={rowGridTemplateColumns}
-            />
-          ))}
+          results.map(([, listOfResults]) =>
+            // TODO add a revision header
+            listOfResults.map((result) => (
+              <RevisionRow
+                key={result.platform}
+                result={result}
+                view={view}
+                gridTemplateColumns={rowGridTemplateColumns}
+              />
+            )),
+          )}
       </div>
     </div>
   );
 }
 
 interface Props {
-  results: CompareResultsItem[];
+  // "results" contains all results for just one test, grouped by revisions.
+  //
+  //              revision        list of results for one test and revision
+  //                 |               |
+  //                 v               v
+  results: Array<[string, CompareResultsItem[]]>;
   rowGridTemplateColumns: string;
   view: typeof compareView | typeof compareOverTimeView;
 }

--- a/src/components/CompareResults/TableRevisionContent.tsx
+++ b/src/components/CompareResults/TableRevisionContent.tsx
@@ -24,7 +24,7 @@ function TableRevisionContent(props: Props) {
     return null;
   }
 
-  // All results are for the same test, so any results hould generate the same
+  // All results are for the same test, so any result should generate the same
   // header appropriately.
   // Here we use the first result for the first revision.
   //                                         First result

--- a/src/components/CompareResults/TestHeader.tsx
+++ b/src/components/CompareResults/TestHeader.tsx
@@ -1,14 +1,9 @@
 import { Link } from '@mui/material';
 import { style } from 'typestyle';
 
-import { Strings } from '../../resources/Strings';
 import { Colors, Spacing } from '../../styles';
 import type { CompareResultsItem } from '../../types/state';
-import {
-  getTreeherderURL,
-  truncateHash,
-  getDocsURL,
-} from '../../utils/helpers';
+import { getDocsURL } from '../../utils/helpers';
 
 const styles = {
   revisionHeader: style({
@@ -16,7 +11,7 @@ const styles = {
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
-    paddingBottom: '12px',
+    paddingBottom: '8px',
     marginBottom: '12px',
   }),
   tagsOptions: style({
@@ -60,13 +55,7 @@ const styles = {
 
 type HeaderProperties = Pick<
   CompareResultsItem,
-  | 'extra_options'
-  | 'framework_id'
-  | 'new_repository_name'
-  | 'new_rev'
-  | 'option_name'
-  | 'suite'
-  | 'test'
+  'extra_options' | 'framework_id' | 'option_name' | 'suite' | 'test'
 >;
 
 function createTitle(
@@ -98,25 +87,17 @@ function getExtraOptions(extraOptions: string) {
   return extraOptions ? extraOptions.split(' ') : [];
 }
 
-function RevisionHeader(props: RevisionHeaderProps) {
+export default function TestHeader(props: TestHeaderProps) {
   const { result } = props;
   const { docsURL, isLinkSupported } = getDocsURL(
     result.suite,
     result.framework_id,
   );
   const extraOptions = getExtraOptions(result.extra_options);
-  const shortHash = truncateHash(result.new_rev);
   return (
     <div className={styles.revisionHeader}>
       <div className={styles.typography}>
-        <strong>{createTitle(result, docsURL, isLinkSupported)}</strong>{' '}
-        <Link
-          href={getTreeherderURL(result.new_rev, result.new_repository_name)}
-          target='_blank'
-          title={`${Strings.components.revisionRow.title.jobLink} ${shortHash}`}
-        >
-          {shortHash}
-        </Link>
+        <strong>{createTitle(result, docsURL, isLinkSupported)}</strong>
       </div>
       <div className={styles.tagsOptions}>
         <span className={styles.chip}>{result.option_name}</span>
@@ -130,8 +111,6 @@ function RevisionHeader(props: RevisionHeaderProps) {
   );
 }
 
-interface RevisionHeaderProps {
+interface TestHeaderProps {
   result: HeaderProperties;
 }
-
-export default RevisionHeader;

--- a/src/components/CompareResults/TestHeader.tsx
+++ b/src/components/CompareResults/TestHeader.tsx
@@ -4,6 +4,7 @@ import { style } from 'typestyle';
 import { Colors, Spacing } from '../../styles';
 import type { CompareResultsItem } from '../../types/state';
 import { getDocsURL } from '../../utils/helpers';
+import LinkToRevision from './LinkToRevision';
 
 const styles = {
   revisionHeader: style({
@@ -55,7 +56,13 @@ const styles = {
 
 type HeaderProperties = Pick<
   CompareResultsItem,
-  'extra_options' | 'framework_id' | 'option_name' | 'suite' | 'test'
+  | 'extra_options'
+  | 'framework_id'
+  | 'option_name'
+  | 'suite'
+  | 'test'
+  | 'new_repository_name'
+  | 'new_rev'
 >;
 
 function createTitle(
@@ -88,7 +95,7 @@ function getExtraOptions(extraOptions: string) {
 }
 
 export default function TestHeader(props: TestHeaderProps) {
-  const { result } = props;
+  const { result, withRevision } = props;
   const { docsURL, isLinkSupported } = getDocsURL(
     result.suite,
     result.framework_id,
@@ -98,6 +105,12 @@ export default function TestHeader(props: TestHeaderProps) {
     <div className={styles.revisionHeader}>
       <div className={styles.typography}>
         <strong>{createTitle(result, docsURL, isLinkSupported)}</strong>
+        {withRevision && (
+          <>
+            {' '}
+            <LinkToRevision result={result} />
+          </>
+        )}
       </div>
       <div className={styles.tagsOptions}>
         <span className={styles.chip}>{result.option_name}</span>
@@ -113,4 +126,5 @@ export default function TestHeader(props: TestHeaderProps) {
 
 interface TestHeaderProps {
   result: HeaderProperties;
+  withRevision: boolean;
 }

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -38,16 +38,6 @@ export type RevisionsData = {
   extra_options: string;
 };
 
-export type RevisionsHeader = {
-  suite: string;
-  framework_id: Framework['id'];
-  test: string;
-  option_name: string;
-  extra_options: string;
-  new_rev: string;
-  new_repo: Repository['name'];
-};
-
 export type SubtestsRevisionsHeader = {
   suite: string;
   framework_id: Framework['id'];


### PR DESCRIPTION
This pull request implements the grouping of results by test. It is useful when there are at least 2 revisions selected for the "new" range. Before this change, all the tests for the 2nd revision would be rendered after all the tests for the 1st revision.

It's easier to review commit by commit, and I believe it's also easier to review by hiding whitespace changes.

Commits:
1. Simple simplification to make TableContent more readable
2. I noticed that to render a header for a test, we were creating a separate object by reusing the results value. I changed this to use the result object directly.
3. Probably the most complex change. I tried to add comments inline in the project, but please tell me if anything needs to be clarified further.
4. This uses the new structure from commit 3 to render the results.
5. This implements the old structure again when there's just 1 revision.
6. This changes existing tests to account for the new changes.
7. This adds a new test covering the new functionality.

[deploy preview with 1 revision](https://deploy-preview-787--mozilla-perfcompare.netlify.app/compare-results?baseRev=68f96e9a3af0bbd2f0a263ba6ed6a3306480ecdf&baseRepo=mozilla-central&newRev=68f96e9a3af0bbd2f0a263ba6ed6a3306480ecdf&newRepo=mozilla-central&framework=1)
[deploy preview with 2 revisions](https://deploy-preview-787--mozilla-perfcompare.netlify.app/compare-results?baseRev=68f96e9a3af0bbd2f0a263ba6ed6a3306480ecdf&baseRepo=mozilla-central&newRev=68f96e9a3af0bbd2f0a263ba6ed6a3306480ecdf&newRepo=mozilla-central&newRev=efb1596265e9da9bbccbcbf3f4f796564780ccec&newRepo=mozilla-central&framework=1)
[deploy preview with 3 revisions](https://deploy-preview-787--mozilla-perfcompare.netlify.app/compare-results?baseRev=68f96e9a3af0bbd2f0a263ba6ed6a3306480ecdf&baseRepo=mozilla-central&newRev=68f96e9a3af0bbd2f0a263ba6ed6a3306480ecdf&newRepo=mozilla-central&newRev=efb1596265e9da9bbccbcbf3f4f796564780ccec&newRepo=mozilla-central&newRev=f8229eb11c8571108c176fdc2308a6566b1912e0&newRepo=mozilla-central&framework=1)

![image](https://github.com/user-attachments/assets/94762e3b-3a44-48d8-8ecf-33f0bc69fd93)

Future improvements:
* make the two headers (TestHeader and RevisionHeader) actual header elements (respectively h3 and h4)
* remove or improve aria-label for the link to the test documentation
