### PR TITLE
Fix break to revision edit panel layout

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -291,7 +291,7 @@ exports[`Results Table Should match snapshot 1`] = `
                           </div>
                         </div>
                         <div
-                          class="selectedRevision_fg76eil MuiBox-root css-0"
+                          class="selectedRevision_fd452xz MuiBox-root css-0"
                         >
                           <div
                             class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
@@ -553,7 +553,7 @@ exports[`Results Table Should match snapshot 1`] = `
                           </div>
                         </div>
                         <div
-                          class="selectedRevision_fg76eil MuiBox-root css-0"
+                          class="selectedRevision_fd452xz MuiBox-root css-0"
                         >
                           <div
                             class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"

--- a/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
@@ -560,7 +560,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
               </div>
             </div>
             <div
-              class="selectedRevision_fg76eil MuiBox-root css-0"
+              class="selectedRevision_fd452xz MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
@@ -1201,7 +1201,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
               </div>
             </div>
             <div
-              class="selectedRevision_fg76eil MuiBox-root css-0"
+              class="selectedRevision_fd452xz MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
@@ -1511,7 +1511,7 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
               </div>
             </div>
             <div
-              class="selectedRevision_fg76eil MuiBox-root css-0"
+              class="selectedRevision_fd452xz MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
@@ -2187,7 +2187,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
               </div>
             </div>
             <div
-              class="selectedRevision_fg76eil MuiBox-root css-0"
+              class="selectedRevision_fd452xz MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
@@ -2304,7 +2304,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
               </div>
             </div>
             <div
-              class="selectedRevision_fg76eil MuiBox-root css-0"
+              class="selectedRevision_fd452xz MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
@@ -2767,7 +2767,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
               </div>
             </div>
             <div
-              class="selectedRevision_fg76eil MuiBox-root css-0"
+              class="selectedRevision_fd452xz MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
@@ -3077,7 +3077,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
               </div>
             </div>
             <div
-              class="selectedRevision_fg76eil MuiBox-root css-0"
+              class="selectedRevision_fd452xz MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"

--- a/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
@@ -215,7 +215,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
               </div>
             </div>
             <div
-              class="selectedRevision_fg76eil MuiBox-root css-0"
+              class="selectedRevision_fd452xz MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
@@ -497,7 +497,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
               </div>
             </div>
             <div
-              class="selectedRevision_fg76eil MuiBox-root css-0"
+              class="selectedRevision_fd452xz MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
@@ -974,7 +974,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
               </div>
             </div>
             <div
-              class="selectedRevision_fg76eil MuiBox-root css-0"
+              class="selectedRevision_fd452xz MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
@@ -1449,7 +1449,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
               </div>
             </div>
             <div
-              class="selectedRevision_fg76eil MuiBox-root css-0"
+              class="selectedRevision_fd452xz MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
@@ -1731,7 +1731,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
               </div>
             </div>
             <div
-              class="selectedRevision_fg76eil MuiBox-root css-0"
+              class="selectedRevision_fd452xz MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
@@ -2083,7 +2083,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
               </div>
             </div>
             <div
-              class="selectedRevision_fg76eil MuiBox-root css-0"
+              class="selectedRevision_fd452xz MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
@@ -2365,7 +2365,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
               </div>
             </div>
             <div
-              class="selectedRevision_fg76eil MuiBox-root css-0"
+              class="selectedRevision_fd452xz MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
@@ -2848,7 +2848,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
               </div>
             </div>
             <div
-              class="selectedRevision_fg76eil MuiBox-root css-0"
+              class="selectedRevision_fd452xz MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
@@ -3225,7 +3225,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
               </div>
             </div>
             <div
-              class="selectedRevision_fg76eil MuiBox-root css-0"
+              class="selectedRevision_fd452xz MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"

--- a/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
@@ -1250,7 +1250,7 @@ exports[`With search parameters both search components are populated as expected
               </div>
             </div>
             <div
-              class="selectedRevision_fg76eil MuiBox-root css-0"
+              class="selectedRevision_fd452xz MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
@@ -1747,7 +1747,7 @@ exports[`With search parameters both search components are populated as expected
               </div>
             </div>
             <div
-              class="selectedRevision_fg76eil MuiBox-root css-0"
+              class="selectedRevision_fd452xz MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
@@ -2252,7 +2252,7 @@ exports[`With search parameters both search components are populated as expected
               </div>
             </div>
             <div
-              class="selectedRevision_fg76eil MuiBox-root css-0"
+              class="selectedRevision_fd452xz MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
@@ -2749,7 +2749,7 @@ exports[`With search parameters both search components are populated as expected
               </div>
             </div>
             <div
-              class="selectedRevision_fg76eil MuiBox-root css-0"
+              class="selectedRevision_fd452xz MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
@@ -3254,7 +3254,7 @@ exports[`With search parameters displays the default value for framework if the 
               </div>
             </div>
             <div
-              class="selectedRevision_fg76eil MuiBox-root css-0"
+              class="selectedRevision_fd452xz MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
@@ -3751,7 +3751,7 @@ exports[`With search parameters displays the default value for framework if the 
               </div>
             </div>
             <div
-              class="selectedRevision_fg76eil MuiBox-root css-0"
+              class="selectedRevision_fd452xz MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"

--- a/src/__tests__/Search/__snapshots__/SelectedRevision.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SelectedRevision.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`SelectedRevision should show the selected checked revisions once a resu
     </div>
   </div>
   <div
-    class="selectedRevision_fg76eil MuiBox-root css-0"
+    class="selectedRevision_fd452xz MuiBox-root css-0"
   >
     <div
       class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"

--- a/src/styles/SelectedRevsStyle.ts
+++ b/src/styles/SelectedRevsStyle.ts
@@ -54,7 +54,8 @@ export const SelectRevsStyles = (mode: string) => {
 
     selectedRevision: {
       display: 'flex',
-
+      alignItems: 'flex-start',
+      flexGrow: 1,
       minWidth: '0px',
       $nest: {
         '.search-revision-item-text': {
@@ -95,6 +96,7 @@ export const SelectRevsStyles = (mode: string) => {
             },
           },
         },
+
         button: {
           padding: 2,
           marginTop: -2,


### PR DESCRIPTION
[Local Link](http://localhost:3000/compare-results?baseRev=d140333670bcd3103a668a5ec04ed438bb192368&baseRepo=mozilla-central&newRev=250be4ca3c669db9a397456402f68249aa15d8d5&newRepo=mozilla-central&newRev=c0157231377305c8d7c22e452beff7c43fe4e9d7&newRepo=mozilla-central&framework=13&search=foo)

[Deploy link](https://deploy-preview-831--mozilla-perfcompare.netlify.app/compare-results?baseRev=d140333670bcd3103a668a5ec04ed438bb192368&baseRepo=mozilla-central&newRev=250be4ca3c669db9a397456402f68249aa15d8d5&newRepo=mozilla-central&newRev=c0157231377305c8d7c22e452beff7c43fe4e9d7&newRepo=mozilla-central&framework=13&search=foo)

Before
![before-lo](https://github.com/user-attachments/assets/8487a111-4c5e-4964-acb3-df801269d4a4)


Added `alignItems:flex-start` to the `selectedRevision` style. This was previously removed because we thought it was a default value and shouldn't be added 

Also added a `flex-grow:1` to stop smaller text to extend to the left.

After
![lo](https://github.com/user-attachments/assets/90064cfd-e46f-4c46-a57b-0e2b60c1b8ef)
