### PR TITLE
PCF-323 Expanded row doesn't match the figma design

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -467,7 +467,7 @@ exports[`Results View The table should match snapshot and other elements should 
               class="fcdpsbx"
             >
               <div
-                class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+                class="revisionRow f1b695ll fp4ugv1 MuiBox-root css-1am90bh"
                 role="row"
               >
                 <div
@@ -691,7 +691,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+                class="revisionRow f1b695ll fp4ugv1 MuiBox-root css-1am90bh"
                 role="row"
               >
                 <div
@@ -914,7 +914,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+                class="revisionRow f1b695ll fp4ugv1 MuiBox-root css-1am90bh"
                 role="row"
               >
                 <div
@@ -1127,7 +1127,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+                class="revisionRow f1b695ll fp4ugv1 MuiBox-root css-1am90bh"
                 role="row"
               >
                 <div

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -1201,7 +1201,7 @@ exports[`Results Table Should match snapshot 1`] = `
                           class="fcdpsbx"
                         >
                           <div
-                            class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+                            class="revisionRow f1b695ll fp4ugv1 MuiBox-root css-1am90bh"
                             role="row"
                           >
                             <div
@@ -1425,7 +1425,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </div>
                           </div>
                           <div
-                            class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+                            class="revisionRow f1b695ll fp4ugv1 MuiBox-root css-1am90bh"
                             role="row"
                           >
                             <div
@@ -1648,7 +1648,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </div>
                           </div>
                           <div
-                            class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+                            class="revisionRow f1b695ll fp4ugv1 MuiBox-root css-1am90bh"
                             role="row"
                           >
                             <div
@@ -1914,7 +1914,7 @@ exports[`Results Table Should match snapshot 1`] = `
                           class="fcdpsbx"
                         >
                           <div
-                            class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+                            class="revisionRow f1b695ll fp4ugv1 MuiBox-root css-1am90bh"
                             role="row"
                           >
                             <div
@@ -2195,7 +2195,7 @@ exports[`Results Table should render different blocks when rendering several rev
       spam
     </a>
     <div
-      class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+      class="revisionRow f1b695ll fp4ugv1 MuiBox-root css-1am90bh"
       role="row"
     >
       <div
@@ -2431,7 +2431,7 @@ exports[`Results Table should render different blocks when rendering several rev
       devilrabbit
     </a>
     <div
-      class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+      class="revisionRow f1b695ll fp4ugv1 MuiBox-root css-1am90bh"
       role="row"
     >
       <div

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Results View Should display Base, New and Common graphs with 1 value an
   data-testid="expanded-row-content"
 >
   <div
-    class="ff20o48"
+    class="f1e1ayr9"
   >
     <div
       class="f19s1n7z"
@@ -227,7 +227,7 @@ exports[`Results View Should display Base, New and Common graphs with replicates
   data-testid="expanded-row-content"
 >
   <div
-    class="ff20o48"
+    class="f1e1ayr9"
   >
     <div
       class="f19s1n7z"
@@ -448,7 +448,7 @@ exports[`Results View Should display Base, New and Common graphs with tooltips 1
   data-testid="expanded-row-content"
 >
   <div
-    class="ff20o48"
+    class="f1e1ayr9"
   >
     <div
       class="f19s1n7z"
@@ -1130,7 +1130,7 @@ exports[`Results View The table should match snapshot and other elements should 
               class="fcdpsbx"
             >
               <div
-                class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+                class="revisionRow f1b695ll fp4ugv1 MuiBox-root css-1am90bh"
                 role="row"
               >
                 <div
@@ -1354,7 +1354,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+                class="revisionRow f1b695ll fp4ugv1 MuiBox-root css-1am90bh"
                 role="row"
               >
                 <div
@@ -1577,7 +1577,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+                class="revisionRow f1b695ll fp4ugv1 MuiBox-root css-1am90bh"
                 role="row"
               >
                 <div
@@ -1790,7 +1790,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1nwzic9 fp4ugv1 MuiBox-root css-1am90bh"
+                class="revisionRow f1b695ll fp4ugv1 MuiBox-root css-1am90bh"
                 role="row"
               >
                 <div

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -29,7 +29,7 @@ import RevisionRowExpandable from './RevisionRowExpandable';
 const revisionsRow = {
   borderRadius: '4px 0px 0px 4px',
   display: 'grid',
-  margin: `${Spacing.Small}px 0px`,
+  margin: `${Spacing.Small}px 0px 0px 0px`,
 };
 
 const typography = {

--- a/src/components/CompareResults/RevisionRowExpandable.tsx
+++ b/src/components/CompareResults/RevisionRowExpandable.tsx
@@ -37,7 +37,6 @@ function RevisionRowExpandable(props: RevisionRowExpandableProps) {
     expandedRow: style({
       backgroundColor: themeColor200,
       padding: Spacing.Medium,
-      marginBottom: Spacing.Small,
       width: '97%',
     }),
     content: style({

--- a/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
@@ -20,7 +20,7 @@ import RevisionRowExpandable from '.././RevisionRowExpandable';
 const revisionsRow = {
   borderRadius: '4px 0px 0px 4px',
   display: 'grid',
-  margin: `${Spacing.Small}px 0px`,
+  margin: `${Spacing.Small}px 0px 0px 0px`,
 };
 
 const typography = style({


### PR DESCRIPTION
[Jira ticket](https://mozilla-hub.atlassian.net/browse/PCF-323)
This PR removes the white space when the row is expanded.

[localhost link - results](http://localhost:3000/compare-results?baseRev=c6fee9276fa2d9f298e9a081b5bcf4a8e3797316&baseRepo=mozilla-central&newRev=a635fc061556de8501069d83b02b083892ab2802&newRepo=mozilla-central&newRev=c9170b504cdce7fd51d1934bad32709bea49b112&newRepo=mozilla-central&framework=1)
[localhost link - subtests](http://localhost:3000/subtests-compare-results?baseRev=c6fee9276fa2d9f298e9a081b5bcf4a8e3797316&baseRepo=mozilla-central&newRev=a635fc061556de8501069d83b02b083892ab2802&newRepo=mozilla-central&framework=1&baseParentSignature=301893&newParentSignature=301893)

[deploy link - results](https://deploy-preview-800--mozilla-perfcompare.netlify.app/compare-results?baseRev=c6fee9276fa2d9f298e9a081b5bcf4a8e3797316&baseRepo=mozilla-central&newRev=a635fc061556de8501069d83b02b083892ab2802&newRepo=mozilla-central&newRev=c9170b504cdce7fd51d1934bad32709bea49b112&newRepo=mozilla-central&framework=1)
[deploy link - subtests](https://deploy-preview-800--mozilla-perfcompare.netlify.app/subtests-compare-results?baseRev=c6fee9276fa2d9f298e9a081b5bcf4a8e3797316&baseRepo=mozilla-central&newRev=a635fc061556de8501069d83b02b083892ab2802&newRepo=mozilla-central&framework=1&baseParentSignature=301893&newParentSignature=301893)


<img width="1205" alt="Screenshot 2024-11-12 at 19 32 01" src="https://github.com/user-attachments/assets/0ea25a70-c052-4c0e-8dd8-94cfd90ef15d">
<img width="1192" alt="Screenshot 2024-11-12 at 19 32 42" src="https://github.com/user-attachments/assets/d3cb473d-5f1c-4d9e-8d2f-2ec274a168fb">
