### PR TITLE
Persist column filters as URL parameters

### DIFF
--- a/src/__tests__/CompareResults/ResultsTable.test.tsx
+++ b/src/__tests__/CompareResults/ResultsTable.test.tsx
@@ -77,6 +77,20 @@ function summarizeVisibleRows() {
   return result;
 }
 
+function summarizeTableFiltersFromUrl() {
+  const searchParams = new URLSearchParams(window.location.search);
+  const result: Record<string, string[]> = {};
+  for (const [key, value] of searchParams) {
+    if (!key.startsWith('filter_')) {
+      continue;
+    }
+
+    const values = value.split(',');
+    result[key.slice('filter_'.length)] = values;
+  }
+  return result;
+}
+
 async function clickMenuItem(
   user: UserEvent,
   menuMatcher: string | RegExp,
@@ -158,6 +172,8 @@ describe('Results Table', () => {
       '  - Android, Improvement, Low',
     ]);
 
+    expect(summarizeTableFiltersFromUrl()).toEqual({});
+
     const user = userEvent.setup({ delay: null });
     await clickMenuItem(user, /Platform/, /Windows/);
     expect(summarizeVisibleRows()).toEqual([
@@ -166,6 +182,9 @@ describe('Results Table', () => {
       '  - Linux, Regression, Medium',
       '  - Android, Improvement, Low',
     ]);
+    expect(summarizeTableFiltersFromUrl()).toEqual({
+      platform: ['osx', 'linux', 'android'],
+    });
 
     await clickMenuItem(user, /Platform/, /Linux/);
     expect(summarizeVisibleRows()).toEqual([
@@ -173,6 +192,10 @@ describe('Results Table', () => {
       '  - OSX, Improvement, Low',
       '  - Android, Improvement, Low',
     ]);
+    expect(summarizeTableFiltersFromUrl()).toEqual({
+      platform: ['osx', 'android'],
+    });
+
     await clickMenuItem(user, /Platform/, /Linux/);
     expect(summarizeVisibleRows()).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
@@ -180,6 +203,9 @@ describe('Results Table', () => {
       '  - Linux, Regression, Medium',
       '  - Android, Improvement, Low',
     ]);
+    expect(summarizeTableFiltersFromUrl()).toEqual({
+      platform: ['osx', 'linux', 'android'],
+    });
 
     await clickMenuItem(user, /Platform/, 'Select all values');
     expect(summarizeVisibleRows()).toEqual([
@@ -190,6 +216,7 @@ describe('Results Table', () => {
       '  - Windows, -, -',
       '  - Android, Improvement, Low',
     ]);
+    expect(summarizeTableFiltersFromUrl()).toEqual({});
 
     await clickMenuItem(user, /Platform/, /OSX/);
     expect(summarizeVisibleRows()).toEqual([
@@ -199,6 +226,9 @@ describe('Results Table', () => {
       '  - Windows, -, -',
       '  - Android, Improvement, Low',
     ]);
+    expect(summarizeTableFiltersFromUrl()).toEqual({
+      platform: ['windows', 'linux', 'android'],
+    });
 
     await clickMenuItem(user, /Platform/, /Android/);
     expect(summarizeVisibleRows()).toEqual([
@@ -207,12 +237,18 @@ describe('Results Table', () => {
       '  - Windows, -, High',
       '  - Windows, -, -',
     ]);
+    expect(summarizeTableFiltersFromUrl()).toEqual({
+      platform: ['windows', 'linux'],
+    });
 
     await clickMenuItem(user, /Platform/, /Select only.*Android/);
     expect(summarizeVisibleRows()).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
       '  - Android, Improvement, Low',
     ]);
+    expect(summarizeTableFiltersFromUrl()).toEqual({
+      platform: ['android'],
+    });
   });
 
   it('should filter on the Status column', async () => {
@@ -227,6 +263,7 @@ describe('Results Table', () => {
       '  - Windows, -, High',
       '  - Windows, -, -',
     ]);
+    expect(summarizeTableFiltersFromUrl()).toEqual({});
 
     const user = userEvent.setup({ delay: null });
     await clickMenuItem(user, /Status/, /No changes/);
@@ -235,6 +272,9 @@ describe('Results Table', () => {
       '  - OSX, Improvement, Low',
       '  - Linux, Regression, Medium',
     ]);
+    expect(summarizeTableFiltersFromUrl()).toEqual({
+      status: ['improvement', 'regression'],
+    });
 
     await clickMenuItem(user, /Status/, /Select all values/);
     await clickMenuItem(user, /Status/, /Improvement/);
@@ -244,6 +284,9 @@ describe('Results Table', () => {
       '  - Windows, -, High',
       '  - Windows, -, -',
     ]);
+    expect(summarizeTableFiltersFromUrl()).toEqual({
+      status: ['none', 'regression'],
+    });
 
     await clickMenuItem(user, /Status/, /Regression/);
     expect(summarizeVisibleRows()).toEqual([
@@ -251,12 +294,18 @@ describe('Results Table', () => {
       '  - Windows, -, High',
       '  - Windows, -, -',
     ]);
+    expect(summarizeTableFiltersFromUrl()).toEqual({
+      status: ['none'],
+    });
 
     await clickMenuItem(user, /Status/, /Select only.*Regression/);
     expect(summarizeVisibleRows()).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
       '  - Linux, Regression, Medium',
     ]);
+    expect(summarizeTableFiltersFromUrl()).toEqual({
+      status: ['regression'],
+    });
   });
 
   it('should filter on the Confidence column', async () => {
@@ -271,6 +320,7 @@ describe('Results Table', () => {
       '  - Windows, -, High',
       '  - Windows, -, -',
     ]);
+    expect(summarizeTableFiltersFromUrl()).toEqual({});
 
     const user = userEvent.setup({ delay: null });
     await clickMenuItem(user, /Confidence/, /Low/);
@@ -280,6 +330,9 @@ describe('Results Table', () => {
       '  - Windows, -, High',
       '  - Windows, -, -',
     ]);
+    expect(summarizeTableFiltersFromUrl()).toEqual({
+      confidence: ['none', 'medium', 'high'],
+    });
 
     await clickMenuItem(user, /Confidence/, /High/);
     expect(summarizeVisibleRows()).toEqual([
@@ -287,12 +340,18 @@ describe('Results Table', () => {
       '  - Linux, Regression, Medium',
       '  - Windows, -, -',
     ]);
+    expect(summarizeTableFiltersFromUrl()).toEqual({
+      confidence: ['none', 'medium'],
+    });
 
     await clickMenuItem(user, /Confidence/, /Medium/);
     expect(summarizeVisibleRows()).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
       '  - Windows, -, -',
     ]);
+    expect(summarizeTableFiltersFromUrl()).toEqual({
+      confidence: ['none'],
+    });
 
     await clickMenuItem(user, /Confidence/, /Select all values/);
     expect(summarizeVisibleRows()).toEqual([
@@ -302,6 +361,7 @@ describe('Results Table', () => {
       '  - Windows, -, High',
       '  - Windows, -, -',
     ]);
+    expect(summarizeTableFiltersFromUrl()).toEqual({});
 
     await clickMenuItem(user, /Confidence/, /No value/);
     expect(summarizeVisibleRows()).toEqual([
@@ -310,11 +370,17 @@ describe('Results Table', () => {
       '  - Linux, Regression, Medium',
       '  - Windows, -, High',
     ]);
+    expect(summarizeTableFiltersFromUrl()).toEqual({
+      confidence: ['low', 'medium', 'high'],
+    });
 
     await clickMenuItem(user, /Confidence/, /Select only.*High/);
     expect(summarizeVisibleRows()).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
       '  - Windows, -, High',
     ]);
+    expect(summarizeTableFiltersFromUrl()).toEqual({
+      confidence: ['high'],
+    });
   });
 });

--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -130,7 +130,8 @@ export default function ResultsTable() {
 
   // This is our custom hook that manages table filters
   // and provides methods for clearing and toggling them.
-  const { tableFilters, onClearFilter, onToggleFilter } = useTableFilters();
+  const { tableFilters, onClearFilter, onToggleFilter } =
+    useTableFilters(cellsConfiguration);
 
   const initialSearchTerm = rawSearchParams.get('search') ?? '';
   const [searchTerm, setSearchTerm] = useState(initialSearchTerm);

--- a/src/components/CompareResults/SubtestsResults/SubtestsResultsTable.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsResultsTable.tsx
@@ -186,7 +186,8 @@ function SubtestsResultsTable({
 }: ResultsTableProps) {
   // This is our custom hook that manages table filters
   // and provides methods for clearing and toggling them.
-  const { tableFilters, onClearFilter, onToggleFilter } = useTableFilters();
+  const { tableFilters, onClearFilter, onToggleFilter } =
+    useTableFilters(cellsConfiguration);
 
   const processedResults = useMemo(() => {
     const filteredResults = filterResults(

--- a/src/hooks/useTableFilters.ts
+++ b/src/hooks/useTableFilters.ts
@@ -1,11 +1,35 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+
+import useRawSearchParams from './useRawSearchParams';
 
 const useTableFilters = () => {
+  // This is our custom hook that updates the search params without a rerender.
+  const [rawSearchParams, updateRawSearchParams] = useRawSearchParams();
+
   const [tableFilters, setTableFilters] = useState(
     new Map() as Map<string, Set<string>>, // ColumnID -> Set<Values to remove>
   );
 
+  useMemo(() => {
+    const filters = Array.from(rawSearchParams.entries())
+      .filter(([key]) => key.startsWith('filter'))
+      .reduce((accumulator: Map<string, Set<string>>, [key, value]) => {
+        const columnId = key.split('_')[1];
+        if (!accumulator.has(columnId)) {
+          accumulator.set(columnId, new Set());
+        }
+        const valuesArray = value.split(',').map((item) => item.trim());
+        valuesArray.forEach((item) => accumulator.get(columnId)?.add(item));
+        return accumulator;
+      }, new Map<string, Set<string>>());
+
+    setTableFilters(filters);
+  }, [rawSearchParams]);
+
   const onClearFilter = (columnId: string) => {
+    rawSearchParams.delete(`filter_${columnId}`);
+    updateRawSearchParams(rawSearchParams);
+
     setTableFilters((oldFilters) => {
       const newFilters = new Map(oldFilters);
       newFilters.delete(columnId);
@@ -14,6 +38,13 @@ const useTableFilters = () => {
   };
 
   const onToggleFilter = (columnId: string, filters: Set<string>) => {
+    if (filters.size > 0) {
+      rawSearchParams.set(`filter_${columnId}`, Array.from(filters).join(','));
+    } else {
+      rawSearchParams.delete(`filter_${columnId}`);
+    }
+    updateRawSearchParams(rawSearchParams);
+
     setTableFilters((oldFilters) => {
       const newFilters = new Map(oldFilters);
       newFilters.set(columnId, filters);

--- a/src/hooks/useTableFilters.ts
+++ b/src/hooks/useTableFilters.ts
@@ -6,11 +6,45 @@ import type {
 } from '../types/types';
 import useRawSearchParams from './useRawSearchParams';
 
+// This hook handles the state that handles table filtering, and also takes care
+// of handling the URL parameters that mirror this state.
+// Currently the state contains the _unselected_ items (the default is that
+// they're all selected), while the URL contains the _selected_ items because it
+// makes more sense to the user.
+//
+// In the URL:
+// * no column indication means the default (that is all values are selected)
+// * a column indication with comma-delimited values will select these values
+//   (therefore the values not specified here will be added to the state).
+// * a column indication with an empty value will unselect everything (all
+//   possible values will be added to the state).
+//
+// For example:
+// * no "filter_confidence" means all values for confidence are shown.
+// * "filter_confidence=medium,high" means that "none" and "low" will be added
+//   to the state, and the lines with confidence values "medium" and "high" are
+//   displayed.
+// * "filter_confidence=" means that no line will be displayed, which isn't
+//   super useful actually (but is supported).
+//
+// In the future we'd like the state to contains the selected items instead.
+
 const useTableFilters = (cellsConfiguration: CompareResultsTableConfig) => {
   const columnIdToConfiguration: Map<string, CompareResultsTableCell> = useMemo(
     () => new Map(cellsConfiguration.map((val) => [val.key, val])),
     [cellsConfiguration],
   );
+
+  const filterValuesBySet = (
+    values: Array<{ key: string }>,
+    excludedKeys: Set<string>,
+  ) => {
+    // Note: in the future it would be more idiomatic to use Set.difference,
+    // but it's not widely available enough at the time of writing this.
+    return values
+      .filter(({ key }) => !excludedKeys.has(key))
+      .map(({ key }) => key);
+  };
 
   // This is our custom hook that updates the search params without a rerender.
   const [rawSearchParams, updateRawSearchParams] = useRawSearchParams();
@@ -32,9 +66,18 @@ const useTableFilters = (cellsConfiguration: CompareResultsTableConfig) => {
         continue;
       }
 
-      const configuredValues = paramValue.split(',').map((item) => item.trim());
+      const configuredValuesSet = new Set(
+        paramValue.split(',').map((item) => item.trim()),
+      );
+      // Now we need to compute which possible values are _not_ specified in the
+      // URL, that is we compute the difference. Remember that the state holds
+      // the unchecked values (currently).
+      const uncheckedValueKeys = filterValuesBySet(
+        cellConfiguration.possibleValues,
+        configuredValuesSet,
+      );
 
-      result.set(columnId, new Set(configuredValues));
+      result.set(columnId, new Set(uncheckedValueKeys));
     }
 
     return result;
@@ -54,8 +97,25 @@ const useTableFilters = (cellsConfiguration: CompareResultsTableConfig) => {
   };
 
   const onToggleFilter = (columnId: string, filters: Set<string>) => {
+    const cellConfiguration = columnIdToConfiguration.get(columnId);
+    if (!cellConfiguration || !cellConfiguration.filter) {
+      // The columnId passed as a parameter doesn't exist or isn't a
+      // filterable column, ignore it.
+      console.error(
+        "The user toggled a filter that's not available in the cellConfiguration, it's likely a bug.",
+      );
+      return;
+    }
+
     if (filters.size > 0) {
-      rawSearchParams.set(`filter_${columnId}`, Array.from(filters).join(','));
+      // We need to compute which values are not stored in the state. They are
+      // the values that should be present in the URL.
+      const checkedValueKeys = filterValuesBySet(
+        cellConfiguration.possibleValues,
+        filters,
+      );
+
+      rawSearchParams.set(`filter_${columnId}`, checkedValueKeys.join(','));
     } else {
       rawSearchParams.delete(`filter_${columnId}`);
     }

--- a/src/hooks/useTableFilters.ts
+++ b/src/hooks/useTableFilters.ts
@@ -1,8 +1,17 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 
+import type {
+  CompareResultsTableConfig,
+  CompareResultsTableCell,
+} from '../types/types';
 import useRawSearchParams from './useRawSearchParams';
 
-const useTableFilters = () => {
+const useTableFilters = (cellsConfiguration: CompareResultsTableConfig) => {
+  const columnIdToConfiguration: Map<string, CompareResultsTableCell> = useMemo(
+    () => new Map(cellsConfiguration.map((val) => [val.key, val])),
+    [cellsConfiguration],
+  );
+
   // This is our custom hook that updates the search params without a rerender.
   const [rawSearchParams, updateRawSearchParams] = useRawSearchParams();
 
@@ -16,6 +25,13 @@ const useTableFilters = () => {
       }
 
       const columnId = param.slice('filter_'.length);
+      const cellConfiguration = columnIdToConfiguration.get(columnId);
+      if (!cellConfiguration || !cellConfiguration.filter) {
+        // The columnId passed as a parameter doesn't exist or isn't a
+        // filterable column, ignore it.
+        continue;
+      }
+
       const configuredValues = paramValue.split(',').map((item) => item.trim());
 
       result.set(columnId, new Set(configuredValues));


### PR DESCRIPTION
This PR implements the persistence of the column filters as URL parameters.

Here are the individual commits:

1. Initial implementation by @ST-KO in #788 that I wanted to keep as is so that the authorship is preserved.
2. Use the cell configuration so that the values are sanitized, in case a user wants to pass invalid filter values
3. This reverses the logic: instead of persisting the unchecked values, this persists the checked value. It seemed more user-friendly if one user wanted to change the url themselves. Also I think we'll eventually change the state to hold the checked values instead of the unchecked values, so this is consistent with this future implementation.
4. A simple move of functions in a test file, because I didn't want to have it in the same commit as the test change.
5. Add some tests for the functionality.

It might be easier to look at them separately but also all together should work too because the feature is quite self-contained.

[JIRA ticket](https://mozilla-hub.atlassian.net/browse/PCF-495)

Some deploy previews:
[main page with a predefined filter on the platform](https://deploy-preview-810--mozilla-perfcompare.netlify.app/compare-results?baseRev=509ed8685f4554d84912f8b6aa6c14b2228b8065&baseRepo=try&newRev=0a64fa4522419b96e51143f656a94442f7339983&newRepo=try&framework=13&filter_platform=linux%2Candroid)
[subtests page with a predefined filter on the confidence](https://deploy-preview-810--mozilla-perfcompare.netlify.app/subtests-compare-results?baseRev=509ed8685f4554d84912f8b6aa6c14b2228b8065&baseRepo=try&newRev=0a64fa4522419b96e51143f656a94442f7339983&newRepo=try&framework=13&baseParentSignature=5131097&newParentSignature=5131097&filter_confidence=medium)