### PR TITLE
Extract the table filters into a common hook

### DIFF
--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from 'react-router-dom';
 import { useLoaderData, Await } from 'react-router-dom';
 
 import useRawSearchParams from '../../hooks/useRawSearchParams';
+import useTableFilters from '../../hooks/useTableFilters';
 import type { CompareResultsItem } from '../../types/state';
 import { Framework } from '../../types/types';
 import type { CompareResultsTableConfig } from '../../types/types';
@@ -106,28 +107,13 @@ export default function ResultsTable() {
   // This is our custom hook that updates the search params without a rerender.
   const [rawSearchParams, updateRawSearchParams] = useRawSearchParams();
 
+  // This is our custom hook that manages table filters
+  // and provides methods for clearing and toggling them.
+  const { tableFilters, onClearFilter, onToggleFilter } = useTableFilters();
+
   const initialSearchTerm = rawSearchParams.get('search') ?? '';
   const [searchTerm, setSearchTerm] = useState(initialSearchTerm);
   const [frameworkIdVal, setFrameworkIdVal] = useState(frameworkId);
-  const [tableFilters, setTableFilters] = useState(
-    new Map() as Map<string, Set<string>>, // ColumnID -> Set<Values to remove>
-  );
-
-  const onClearFilter = (columnId: string) => {
-    setTableFilters((oldFilters) => {
-      const newFilters = new Map(oldFilters);
-      newFilters.delete(columnId);
-      return newFilters;
-    });
-  };
-
-  const onToggleFilter = (columnId: string, filters: Set<string>) => {
-    setTableFilters((oldFilters) => {
-      const newFilters = new Map(oldFilters);
-      newFilters.set(columnId, filters);
-      return newFilters;
-    });
-  };
 
   const onFrameworkChange = (newFrameworkId: Framework['id']) => {
     setFrameworkIdVal(newFrameworkId);

--- a/src/components/CompareResults/SubtestsResults/SubtestsResultsTable.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsResultsTable.tsx
@@ -1,7 +1,8 @@
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 import Box from '@mui/material/Box';
 
+import useTableFilters from '../../../hooks/useTableFilters';
 import type { CompareResultsItem } from '../../../types/state';
 import type { CompareResultsTableConfig } from '../../../types/types';
 import NoResultsFound from '.././NoResultsFound';
@@ -165,9 +166,9 @@ function SubtestsResultsTable({
   filteringSearchTerm,
   results,
 }: ResultsTableProps) {
-  const [tableFilters, setTableFilters] = useState(
-    new Map() as Map<string, Set<string>>, // ColumnID -> Set<Values to remove>
-  );
+  // This is our custom hook that manages table filters
+  // and provides methods for clearing and toggling them.
+  const { tableFilters, onClearFilter, onToggleFilter } = useTableFilters();
 
   const processedResults = useMemo(() => {
     const filteredResults = filterResults(
@@ -177,22 +178,6 @@ function SubtestsResultsTable({
     );
     return processResults(filteredResults);
   }, [results, filteringSearchTerm, tableFilters]);
-
-  const onClearFilter = (columnId: string) => {
-    setTableFilters((oldFilters) => {
-      const newFilters = new Map(oldFilters);
-      newFilters.delete(columnId);
-      return newFilters;
-    });
-  };
-
-  const onToggleFilter = (columnId: string, filters: Set<string>) => {
-    setTableFilters((oldFilters) => {
-      const newFilters = new Map(oldFilters);
-      newFilters.set(columnId, filters);
-      return newFilters;
-    });
-  };
 
   const rowGridTemplateColumns = cellsConfiguration
     .map((config) => config.gridWidth)

--- a/src/hooks/useTableFilters.ts
+++ b/src/hooks/useTableFilters.ts
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+
+const useTableFilters = () => {
+  const [tableFilters, setTableFilters] = useState(
+    new Map() as Map<string, Set<string>>, // ColumnID -> Set<Values to remove>
+  );
+
+  const onClearFilter = (columnId: string) => {
+    setTableFilters((oldFilters) => {
+      const newFilters = new Map(oldFilters);
+      newFilters.delete(columnId);
+      return newFilters;
+    });
+  };
+
+  const onToggleFilter = (columnId: string, filters: Set<string>) => {
+    setTableFilters((oldFilters) => {
+      const newFilters = new Map(oldFilters);
+      newFilters.set(columnId, filters);
+      return newFilters;
+    });
+  };
+
+  return { tableFilters, onClearFilter, onToggleFilter };
+};
+
+export default useTableFilters;


### PR DESCRIPTION
This is a part of #788 that I was most interested in and that I extracted out. I also used the new hook on the subtests page.

There should be no user-visible change.

This is a refactoring prerequisite to implementing the persisting of the table filters.

[main page on the production server](https://perf.compare/compare-results?baseRev=509ed8685f4554d84912f8b6aa6c14b2228b8065&baseRepo=try&newRev=0a64fa4522419b96e51143f656a94442f7339983&newRepo=try&framework=13) / [main page on the deploy preview ](https://deploy-preview-808--mozilla-perfcompare.netlify.app/compare-results?baseRev=509ed8685f4554d84912f8b6aa6c14b2228b8065&baseRepo=try&newRev=0a64fa4522419b96e51143f656a94442f7339983&newRepo=try&framework=13)
[subtests on production server](https://perf.compare/subtests-compare-results?baseRev=509ed8685f4554d84912f8b6aa6c14b2228b8065&baseRepo=try&newRev=0a64fa4522419b96e51143f656a94442f7339983&newRepo=try&framework=13&baseParentSignature=5131097&newParentSignature=5131097) / [subtests on the deploy preview](https://deploy-preview-808--mozilla-perfcompare.netlify.app/subtests-compare-results?baseRev=509ed8685f4554d84912f8b6aa6c14b2228b8065&baseRepo=try&newRev=0a64fa4522419b96e51143f656a94442f7339983&newRepo=try&framework=13&baseParentSignature=5131097&newParentSignature=5131097)