### PR TITLE
Add aria expanded to revision row expand button

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -734,6 +734,8 @@ exports[`Results View The table should match snapshot and other elements should 
                     data-testid="expand-revision-button"
                   >
                     <button
+                      aria-controls="revision-row-expandable"
+                      aria-expanded="false"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
                       title="expand this row"
@@ -958,6 +960,8 @@ exports[`Results View The table should match snapshot and other elements should 
                     data-testid="expand-revision-button"
                   >
                     <button
+                      aria-controls="revision-row-expandable"
+                      aria-expanded="false"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
                       title="expand this row"
@@ -1160,6 +1164,8 @@ exports[`Results View The table should match snapshot and other elements should 
                     data-testid="expand-revision-button"
                   >
                     <button
+                      aria-controls="revision-row-expandable"
+                      aria-expanded="false"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
                       title="expand this row"
@@ -1373,6 +1379,8 @@ exports[`Results View The table should match snapshot and other elements should 
                     data-testid="expand-revision-button"
                   >
                     <button
+                      aria-controls="revision-row-expandable"
+                      aria-expanded="false"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
                       title="expand this row"

--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -765,7 +765,7 @@ exports[`Results View The table should match snapshot and other elements should 
                     data-testid="expand-revision-button"
                   >
                     <button
-                      aria-controls=":r5:"
+                      aria-controls=":ra:"
                       aria-expanded="false"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
@@ -991,7 +991,7 @@ exports[`Results View The table should match snapshot and other elements should 
                     data-testid="expand-revision-button"
                   >
                     <button
-                      aria-controls=":r9:"
+                      aria-controls=":re:"
                       aria-expanded="false"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
@@ -1195,7 +1195,7 @@ exports[`Results View The table should match snapshot and other elements should 
                     data-testid="expand-revision-button"
                   >
                     <button
-                      aria-controls=":rd:"
+                      aria-controls=":ri:"
                       aria-expanded="false"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
@@ -1410,7 +1410,7 @@ exports[`Results View The table should match snapshot and other elements should 
                     data-testid="expand-revision-button"
                   >
                     <button
-                      aria-controls=":rh:"
+                      aria-controls=":rm:"
                       aria-expanded="false"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"

--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -734,7 +734,7 @@ exports[`Results View The table should match snapshot and other elements should 
                     data-testid="expand-revision-button"
                   >
                     <button
-                      aria-controls="revision-row-expandable"
+                      aria-controls=":r5:"
                       aria-expanded="false"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
@@ -960,7 +960,7 @@ exports[`Results View The table should match snapshot and other elements should 
                     data-testid="expand-revision-button"
                   >
                     <button
-                      aria-controls="revision-row-expandable"
+                      aria-controls=":r9:"
                       aria-expanded="false"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
@@ -1164,7 +1164,7 @@ exports[`Results View The table should match snapshot and other elements should 
                     data-testid="expand-revision-button"
                   >
                     <button
-                      aria-controls="revision-row-expandable"
+                      aria-controls=":rd:"
                       aria-expanded="false"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
@@ -1379,7 +1379,7 @@ exports[`Results View The table should match snapshot and other elements should 
                     data-testid="expand-revision-button"
                   >
                     <button
-                      aria-controls="revision-row-expandable"
+                      aria-controls=":rh:"
                       aria-expanded="false"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -1489,7 +1489,7 @@ exports[`Results Table Should match snapshot 1`] = `
                                 data-testid="expand-revision-button"
                               >
                                 <button
-                                  aria-controls=":r7:"
+                                  aria-controls=":rc:"
                                   aria-expanded="false"
                                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                                   tabindex="0"
@@ -1715,7 +1715,7 @@ exports[`Results Table Should match snapshot 1`] = `
                                 data-testid="expand-revision-button"
                               >
                                 <button
-                                  aria-controls=":rb:"
+                                  aria-controls=":rg:"
                                   aria-expanded="false"
                                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                                   tabindex="0"
@@ -1930,7 +1930,7 @@ exports[`Results Table Should match snapshot 1`] = `
                                 data-testid="expand-revision-button"
                               >
                                 <button
-                                  aria-controls=":rf:"
+                                  aria-controls=":rk:"
                                   aria-expanded="false"
                                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                                   tabindex="0"
@@ -2188,7 +2188,7 @@ exports[`Results Table Should match snapshot 1`] = `
                                 data-testid="expand-revision-button"
                               >
                                 <button
-                                  aria-controls=":rj:"
+                                  aria-controls=":ro:"
                                   aria-expanded="false"
                                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                                   tabindex="0"
@@ -2741,7 +2741,7 @@ exports[`Results Table should render different blocks when rendering several rev
           data-testid="expand-revision-button"
         >
           <button
-            aria-controls=":r15:"
+            aria-controls=":r1k:"
             aria-expanded="false"
             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
             tabindex="0"
@@ -2979,7 +2979,7 @@ exports[`Results Table should render different blocks when rendering several rev
           data-testid="expand-revision-button"
         >
           <button
-            aria-controls=":r19:"
+            aria-controls=":r1o:"
             aria-expanded="false"
             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
             tabindex="0"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -1458,6 +1458,8 @@ exports[`Results Table Should match snapshot 1`] = `
                                 data-testid="expand-revision-button"
                               >
                                 <button
+                                  aria-controls="revision-row-expandable"
+                                  aria-expanded="false"
                                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                                   tabindex="0"
                                   title="expand this row"
@@ -1682,6 +1684,8 @@ exports[`Results Table Should match snapshot 1`] = `
                                 data-testid="expand-revision-button"
                               >
                                 <button
+                                  aria-controls="revision-row-expandable"
+                                  aria-expanded="false"
                                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                                   tabindex="0"
                                   title="expand this row"
@@ -1895,6 +1899,8 @@ exports[`Results Table Should match snapshot 1`] = `
                                 data-testid="expand-revision-button"
                               >
                                 <button
+                                  aria-controls="revision-row-expandable"
+                                  aria-expanded="false"
                                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                                   tabindex="0"
                                   title="expand this row"
@@ -2150,6 +2156,8 @@ exports[`Results Table Should match snapshot 1`] = `
                                 data-testid="expand-revision-button"
                               >
                                 <button
+                                  aria-controls="revision-row-expandable"
+                                  aria-expanded="false"
                                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                                   tabindex="0"
                                   title="expand this row"
@@ -2700,6 +2708,8 @@ exports[`Results Table should render different blocks when rendering several rev
           data-testid="expand-revision-button"
         >
           <button
+            aria-controls="revision-row-expandable"
+            aria-expanded="false"
             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
             tabindex="0"
             title="expand this row"
@@ -2936,6 +2946,8 @@ exports[`Results Table should render different blocks when rendering several rev
           data-testid="expand-revision-button"
         >
           <button
+            aria-controls="revision-row-expandable"
+            aria-expanded="false"
             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
             tabindex="0"
             title="expand this row"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -1458,7 +1458,7 @@ exports[`Results Table Should match snapshot 1`] = `
                                 data-testid="expand-revision-button"
                               >
                                 <button
-                                  aria-controls="revision-row-expandable"
+                                  aria-controls=":r7:"
                                   aria-expanded="false"
                                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                                   tabindex="0"
@@ -1684,7 +1684,7 @@ exports[`Results Table Should match snapshot 1`] = `
                                 data-testid="expand-revision-button"
                               >
                                 <button
-                                  aria-controls="revision-row-expandable"
+                                  aria-controls=":rb:"
                                   aria-expanded="false"
                                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                                   tabindex="0"
@@ -1899,7 +1899,7 @@ exports[`Results Table Should match snapshot 1`] = `
                                 data-testid="expand-revision-button"
                               >
                                 <button
-                                  aria-controls="revision-row-expandable"
+                                  aria-controls=":rf:"
                                   aria-expanded="false"
                                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                                   tabindex="0"
@@ -2156,7 +2156,7 @@ exports[`Results Table Should match snapshot 1`] = `
                                 data-testid="expand-revision-button"
                               >
                                 <button
-                                  aria-controls="revision-row-expandable"
+                                  aria-controls=":rj:"
                                   aria-expanded="false"
                                   class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                                   tabindex="0"
@@ -2708,7 +2708,7 @@ exports[`Results Table should render different blocks when rendering several rev
           data-testid="expand-revision-button"
         >
           <button
-            aria-controls="revision-row-expandable"
+            aria-controls=":r15:"
             aria-expanded="false"
             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
             tabindex="0"
@@ -2946,7 +2946,7 @@ exports[`Results Table should render different blocks when rendering several rev
           data-testid="expand-revision-button"
         >
           <button
-            aria-controls="revision-row-expandable"
+            aria-controls=":r19:"
             aria-expanded="false"
             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
             tabindex="0"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Results View Should display Base, New and Common graphs with 1 value an
 <section
   aria-label="Revision Row Details"
   class="fgv9bhz"
-  id=":r3d:"
+  id=":r4g:"
 >
   <div
     class="fp3h4kr"
@@ -276,7 +276,7 @@ exports[`Results View Should display Base, New and Common graphs with replicates
 <section
   aria-label="Revision Row Details"
   class="fgv9bhz"
-  id=":r32:"
+  id=":r40:"
 >
   <div
     class="fp3h4kr"
@@ -548,7 +548,7 @@ exports[`Results View Should display Base, New and Common graphs with tooltips 1
 <section
   aria-label="Revision Row Details"
   class="fgv9bhz"
-  id=":r1l:"
+  id=":r24:"
 >
   <div
     class="fp3h4kr"
@@ -1581,7 +1581,7 @@ exports[`Results View The table should match snapshot and other elements should 
                     data-testid="expand-revision-button"
                   >
                     <button
-                      aria-controls=":r7:"
+                      aria-controls=":rc:"
                       aria-expanded="false"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
@@ -1807,7 +1807,7 @@ exports[`Results View The table should match snapshot and other elements should 
                     data-testid="expand-revision-button"
                   >
                     <button
-                      aria-controls=":rb:"
+                      aria-controls=":rg:"
                       aria-expanded="false"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
@@ -2011,7 +2011,7 @@ exports[`Results View The table should match snapshot and other elements should 
                     data-testid="expand-revision-button"
                   >
                     <button
-                      aria-controls=":rf:"
+                      aria-controls=":rk:"
                       aria-expanded="false"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
@@ -2226,7 +2226,7 @@ exports[`Results View The table should match snapshot and other elements should 
                     data-testid="expand-revision-button"
                   >
                     <button
-                      aria-controls=":rj:"
+                      aria-controls=":ro:"
                       aria-expanded="false"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -3,8 +3,8 @@
 exports[`Results View Should display Base, New and Common graphs with 1 value and replicates 1`] = `
 <section
   aria-label="Revision Row Details"
-  class="fgv9bhz MuiBox-root css-0"
-  id="revision-row-expandable"
+  class="fgv9bhz"
+  id=":r3d:"
 >
   <div
     class="fp3h4kr"
@@ -275,8 +275,8 @@ exports[`Results View Should display Base, New and Common graphs with 1 value an
 exports[`Results View Should display Base, New and Common graphs with replicates 1`] = `
 <section
   aria-label="Revision Row Details"
-  class="fgv9bhz MuiBox-root css-0"
-  id="revision-row-expandable"
+  class="fgv9bhz"
+  id=":r32:"
 >
   <div
     class="fp3h4kr"
@@ -547,8 +547,8 @@ exports[`Results View Should display Base, New and Common graphs with replicates
 exports[`Results View Should display Base, New and Common graphs with tooltips 1`] = `
 <section
   aria-label="Revision Row Details"
-  class="fgv9bhz MuiBox-root css-0"
-  id="revision-row-expandable"
+  class="fgv9bhz"
+  id=":r1l:"
 >
   <div
     class="fp3h4kr"
@@ -1550,7 +1550,7 @@ exports[`Results View The table should match snapshot and other elements should 
                     data-testid="expand-revision-button"
                   >
                     <button
-                      aria-controls="revision-row-expandable"
+                      aria-controls=":r7:"
                       aria-expanded="false"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
@@ -1776,7 +1776,7 @@ exports[`Results View The table should match snapshot and other elements should 
                     data-testid="expand-revision-button"
                   >
                     <button
-                      aria-controls="revision-row-expandable"
+                      aria-controls=":rb:"
                       aria-expanded="false"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
@@ -1980,7 +1980,7 @@ exports[`Results View The table should match snapshot and other elements should 
                     data-testid="expand-revision-button"
                   >
                     <button
-                      aria-controls="revision-row-expandable"
+                      aria-controls=":rf:"
                       aria-expanded="false"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
@@ -2195,7 +2195,7 @@ exports[`Results View The table should match snapshot and other elements should 
                     data-testid="expand-revision-button"
                   >
                     <button
-                      aria-controls="revision-row-expandable"
+                      aria-controls=":rj:"
                       aria-expanded="false"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Results View Should display Base, New and Common graphs with 1 value and replicates 1`] = `
-<div
-  aria-label="revision-row"
-  class="fgv9bhz"
+<section
+  aria-label="Revision Row Details"
+  class="fgv9bhz MuiBox-root css-0"
   id="revision-row-expandable"
 >
   <div
@@ -269,13 +269,13 @@ exports[`Results View Should display Base, New and Common graphs with 1 value an
       </div>
     </div>
   </div>
-</div>
+</section>
 `;
 
 exports[`Results View Should display Base, New and Common graphs with replicates 1`] = `
-<div
-  aria-label="revision-row"
-  class="fgv9bhz"
+<section
+  aria-label="Revision Row Details"
+  class="fgv9bhz MuiBox-root css-0"
   id="revision-row-expandable"
 >
   <div
@@ -541,13 +541,13 @@ exports[`Results View Should display Base, New and Common graphs with replicates
       </div>
     </div>
   </div>
-</div>
+</section>
 `;
 
 exports[`Results View Should display Base, New and Common graphs with tooltips 1`] = `
-<div
-  aria-label="revision-row"
-  class="fgv9bhz"
+<section
+  aria-label="Revision Row Details"
+  class="fgv9bhz MuiBox-root css-0"
   id="revision-row-expandable"
 >
   <div
@@ -813,7 +813,7 @@ exports[`Results View Should display Base, New and Common graphs with tooltips 1
       </div>
     </div>
   </div>
-</div>
+</section>
 `;
 
 exports[`Results View The table should match snapshot and other elements should be present in the page 1`] = `

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`Results View Should display Base, New and Common graphs with 1 value and replicates 1`] = `
 <div
+  aria-label="revision-row"
   class="fgv9bhz"
+  id="revision-row-expandable"
 >
   <div
     class="fp3h4kr"
@@ -272,7 +274,9 @@ exports[`Results View Should display Base, New and Common graphs with 1 value an
 
 exports[`Results View Should display Base, New and Common graphs with replicates 1`] = `
 <div
+  aria-label="revision-row"
   class="fgv9bhz"
+  id="revision-row-expandable"
 >
   <div
     class="fp3h4kr"
@@ -542,7 +546,9 @@ exports[`Results View Should display Base, New and Common graphs with replicates
 
 exports[`Results View Should display Base, New and Common graphs with tooltips 1`] = `
 <div
+  aria-label="revision-row"
   class="fgv9bhz"
+  id="revision-row-expandable"
 >
   <div
     class="fp3h4kr"
@@ -1544,6 +1550,8 @@ exports[`Results View The table should match snapshot and other elements should 
                     data-testid="expand-revision-button"
                   >
                     <button
+                      aria-controls="revision-row-expandable"
+                      aria-expanded="false"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
                       title="expand this row"
@@ -1768,6 +1776,8 @@ exports[`Results View The table should match snapshot and other elements should 
                     data-testid="expand-revision-button"
                   >
                     <button
+                      aria-controls="revision-row-expandable"
+                      aria-expanded="false"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
                       title="expand this row"
@@ -1970,6 +1980,8 @@ exports[`Results View The table should match snapshot and other elements should 
                     data-testid="expand-revision-button"
                   >
                     <button
+                      aria-controls="revision-row-expandable"
+                      aria-expanded="false"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
                       title="expand this row"
@@ -2183,6 +2195,8 @@ exports[`Results View The table should match snapshot and other elements should 
                     data-testid="expand-revision-button"
                   >
                     <button
+                      aria-controls="revision-row-expandable"
+                      aria-expanded="false"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
                       title="expand this row"

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -1900,7 +1900,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                           aria-invalid="false"
                           aria-label="Search by title, platform, revision or options"
                           class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-rg83rj-MuiInputBase-input-MuiOutlinedInput-input"
-                          id=":rl:"
+                          id=":r1h:"
                           placeholder="Search results"
                           type="text"
                           value=""

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -734,6 +734,8 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   role="cell"
                 >
                   <button
+                    aria-controls=":r3:"
+                    aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
                     title="expand this row"
@@ -903,6 +905,8 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   role="cell"
                 >
                   <button
+                    aria-controls=":r4:"
+                    aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
                     title="expand this row"
@@ -1072,6 +1076,8 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   role="cell"
                 >
                   <button
+                    aria-controls=":r5:"
+                    aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
                     title="expand this row"
@@ -1230,6 +1236,8 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   role="cell"
                 >
                   <button
+                    aria-controls=":r6:"
+                    aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
                     title="expand this row"
@@ -2336,6 +2344,8 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   role="cell"
                 >
                   <button
+                    aria-controls=":r1k:"
+                    aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
                     title="expand this row"
@@ -2505,6 +2515,8 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   role="cell"
                 >
                   <button
+                    aria-controls=":r1l:"
+                    aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
                     title="expand this row"
@@ -2674,6 +2686,8 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   role="cell"
                 >
                   <button
+                    aria-controls=":r1m:"
+                    aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
                     title="expand this row"
@@ -2832,6 +2846,8 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   role="cell"
                 >
                   <button
+                    aria-controls=":r1n:"
+                    aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
                     title="expand this row"

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsRevisionRow.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsRevisionRow.test.tsx.snap
@@ -139,6 +139,8 @@ exports[`SubtestsRevisionRow Component renders the component with correct data 1
         role="cell"
       >
         <button
+          aria-controls=":r0:"
+          aria-expanded="false"
           class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
           tabindex="0"
           title="expand this row"

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -417,6 +417,8 @@ function RevisionRow(props: RevisionRowProps) {
               }
               color='primary'
               size='small'
+              aria-expanded={expanded}
+              aria-controls='revision-row-expandable'
             >
               {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
             </IconButton>

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from 'react';
+import { useId, useState, type ReactNode } from 'react';
 
 import AppleIcon from '@mui/icons-material/Apple';
 import DragHandleIcon from '@mui/icons-material/DragHandle';
@@ -265,6 +265,7 @@ const getSubtestsCompareOverTimeLink = (result: CompareResultsItem) => {
 };
 
 function RevisionRow(props: RevisionRowProps) {
+  const id = useId();
   const { result, view, gridTemplateColumns } = props;
   const {
     platform,
@@ -418,14 +419,14 @@ function RevisionRow(props: RevisionRowProps) {
               color='primary'
               size='small'
               aria-expanded={expanded}
-              aria-controls='revision-row-expandable'
+              aria-controls={id}
             >
               {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
             </IconButton>
           </div>
         </div>
       </Box>
-      {expanded && <RevisionRowExpandable result={result} />}
+      {expanded && <RevisionRowExpandable id={id} result={result} />}
     </>
   );
 }

--- a/src/components/CompareResults/RevisionRowExpandable.tsx
+++ b/src/components/CompareResults/RevisionRowExpandable.tsx
@@ -1,3 +1,4 @@
+import { Box } from '@mui/material';
 import Divider from '@mui/material/Divider';
 import { style } from 'typestyle';
 
@@ -71,9 +72,10 @@ function RevisionRowExpandable(props: RevisionRowExpandableProps) {
   };
 
   return (
-    <div
+    <Box
       id='revision-row-expandable'
-      aria-label='revision-row'
+      aria-label='Revision Row Details'
+      component={'section'}
       className={`${styles.expandedRow}`}
     >
       <div className={`${styles.content}`}>
@@ -133,7 +135,7 @@ function RevisionRowExpandable(props: RevisionRowExpandableProps) {
           </div>
         )}
       </div>
-    </div>
+    </Box>
   );
 }
 

--- a/src/components/CompareResults/RevisionRowExpandable.tsx
+++ b/src/components/CompareResults/RevisionRowExpandable.tsx
@@ -1,4 +1,3 @@
-import { Box } from '@mui/material';
 import Divider from '@mui/material/Divider';
 import { style } from 'typestyle';
 
@@ -12,7 +11,8 @@ const strings = Strings.components.expandableRow;
 const { singleRun } = strings;
 
 function RevisionRowExpandable(props: RevisionRowExpandableProps) {
-  const { result } = props;
+  const { result, id } = props;
+
   const {
     platform,
     delta_percentage: deltaPercent,
@@ -72,10 +72,9 @@ function RevisionRowExpandable(props: RevisionRowExpandableProps) {
   };
 
   return (
-    <Box
-      id='revision-row-expandable'
+    <section
+      id={id}
       aria-label='Revision Row Details'
-      component={'section'}
       className={`${styles.expandedRow}`}
     >
       <div className={`${styles.content}`}>
@@ -135,12 +134,13 @@ function RevisionRowExpandable(props: RevisionRowExpandableProps) {
           </div>
         )}
       </div>
-    </Box>
+    </section>
   );
 }
 
 interface RevisionRowExpandableProps {
   result: CompareResultsItem;
+  id: string;
 }
 
 export default RevisionRowExpandable;

--- a/src/components/CompareResults/RevisionRowExpandable.tsx
+++ b/src/components/CompareResults/RevisionRowExpandable.tsx
@@ -71,7 +71,11 @@ function RevisionRowExpandable(props: RevisionRowExpandableProps) {
   };
 
   return (
-    <div className={`${styles.expandedRow}`}>
+    <div
+      id='revision-row-expandable'
+      aria-label='revision-row'
+      className={`${styles.expandedRow}`}
+    >
       <div className={`${styles.content}`}>
         <div className={`${styles.bottomSpace}`}>
           <b>{platform}</b> <br />

--- a/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
@@ -230,6 +230,8 @@ function SubtestsRevisionRow(props: RevisionRowProps) {
             color='primary'
             size='small'
             onClick={toggleIsExpanded}
+            aria-expanded={expanded}
+            aria-controls={id}
           >
             {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
           </IconButton>

--- a/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useId, useState } from 'react';
 
 import DragHandleIcon from '@mui/icons-material/DragHandle';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
@@ -122,6 +122,7 @@ function determineSign(baseMedianValue: number, newMedianValue: number) {
 }
 
 function SubtestsRevisionRow(props: RevisionRowProps) {
+  const id = useId();
   const { result, gridTemplateColumns } = props;
   const {
     test,
@@ -234,7 +235,7 @@ function SubtestsRevisionRow(props: RevisionRowProps) {
           </IconButton>
         </div>
       </Box>
-      {expanded && <RevisionRowExpandable result={result} />}
+      {expanded && <RevisionRowExpandable id={id} result={result} />}
     </>
   );
 }


### PR DESCRIPTION
[Bugzilla link](https://bugzilla.mozilla.org/show_bug.cgi?id=1935720)
[Bugzilla link 2](https://bugzilla.mozilla.org/show_bug.cgi?id=1935719)

[Deploy preview link](https://deploy-preview-826--mozilla-perfcompare.netlify.app/)

### Description
This PR improves the accessibility of the expand button for the revision row by adding proper ARIA attributes.
- Added `aria-expanded` to dynamically set to true or false based on the expanded state of the row.
- Added `aria-controls` that point to the `id` of the expandable section (`revision-row-expandable`)
- Changed the `div` being used for the expandable row to a `section`






