### PR TITLE
Fix the lack of space at the bottom of the results page

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -249,7 +249,7 @@ exports[`Results View The table should match snapshot and other elements should 
       </div>
     </div>
     <div
-      class="f1upmfeo fr2n4tx"
+      class="f75bkdv fr2n4tx"
       data-testid="table-header"
       role="row"
     >
@@ -418,7 +418,7 @@ exports[`Results View The table should match snapshot and other elements should 
           style="overflow-anchor: none;"
         >
           <div
-            class="f1d2zsj2"
+            class="f1k5y3nc"
             role="rowgroup"
           >
             <div
@@ -479,7 +479,7 @@ exports[`Results View The table should match snapshot and other elements should 
               </div>
             </div>
             <div
-              class="fcdpsbx"
+              class="fw0pvlu"
             >
               <div
                 class="revisionRow f19d5lu7 fp4ugv1 MuiBox-root css-1txhl5e"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -983,7 +983,7 @@ exports[`Results Table Should match snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="f1upmfeo fr2n4tx"
+                  class="f75bkdv fr2n4tx"
                   data-testid="table-header"
                   role="row"
                 >
@@ -1152,7 +1152,7 @@ exports[`Results Table Should match snapshot 1`] = `
                       style="overflow-anchor: none;"
                     >
                       <div
-                        class="f1d2zsj2"
+                        class="f1k5y3nc"
                         role="rowgroup"
                       >
                         <div
@@ -1213,7 +1213,7 @@ exports[`Results Table Should match snapshot 1`] = `
                           </div>
                         </div>
                         <div
-                          class="fcdpsbx"
+                          class="fw0pvlu"
                         >
                           <div
                             class="revisionRow f19d5lu7 fp4ugv1 MuiBox-root css-1txhl5e"
@@ -1885,7 +1885,7 @@ exports[`Results Table Should match snapshot 1`] = `
                       style="overflow-anchor: none;"
                     >
                       <div
-                        class="f1d2zsj2"
+                        class="f1k5y3nc"
                         role="rowgroup"
                       >
                         <div
@@ -1926,7 +1926,7 @@ exports[`Results Table Should match snapshot 1`] = `
                           </div>
                         </div>
                         <div
-                          class="fcdpsbx"
+                          class="fw0pvlu"
                         >
                           <div
                             class="revisionRow f19d5lu7 fp4ugv1 MuiBox-root css-1txhl5e"
@@ -2147,7 +2147,7 @@ exports[`Results Table Should match snapshot 1`] = `
 
 exports[`Results Table should render different blocks when rendering several revisions 1`] = `
 <div
-  class="f1d2zsj2"
+  class="f1k5y3nc"
   role="rowgroup"
 >
   <div
@@ -2199,7 +2199,7 @@ exports[`Results Table should render different blocks when rendering several rev
     </div>
   </div>
   <div
-    class="fcdpsbx"
+    class="fw0pvlu"
   >
     <a
       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways f897l9y css-1qhous5-MuiTypography-root-MuiLink-root"
@@ -2435,7 +2435,7 @@ exports[`Results Table should render different blocks when rendering several rev
     </div>
   </div>
   <div
-    class="fcdpsbx"
+    class="fw0pvlu"
   >
     <a
       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways f897l9y css-1qhous5-MuiTypography-root-MuiLink-root"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -1059,7 +1059,7 @@ exports[`Results View The table should match snapshot and other elements should 
       </div>
     </div>
     <div
-      class="f1upmfeo fr2n4tx"
+      class="f75bkdv fr2n4tx"
       data-testid="table-header"
       role="row"
     >
@@ -1228,7 +1228,7 @@ exports[`Results View The table should match snapshot and other elements should 
           style="overflow-anchor: none;"
         >
           <div
-            class="f1d2zsj2"
+            class="f1k5y3nc"
             role="rowgroup"
           >
             <div
@@ -1289,7 +1289,7 @@ exports[`Results View The table should match snapshot and other elements should 
               </div>
             </div>
             <div
-              class="fcdpsbx"
+              class="fw0pvlu"
             >
               <div
                 class="revisionRow f19d5lu7 fp4ugv1 MuiBox-root css-1txhl5e"

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -399,7 +399,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
               role="table"
             >
               <div
-                class="fkzbi14 fr2n4tx"
+                class="f1fd041n fr2n4tx"
                 data-testid="table-header"
                 role="row"
               >
@@ -1235,7 +1235,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
               role="table"
             >
               <div
-                class="fkzbi14 fr2n4tx"
+                class="f1fd041n fr2n4tx"
                 data-testid="table-header"
                 role="row"
               >

--- a/src/components/CompareResults/TableHeader.tsx
+++ b/src/components/CompareResults/TableHeader.tsx
@@ -156,6 +156,7 @@ function TableHeader({
       borderRadius: '4px',
       paddingBlock: Spacing.Small,
       marginTop: Spacing.Medium,
+      marginBottom: Spacing.Large,
       $nest: {
         '.cell': {
           borderBottom: 'none',

--- a/src/components/CompareResults/TableRevisionContent.tsx
+++ b/src/components/CompareResults/TableRevisionContent.tsx
@@ -9,12 +9,15 @@ import type { CompareResultsItem } from '../../types/state';
 
 // We're using typestyle styles on purpose, to avoid the performance impact of
 // MUI's sx prop for these numerous elements.
+// Also note that we're using paddings, not margins. Indeed Virtuoso can't
+// compute properly the heights of the elements if we're using margins, but
+// paddings work fine.
 const styles = {
   testBlock: style({
-    /* Note that this margin will be merged with the margin below */
-    marginTop: Spacing.xLarge,
+    /* Note that this padding will be added to the padding below */
+    paddingTop: Spacing.Small,
   }),
-  revisionBlock: style({ marginBottom: Spacing.Large }),
+  revisionBlock: style({ paddingBottom: Spacing.Large }),
 };
 
 function TableRevisionContent(props: Props) {


### PR DESCRIPTION
Fix [Bug 1933586](https://bugzilla.mozilla.org/show_bug.cgi?id=1933586) / JIRA [PCF-577](https://mozilla-hub.atlassian.net/browse/PCF-577).

The problem is outlined in this FAQ on Virtuoso website: https://virtuoso.dev/troubleshooting/#list-does-not-scroll-to-the-bottom--items-jump-around
The problem is that Virtuoso can't measure margins properly, so we have to replace them with paddings, where necessary (basically when margins make the shape of the item bigger).
And this leads to all sort of problems, because while margins of different elements can merge, paddings don't merge. So I had to adjust paddings and margins in a lot of different places.

Especially I changed the margin bottom for the TableHeader component, which applies also to the subtests. But fortunately this also makes the header on the subtests page closer to [what the figma design specifies](https://www.figma.com/design/LRV76asSVOULlsWbRNZYp0/PerfCompare?node-id=2984-38886&node-type=frame&m=dev), so I believe that's good.

There should be no visible change on the main results page besides the fact that when scrolling to the bottom there's now a good padding. The "no results found" component is also lower but I think it's reasonable (I can fix it if you want to).
On the subtests page only the table header's bottom margin should be changed.

Deploy previews:
* several revisions: [main branch](https://main--mozilla-perfcompare.netlify.app/compare-results?baseRev=d140333670bcd3103a668a5ec04ed438bb192368&baseRepo=mozilla-central&newRev=250be4ca3c669db9a397456402f68249aa15d8d5&newRepo=mozilla-central&newRev=c0157231377305c8d7c22e452beff7c43fe4e9d7&newRepo=mozilla-central&framework=13&search=speedo) / [deploy preview](https://deploy-preview-824--mozilla-perfcompare.netlify.app/compare-results?baseRev=d140333670bcd3103a668a5ec04ed438bb192368&baseRepo=mozilla-central&newRev=250be4ca3c669db9a397456402f68249aa15d8d5&newRepo=mozilla-central&newRev=c0157231377305c8d7c22e452beff7c43fe4e9d7&newRepo=mozilla-central&framework=13&search=speedo)
* one revision: [main branch](https://main--mozilla-perfcompare.netlify.app/compare-results?baseRev=d140333670bcd3103a668a5ec04ed438bb192368&baseRepo=mozilla-central&newRev=250be4ca3c669db9a397456402f68249aa15d8d5&newRepo=mozilla-central&newRev=c0157231377305c8d7c22e452beff7c43fe4e9d7&newRepo=mozilla-central&framework=13&search=speedo) / [deploy preview](https://deploy-preview-824--mozilla-perfcompare.netlify.app/compare-results?baseRev=d140333670bcd3103a668a5ec04ed438bb192368&baseRepo=mozilla-central&newRev=250be4ca3c669db9a397456402f68249aa15d8d5&newRepo=mozilla-central&newRev=c0157231377305c8d7c22e452beff7c43fe4e9d7&newRepo=mozilla-central&framework=13&search=speedo)
* subtests: [main branch](https://main--mozilla-perfcompare.netlify.app/subtests-compare-results?baseRev=d140333670bcd3103a668a5ec04ed438bb192368&baseRepo=mozilla-central&newRev=250be4ca3c669db9a397456402f68249aa15d8d5&newRepo=mozilla-central&framework=13&baseParentSignature=3424580&newParentSignature=3424580) / [deploy preview](https://deploy-preview-824--mozilla-perfcompare.netlify.app/subtests-compare-results?baseRev=d140333670bcd3103a668a5ec04ed438bb192368&baseRepo=mozilla-central&newRev=250be4ca3c669db9a397456402f68249aa15d8d5&newRepo=mozilla-central&framework=13&baseParentSignature=3424580&newParentSignature=3424580)

[PCF-577]: https://mozilla-hub.atlassian.net/browse/PCF-577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ