### PR TITLE
Add tooltips to revision column headers

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -257,146 +257,251 @@ exports[`Results View The table should match snapshot and other elements should 
         class="cell platform-header"
         role="columnheader"
       >
-        <button
-          aria-haspopup="true"
-          aria-label="Platform (Click to filter values)"
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-l63e0u-MuiButtonBase-root-MuiButton-root"
-          tabindex="0"
-          type="button"
+        <div
+          class="f1vwntit"
         >
-          Platform
-          <div
-            aria-label="4 items selected"
-            class="MuiBox-root css-18uhbjh"
+          <button
+            aria-haspopup="true"
+            aria-label="Platform (Click to filter values)"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-l63e0u-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
           >
-            (
-            4
-            )
-          </div>
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-            data-testid="KeyboardArrowDownIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+            Platform
+            <div
+              aria-label="4 items selected"
+              class="MuiBox-root css-18uhbjh"
+            >
+              (
+              4
+              )
+            </div>
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+              data-testid="KeyboardArrowDownIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+              />
+            </svg>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
             />
-          </svg>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </button>
+          </button>
+        </div>
       </div>
       <div
         class="cell base-header"
         role="columnheader"
       >
-        Base
+        <div
+          class="f1vwntit"
+        >
+          Base
+          <svg
+            aria-hidden="true"
+            aria-label="A summary of all values from Base runs using a median."
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+            data-mui-internal-clone-element="true"
+            data-testid="InfoOutlinedIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+            />
+          </svg>
+        </div>
       </div>
       <div
         class="cell comparisonSign-header"
         role="columnheader"
-      />
+      >
+        <div
+          class="f1vwntit"
+        />
+      </div>
       <div
         class="cell new-header"
         role="columnheader"
       >
-        New
+        <div
+          class="f1vwntit"
+        >
+          New
+          <svg
+            aria-hidden="true"
+            aria-label="A summary of all values from New runs using a median."
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+            data-mui-internal-clone-element="true"
+            data-testid="InfoOutlinedIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+            />
+          </svg>
+        </div>
       </div>
       <div
         class="cell status-header"
         role="columnheader"
       >
-        <button
-          aria-haspopup="true"
-          aria-label="Status (Click to filter values)"
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-l63e0u-MuiButtonBase-root-MuiButton-root"
-          tabindex="0"
-          type="button"
+        <div
+          class="f1vwntit"
         >
-          Status
-          <div
-            aria-label="3 items selected"
-            class="MuiBox-root css-18uhbjh"
+          <button
+            aria-haspopup="true"
+            aria-label="Status (Click to filter values)"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-l63e0u-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
           >
-            (
-            3
-            )
-          </div>
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-            data-testid="KeyboardArrowDownIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+            Status
+            <div
+              aria-label="3 items selected"
+              class="MuiBox-root css-18uhbjh"
+            >
+              (
+              3
+              )
+            </div>
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+              data-testid="KeyboardArrowDownIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+              />
+            </svg>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
             />
-          </svg>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </button>
+          </button>
+        </div>
       </div>
       <div
         class="cell delta-header"
         role="columnheader"
       >
-        Delta
+        <div
+          class="f1vwntit"
+        >
+          Delta
+          <svg
+            aria-hidden="true"
+            aria-label="The percentage differnce between the Base and New values"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+            data-mui-internal-clone-element="true"
+            data-testid="InfoOutlinedIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+            />
+          </svg>
+        </div>
       </div>
       <div
         class="cell confidence-header"
         role="columnheader"
       >
-        <button
-          aria-haspopup="true"
-          aria-label="Confidence (Click to filter values)"
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-l63e0u-MuiButtonBase-root-MuiButton-root"
-          tabindex="0"
-          type="button"
+        <div
+          class="f1vwntit"
         >
-          Confidence
-          <div
-            aria-label="4 items selected"
-            class="MuiBox-root css-18uhbjh"
+          <button
+            aria-haspopup="true"
+            aria-label="Confidence (Click to filter values)"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-l63e0u-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
           >
-            (
-            4
-            )
-          </div>
+            Confidence
+            <div
+              aria-label="4 items selected"
+              class="MuiBox-root css-18uhbjh"
+            >
+              (
+              4
+              )
+            </div>
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+              data-testid="KeyboardArrowDownIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+              />
+            </svg>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-            data-testid="KeyboardArrowDownIcon"
+            aria-label="Calculated using a Student's T-test comparison. Low is anything under a T value of 3, Medium is between 3 and 5, and High is anything higher than 5."
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+            data-mui-internal-clone-element="true"
+            data-testid="InfoOutlinedIcon"
             focusable="false"
             viewBox="0 0 24 24"
           >
             <path
-              d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+              d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
             />
           </svg>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </button>
+        </div>
       </div>
       <div
         class="cell runs-header"
         role="columnheader"
       >
-        Total Runs
+        <div
+          class="f1vwntit"
+        >
+          Total Runs
+          <svg
+            aria-hidden="true"
+            aria-label="The total number of tasks/jobs that ran for this metric."
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+            data-mui-internal-clone-element="true"
+            data-testid="InfoOutlinedIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+            />
+          </svg>
+        </div>
       </div>
       <div
         class="cell buttons-header"
         role="columnheader"
-      />
+      >
+        <div
+          class="f1vwntit"
+        />
+      </div>
       <div
         class="cell expand-header"
         role="columnheader"
-      />
+      >
+        <div
+          class="f1vwntit"
+        />
+      </div>
     </div>
   </div>
   <div

--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -433,6 +433,7 @@ exports[`Results View The table should match snapshot and other elements should 
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-g8z9fn-MuiTypography-root-MuiLink-root"
                     href="https://firefox-source-docs.mozilla.org/testing/perfdocs/talos.html#a11yr"
                     target="_blank"
+                    title="Link to suite documentation"
                   >
                     a11yr
                   </a>

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -1157,6 +1157,7 @@ exports[`Results Table Should match snapshot 1`] = `
                                 class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-g8z9fn-MuiTypography-root-MuiLink-root"
                                 href="https://firefox-source-docs.mozilla.org/testing/perfdocs/talos.html#a11yr"
                                 target="_blank"
+                                title="Link to suite documentation"
                               >
                                 a11yr
                               </a>
@@ -1890,6 +1891,7 @@ exports[`Results Table Should match snapshot 1`] = `
                                 class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-g8z9fn-MuiTypography-root-MuiLink-root"
                                 href="https://firefox-source-docs.mozilla.org/testing/perfdocs/talos.html#a11yr"
                                 target="_blank"
+                                title="Link to suite documentation"
                               >
                                 a11yr
                               </a>
@@ -2152,6 +2154,7 @@ exports[`Results Table should render different blocks when rendering several rev
           class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-g8z9fn-MuiTypography-root-MuiLink-root"
           href="https://firefox-source-docs.mozilla.org/testing/perfdocs/talos.html#a11yr"
           target="_blank"
+          title="Link to suite documentation"
         >
           a11yr
         </a>

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -981,146 +981,251 @@ exports[`Results Table Should match snapshot 1`] = `
                     class="cell platform-header"
                     role="columnheader"
                   >
-                    <button
-                      aria-haspopup="true"
-                      aria-label="Platform (Click to filter values)"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-l63e0u-MuiButtonBase-root-MuiButton-root"
-                      tabindex="0"
-                      type="button"
+                    <div
+                      class="f1vwntit"
                     >
-                      Platform
-                      <div
-                        aria-label="4 items selected"
-                        class="MuiBox-root css-18uhbjh"
+                      <button
+                        aria-haspopup="true"
+                        aria-label="Platform (Click to filter values)"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-l63e0u-MuiButtonBase-root-MuiButton-root"
+                        tabindex="0"
+                        type="button"
                       >
-                        (
-                        4
-                        )
-                      </div>
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                        data-testid="KeyboardArrowDownIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                        Platform
+                        <div
+                          aria-label="4 items selected"
+                          class="MuiBox-root css-18uhbjh"
+                        >
+                          (
+                          4
+                          )
+                        </div>
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                          data-testid="KeyboardArrowDownIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                         />
-                      </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </button>
+                      </button>
+                    </div>
                   </div>
                   <div
                     class="cell base-header"
                     role="columnheader"
                   >
-                    Base
+                    <div
+                      class="f1vwntit"
+                    >
+                      Base
+                      <svg
+                        aria-hidden="true"
+                        aria-label="A summary of all values from Base runs using a median."
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+                        data-mui-internal-clone-element="true"
+                        data-testid="InfoOutlinedIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+                        />
+                      </svg>
+                    </div>
                   </div>
                   <div
                     class="cell comparisonSign-header"
                     role="columnheader"
-                  />
+                  >
+                    <div
+                      class="f1vwntit"
+                    />
+                  </div>
                   <div
                     class="cell new-header"
                     role="columnheader"
                   >
-                    New
+                    <div
+                      class="f1vwntit"
+                    >
+                      New
+                      <svg
+                        aria-hidden="true"
+                        aria-label="A summary of all values from New runs using a median."
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+                        data-mui-internal-clone-element="true"
+                        data-testid="InfoOutlinedIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+                        />
+                      </svg>
+                    </div>
                   </div>
                   <div
                     class="cell status-header"
                     role="columnheader"
                   >
-                    <button
-                      aria-haspopup="true"
-                      aria-label="Status (Click to filter values)"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-l63e0u-MuiButtonBase-root-MuiButton-root"
-                      tabindex="0"
-                      type="button"
+                    <div
+                      class="f1vwntit"
                     >
-                      Status
-                      <div
-                        aria-label="3 items selected"
-                        class="MuiBox-root css-18uhbjh"
+                      <button
+                        aria-haspopup="true"
+                        aria-label="Status (Click to filter values)"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-l63e0u-MuiButtonBase-root-MuiButton-root"
+                        tabindex="0"
+                        type="button"
                       >
-                        (
-                        3
-                        )
-                      </div>
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                        data-testid="KeyboardArrowDownIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                        Status
+                        <div
+                          aria-label="3 items selected"
+                          class="MuiBox-root css-18uhbjh"
+                        >
+                          (
+                          3
+                          )
+                        </div>
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                          data-testid="KeyboardArrowDownIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                         />
-                      </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </button>
+                      </button>
+                    </div>
                   </div>
                   <div
                     class="cell delta-header"
                     role="columnheader"
                   >
-                    Delta
+                    <div
+                      class="f1vwntit"
+                    >
+                      Delta
+                      <svg
+                        aria-hidden="true"
+                        aria-label="The percentage differnce between the Base and New values"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+                        data-mui-internal-clone-element="true"
+                        data-testid="InfoOutlinedIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+                        />
+                      </svg>
+                    </div>
                   </div>
                   <div
                     class="cell confidence-header"
                     role="columnheader"
                   >
-                    <button
-                      aria-haspopup="true"
-                      aria-label="Confidence (Click to filter values)"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-l63e0u-MuiButtonBase-root-MuiButton-root"
-                      tabindex="0"
-                      type="button"
+                    <div
+                      class="f1vwntit"
                     >
-                      Confidence
-                      <div
-                        aria-label="4 items selected"
-                        class="MuiBox-root css-18uhbjh"
+                      <button
+                        aria-haspopup="true"
+                        aria-label="Confidence (Click to filter values)"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-l63e0u-MuiButtonBase-root-MuiButton-root"
+                        tabindex="0"
+                        type="button"
                       >
-                        (
-                        4
-                        )
-                      </div>
+                        Confidence
+                        <div
+                          aria-label="4 items selected"
+                          class="MuiBox-root css-18uhbjh"
+                        >
+                          (
+                          4
+                          )
+                        </div>
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                          data-testid="KeyboardArrowDownIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                        />
+                      </button>
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                        data-testid="KeyboardArrowDownIcon"
+                        aria-label="Calculated using a Student's T-test comparison. Low is anything under a T value of 3, Medium is between 3 and 5, and High is anything higher than 5."
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+                        data-mui-internal-clone-element="true"
+                        data-testid="InfoOutlinedIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
                       >
                         <path
-                          d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                          d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
                         />
                       </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </button>
+                    </div>
                   </div>
                   <div
                     class="cell runs-header"
                     role="columnheader"
                   >
-                    Total Runs
+                    <div
+                      class="f1vwntit"
+                    >
+                      Total Runs
+                      <svg
+                        aria-hidden="true"
+                        aria-label="The total number of tasks/jobs that ran for this metric."
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+                        data-mui-internal-clone-element="true"
+                        data-testid="InfoOutlinedIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+                        />
+                      </svg>
+                    </div>
                   </div>
                   <div
                     class="cell buttons-header"
                     role="columnheader"
-                  />
+                  >
+                    <div
+                      class="f1vwntit"
+                    />
+                  </div>
                   <div
                     class="cell expand-header"
                     role="columnheader"
-                  />
+                  >
+                    <div
+                      class="f1vwntit"
+                    />
+                  </div>
                 </div>
               </div>
               <div

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -1243,6 +1243,7 @@ exports[`Results View The table should match snapshot and other elements should 
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-g8z9fn-MuiTypography-root-MuiLink-root"
                     href="https://firefox-source-docs.mozilla.org/testing/perfdocs/talos.html#a11yr"
                     target="_blank"
+                    title="Link to suite documentation"
                   >
                     a11yr
                   </a>

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -1067,146 +1067,251 @@ exports[`Results View The table should match snapshot and other elements should 
         class="cell platform-header"
         role="columnheader"
       >
-        <button
-          aria-haspopup="true"
-          aria-label="Platform (Click to filter values)"
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-l63e0u-MuiButtonBase-root-MuiButton-root"
-          tabindex="0"
-          type="button"
+        <div
+          class="f1vwntit"
         >
-          Platform
-          <div
-            aria-label="4 items selected"
-            class="MuiBox-root css-18uhbjh"
+          <button
+            aria-haspopup="true"
+            aria-label="Platform (Click to filter values)"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-l63e0u-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
           >
-            (
-            4
-            )
-          </div>
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-            data-testid="KeyboardArrowDownIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+            Platform
+            <div
+              aria-label="4 items selected"
+              class="MuiBox-root css-18uhbjh"
+            >
+              (
+              4
+              )
+            </div>
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+              data-testid="KeyboardArrowDownIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+              />
+            </svg>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
             />
-          </svg>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </button>
+          </button>
+        </div>
       </div>
       <div
         class="cell base-header"
         role="columnheader"
       >
-        Base
+        <div
+          class="f1vwntit"
+        >
+          Base
+          <svg
+            aria-hidden="true"
+            aria-label="A summary of all values from Base runs using a median."
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+            data-mui-internal-clone-element="true"
+            data-testid="InfoOutlinedIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+            />
+          </svg>
+        </div>
       </div>
       <div
         class="cell comparisonSign-header"
         role="columnheader"
-      />
+      >
+        <div
+          class="f1vwntit"
+        />
+      </div>
       <div
         class="cell new-header"
         role="columnheader"
       >
-        New
+        <div
+          class="f1vwntit"
+        >
+          New
+          <svg
+            aria-hidden="true"
+            aria-label="A summary of all values from New runs using a median."
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+            data-mui-internal-clone-element="true"
+            data-testid="InfoOutlinedIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+            />
+          </svg>
+        </div>
       </div>
       <div
         class="cell status-header"
         role="columnheader"
       >
-        <button
-          aria-haspopup="true"
-          aria-label="Status (Click to filter values)"
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-l63e0u-MuiButtonBase-root-MuiButton-root"
-          tabindex="0"
-          type="button"
+        <div
+          class="f1vwntit"
         >
-          Status
-          <div
-            aria-label="3 items selected"
-            class="MuiBox-root css-18uhbjh"
+          <button
+            aria-haspopup="true"
+            aria-label="Status (Click to filter values)"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-l63e0u-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
           >
-            (
-            3
-            )
-          </div>
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-            data-testid="KeyboardArrowDownIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+            Status
+            <div
+              aria-label="3 items selected"
+              class="MuiBox-root css-18uhbjh"
+            >
+              (
+              3
+              )
+            </div>
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+              data-testid="KeyboardArrowDownIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+              />
+            </svg>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
             />
-          </svg>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </button>
+          </button>
+        </div>
       </div>
       <div
         class="cell delta-header"
         role="columnheader"
       >
-        Delta
+        <div
+          class="f1vwntit"
+        >
+          Delta
+          <svg
+            aria-hidden="true"
+            aria-label="The percentage differnce between the Base and New values"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+            data-mui-internal-clone-element="true"
+            data-testid="InfoOutlinedIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+            />
+          </svg>
+        </div>
       </div>
       <div
         class="cell confidence-header"
         role="columnheader"
       >
-        <button
-          aria-haspopup="true"
-          aria-label="Confidence (Click to filter values)"
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-l63e0u-MuiButtonBase-root-MuiButton-root"
-          tabindex="0"
-          type="button"
+        <div
+          class="f1vwntit"
         >
-          Confidence
-          <div
-            aria-label="4 items selected"
-            class="MuiBox-root css-18uhbjh"
+          <button
+            aria-haspopup="true"
+            aria-label="Confidence (Click to filter values)"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-l63e0u-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
           >
-            (
-            4
-            )
-          </div>
+            Confidence
+            <div
+              aria-label="4 items selected"
+              class="MuiBox-root css-18uhbjh"
+            >
+              (
+              4
+              )
+            </div>
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+              data-testid="KeyboardArrowDownIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+              />
+            </svg>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-            data-testid="KeyboardArrowDownIcon"
+            aria-label="Calculated using a Student's T-test comparison. Low is anything under a T value of 3, Medium is between 3 and 5, and High is anything higher than 5."
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+            data-mui-internal-clone-element="true"
+            data-testid="InfoOutlinedIcon"
             focusable="false"
             viewBox="0 0 24 24"
           >
             <path
-              d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+              d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
             />
           </svg>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </button>
+        </div>
       </div>
       <div
         class="cell runs-header"
         role="columnheader"
       >
-        Total Runs
+        <div
+          class="f1vwntit"
+        >
+          Total Runs
+          <svg
+            aria-hidden="true"
+            aria-label="The total number of tasks/jobs that ran for this metric."
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall dropdown-info-icon css-1mecf1h-MuiSvgIcon-root"
+            data-mui-internal-clone-element="true"
+            data-testid="InfoOutlinedIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
+            />
+          </svg>
+        </div>
       </div>
       <div
         class="cell buttons-header"
         role="columnheader"
-      />
+      >
+        <div
+          class="f1vwntit"
+        />
+      </div>
       <div
         class="cell expand-header"
         role="columnheader"
-      />
+      >
+        <div
+          class="f1vwntit"
+        />
+      </div>
     </div>
   </div>
   <div

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -407,116 +407,156 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   class="cell subtests-header"
                   role="columnheader"
                 >
-                  Subtests
+                  <div
+                    class="f1vwntit"
+                  >
+                    Subtests
+                  </div>
                 </div>
                 <div
                   class="cell base-header"
                   role="columnheader"
                 >
-                  Base
+                  <div
+                    class="f1vwntit"
+                  >
+                    Base
+                  </div>
                 </div>
                 <div
                   class="cell comparisonSign-header"
                   role="columnheader"
-                />
+                >
+                  <div
+                    class="f1vwntit"
+                  />
+                </div>
                 <div
                   class="cell new-header"
                   role="columnheader"
                 >
-                  New
+                  <div
+                    class="f1vwntit"
+                  >
+                    New
+                  </div>
                 </div>
                 <div
                   class="cell status-header"
                   role="columnheader"
                 >
-                  <button
-                    aria-haspopup="true"
-                    aria-label="Status (Click to filter values)"
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-l63e0u-MuiButtonBase-root-MuiButton-root"
-                    tabindex="0"
-                    type="button"
+                  <div
+                    class="f1vwntit"
                   >
-                    Status
-                    <div
-                      aria-label="3 items selected"
-                      class="MuiBox-root css-18uhbjh"
+                    <button
+                      aria-haspopup="true"
+                      aria-label="Status (Click to filter values)"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-l63e0u-MuiButtonBase-root-MuiButton-root"
+                      tabindex="0"
+                      type="button"
                     >
-                      (
-                      3
-                      )
-                    </div>
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                      data-testid="KeyboardArrowDownIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                      Status
+                      <div
+                        aria-label="3 items selected"
+                        class="MuiBox-root css-18uhbjh"
+                      >
+                        (
+                        3
+                        )
+                      </div>
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                        data-testid="KeyboardArrowDownIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                       />
-                    </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
-                  </button>
+                    </button>
+                  </div>
                 </div>
                 <div
                   class="cell delta-header"
                   role="columnheader"
                 >
-                  Delta
+                  <div
+                    class="f1vwntit"
+                  >
+                    Delta
+                  </div>
                 </div>
                 <div
                   class="cell confidence-header"
                   role="columnheader"
                 >
-                  <button
-                    aria-haspopup="true"
-                    aria-label="Confidence (Click to filter values)"
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-l63e0u-MuiButtonBase-root-MuiButton-root"
-                    tabindex="0"
-                    type="button"
+                  <div
+                    class="f1vwntit"
                   >
-                    Confidence
-                    <div
-                      aria-label="4 items selected"
-                      class="MuiBox-root css-18uhbjh"
+                    <button
+                      aria-haspopup="true"
+                      aria-label="Confidence (Click to filter values)"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-l63e0u-MuiButtonBase-root-MuiButton-root"
+                      tabindex="0"
+                      type="button"
                     >
-                      (
-                      4
-                      )
-                    </div>
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                      data-testid="KeyboardArrowDownIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                      Confidence
+                      <div
+                        aria-label="4 items selected"
+                        class="MuiBox-root css-18uhbjh"
+                      >
+                        (
+                        4
+                        )
+                      </div>
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                        data-testid="KeyboardArrowDownIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                       />
-                    </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
-                  </button>
+                    </button>
+                  </div>
                 </div>
                 <div
                   class="cell runs-header"
                   role="columnheader"
                 >
-                  Total Runs
+                  <div
+                    class="f1vwntit"
+                  >
+                    Total Runs
+                  </div>
                 </div>
                 <div
                   class="cell buttons-header"
                   role="columnheader"
-                />
+                >
+                  <div
+                    class="f1vwntit"
+                  />
+                </div>
                 <div
                   class="cell expand-header"
                   role="columnheader"
-                />
+                >
+                  <div
+                    class="f1vwntit"
+                  />
+                </div>
               </div>
               <div
                 class="revisionRow f15pv6go fp4ugv1 MuiBox-root css-14ka4hc"
@@ -1581,116 +1621,156 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   class="cell subtests-header"
                   role="columnheader"
                 >
-                  Subtests
+                  <div
+                    class="f1vwntit"
+                  >
+                    Subtests
+                  </div>
                 </div>
                 <div
                   class="cell base-header"
                   role="columnheader"
                 >
-                  Base
+                  <div
+                    class="f1vwntit"
+                  >
+                    Base
+                  </div>
                 </div>
                 <div
                   class="cell comparisonSign-header"
                   role="columnheader"
-                />
+                >
+                  <div
+                    class="f1vwntit"
+                  />
+                </div>
                 <div
                   class="cell new-header"
                   role="columnheader"
                 >
-                  New
+                  <div
+                    class="f1vwntit"
+                  >
+                    New
+                  </div>
                 </div>
                 <div
                   class="cell status-header"
                   role="columnheader"
                 >
-                  <button
-                    aria-haspopup="true"
-                    aria-label="Status (Click to filter values)"
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-l63e0u-MuiButtonBase-root-MuiButton-root"
-                    tabindex="0"
-                    type="button"
+                  <div
+                    class="f1vwntit"
                   >
-                    Status
-                    <div
-                      aria-label="3 items selected"
-                      class="MuiBox-root css-18uhbjh"
+                    <button
+                      aria-haspopup="true"
+                      aria-label="Status (Click to filter values)"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-l63e0u-MuiButtonBase-root-MuiButton-root"
+                      tabindex="0"
+                      type="button"
                     >
-                      (
-                      3
-                      )
-                    </div>
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                      data-testid="KeyboardArrowDownIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                      Status
+                      <div
+                        aria-label="3 items selected"
+                        class="MuiBox-root css-18uhbjh"
+                      >
+                        (
+                        3
+                        )
+                      </div>
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                        data-testid="KeyboardArrowDownIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                       />
-                    </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
-                  </button>
+                    </button>
+                  </div>
                 </div>
                 <div
                   class="cell delta-header"
                   role="columnheader"
                 >
-                  Delta
+                  <div
+                    class="f1vwntit"
+                  >
+                    Delta
+                  </div>
                 </div>
                 <div
                   class="cell confidence-header"
                   role="columnheader"
                 >
-                  <button
-                    aria-haspopup="true"
-                    aria-label="Confidence (Click to filter values)"
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-l63e0u-MuiButtonBase-root-MuiButton-root"
-                    tabindex="0"
-                    type="button"
+                  <div
+                    class="f1vwntit"
                   >
-                    Confidence
-                    <div
-                      aria-label="4 items selected"
-                      class="MuiBox-root css-18uhbjh"
+                    <button
+                      aria-haspopup="true"
+                      aria-label="Confidence (Click to filter values)"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-l63e0u-MuiButtonBase-root-MuiButton-root"
+                      tabindex="0"
+                      type="button"
                     >
-                      (
-                      4
-                      )
-                    </div>
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
-                      data-testid="KeyboardArrowDownIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                      Confidence
+                      <div
+                        aria-label="4 items selected"
+                        class="MuiBox-root css-18uhbjh"
+                      >
+                        (
+                        4
+                        )
+                      </div>
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-fuz6rv-MuiSvgIcon-root"
+                        data-testid="KeyboardArrowDownIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                       />
-                    </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
-                  </button>
+                    </button>
+                  </div>
                 </div>
                 <div
                   class="cell runs-header"
                   role="columnheader"
                 >
-                  Total Runs
+                  <div
+                    class="f1vwntit"
+                  >
+                    Total Runs
+                  </div>
                 </div>
                 <div
                   class="cell buttons-header"
                   role="columnheader"
-                />
+                >
+                  <div
+                    class="f1vwntit"
+                  />
+                </div>
                 <div
                   class="cell expand-header"
                   role="columnheader"
-                />
+                >
+                  <div
+                    class="f1vwntit"
+                  />
+                </div>
               </div>
               <div
                 class="revisionRow f15pv6go fp4ugv1 MuiBox-root css-14ka4hc"

--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -42,6 +42,8 @@ const cellsConfiguration: CompareResultsTableConfig = [
     name: 'Base',
     key: 'base',
     gridWidth: '1fr',
+    tooltip: true,
+    tooltipContent: 'A summary of all values from Base runs using a median.',
   },
   {
     key: 'comparisonSign',
@@ -51,8 +53,9 @@ const cellsConfiguration: CompareResultsTableConfig = [
   {
     name: 'New',
     key: 'new',
-
     gridWidth: '1fr',
+    tooltip: true,
+    tooltipContent: 'A summary of all values from New runs using a median.',
   },
   {
     name: 'Status',
@@ -80,6 +83,8 @@ const cellsConfiguration: CompareResultsTableConfig = [
     name: 'Delta',
     key: 'delta',
     gridWidth: '1fr',
+    tooltip: true,
+    tooltipContent: 'The percentage difference between the Base and New values',
   },
   {
     name: 'Confidence',
@@ -87,6 +92,9 @@ const cellsConfiguration: CompareResultsTableConfig = [
     filter: true,
     key: 'confidence',
     gridWidth: '1.5fr',
+    tooltip: true,
+    tooltipContent:
+      "Calculated using a Student's T-test comparison. Low is anything under a T value of 3, Medium is between 3 and 5, and High is anything higher than 5.",
     possibleValues: [
       { label: 'No value', key: 'none' },
       { label: 'Low', key: 'low' },
@@ -109,8 +117,9 @@ const cellsConfiguration: CompareResultsTableConfig = [
   {
     name: 'Total Runs',
     key: 'runs',
-
     gridWidth: '1fr',
+    tooltip: true,
+    tooltipContent: 'The total number of tasks/jobs that ran for this metric.',
   },
   // We use the real pixel value for the buttons, so that everything is better aligned.
   { key: 'buttons', gridWidth: `calc(3.5 * 34px)` }, // 2 or 3 buttons, so at least 3*34px, but give more so that it can "breathe"

--- a/src/components/CompareResults/TableHeader.tsx
+++ b/src/components/CompareResults/TableHeader.tsx
@@ -1,5 +1,6 @@
+import InfoIcon from '@mui/icons-material/InfoOutlined';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
-import { ListItemIcon, ListItemText } from '@mui/material';
+import { ListItemIcon, ListItemText, Tooltip } from '@mui/material';
 import Button from '@mui/material/Button';
 import Checkbox from '@mui/material/Checkbox';
 import Divider from '@mui/material/Divider';
@@ -193,6 +194,11 @@ function TableHeader({
       fontSize: '13px',
       lineHeight: '16px',
     }),
+    headerBox: style({
+      display: 'flex',
+      alignItems: 'center',
+      gap: Spacing.xSmall,
+    }),
   };
 
   return (
@@ -207,20 +213,32 @@ function TableHeader({
           className={`cell ${header.key}-header`}
           role='columnheader'
         >
-          {header.filter ? (
-            <FilterableColumn
-              possibleValues={header.possibleValues}
-              name={header.name}
-              columnId={header.key}
-              uncheckedValues={filters.get(header.key)}
-              onClear={() => onClearFilter(header.key)}
-              onToggle={(checkedValues) =>
-                onToggleFilter(header.key, checkedValues)
-              }
-            />
-          ) : (
-            header.name
-          )}
+          <div className={styles.headerBox}>
+            {header.filter ? (
+              <FilterableColumn
+                possibleValues={header.possibleValues}
+                name={header.name}
+                columnId={header.key}
+                uncheckedValues={filters.get(header.key)}
+                onClear={() => onClearFilter(header.key)}
+                onToggle={(checkedValues) =>
+                  onToggleFilter(header.key, checkedValues)
+                }
+              />
+            ) : (
+              header.name
+            )}
+            {header?.tooltip && (
+              <Tooltip
+                title={header.tooltipContent}
+                placement='top'
+                arrow
+                classes={{ tooltip: styles.typography }}
+              >
+                <InfoIcon fontSize='small' className='dropdown-info-icon' />
+              </Tooltip>
+            )}
+          </div>
         </div>
       ))}
     </div>

--- a/src/components/CompareResults/TestHeader.tsx
+++ b/src/components/CompareResults/TestHeader.tsx
@@ -79,6 +79,7 @@ function createTitle(
           underline='hover'
           target='_blank'
           href={docsURL}
+          title='Link to suite documentation'
         >
           {result.suite}
         </Link>

--- a/src/components/CompareResults/TestHeader.tsx
+++ b/src/components/CompareResults/TestHeader.tsx
@@ -2,9 +2,11 @@ import { Link } from '@mui/material';
 import { style } from 'typestyle';
 
 import LinkToRevision from './LinkToRevision';
+import { Strings } from '../../resources/Strings';
 import { Colors, Spacing } from '../../styles';
 import type { CompareResultsItem } from '../../types/state';
 import { getDocsURL } from '../../utils/helpers';
+
 
 const styles = {
   revisionHeader: style({
@@ -79,7 +81,7 @@ function createTitle(
           underline='hover'
           target='_blank'
           href={docsURL}
-          title='Link to suite documentation'
+          title={Strings.components.revisionRow.title.suiteLink}
         >
           {result.suite}
         </Link>

--- a/src/resources/Strings.tsx
+++ b/src/resources/Strings.tsx
@@ -101,6 +101,7 @@ export const Strings = {
         jobLink: 'open treeherder view for',
         retriggerJobs: 'retrigger jobs',
         compareViewLink: 'open perfherder compare view for',
+        suiteLink:'Link to suite documentation  '
       },
     },
     expandableRow: {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -7,6 +7,8 @@ export type CompareResultsTableFilterableCell = {
   filter: true;
   possibleValues: Array<{ label: string; key: string }>;
   gridWidth?: string;
+  tooltip?: boolean;
+  tooltipContent?: string;
   // This function returns whether this result matches the value for this column.
   matchesFunction: (
     this: CompareResultsTableFilterableCell,
@@ -22,6 +24,8 @@ export type CompareResultsTableCell =
       key: string;
       disable?: boolean;
       gridWidth?: string;
+      tooltip?: boolean;
+      tooltipContent?: string;
     }
   | CompareResultsTableFilterableCell;
 


### PR DESCRIPTION
[Bugzilla link](https://bugzilla.mozilla.org/show_bug.cgi?id=1912026)

[Deploy link](url)

### Description

This PR adds a tooltip to the Revision Column header names to give users more description of what each columns do. The tooltip description was obtained from the bugzilla report.

Platform - No tooltip
Base - A summary of all values from Base runs using a median.
New- A summary of all values from New runs using a median.
Status- No tooltip
Delta- The percentage difference between the Base and New values
Confidence- Calculated using a Student's T-test comparison. Low is anything under a T value of 3, Medium is between 3 and 5, and High is anything higher than 5.
Total runs- The total number of tasks/jobs that ran for this metric.

Before screenshot

![tooltip-before](https://github.com/user-attachments/assets/028a53e7-9591-49db-997f-4db8ab6b437f)

After screenshot
![tooltip](https://github.com/user-attachments/assets/0b3997f7-1197-4541-a003-1d81479a9233)

A description is also added to the test name on hover. I used same text used for the `aria-label`

![tooltipname](https://github.com/user-attachments/assets/59603286-fd48-446e-8606-747626341d66)



