### PR TITLE
Small adjustments on the sort functionality

### DIFF
--- a/src/__tests__/CompareResults/SubtestsResultsView.test.tsx
+++ b/src/__tests__/CompareResults/SubtestsResultsView.test.tsx
@@ -209,7 +209,7 @@ describe('SubtestsResultsView Component Tests', () => {
       // Initial view (alphabetical ordered, even if "sort by subtests" isn't specified
       expect(summarizeVisibleRows()).toEqual([
         'dhtml.html: 1.14 %, Low',
-        'improvement.html: 1.44 %, Low',
+        'improvement.html: -1.44 %, Low',
         'regression.html: 1.04 %, High',
         'tablemutation.html: 0.98 %, Low',
       ]);
@@ -225,7 +225,7 @@ describe('SubtestsResultsView Component Tests', () => {
         'tablemutation.html: 0.98 %, Low',
         'regression.html: 1.04 %, High',
         'dhtml.html: 1.14 %, Low',
-        'improvement.html: 1.44 %, Low',
+        'improvement.html: -1.44 %, Low',
       ]);
       // It should have the "ascending" SVG.
       expect(deltaButton).toMatchSnapshot();
@@ -235,7 +235,7 @@ describe('SubtestsResultsView Component Tests', () => {
       // Sort descending
       await user.click(deltaButton);
       expect(summarizeVisibleRows()).toEqual([
-        'improvement.html: 1.44 %, Low',
+        'improvement.html: -1.44 %, Low',
         'dhtml.html: 1.14 %, Low',
         'regression.html: 1.04 %, High',
         'tablemutation.html: 0.98 %, Low',
@@ -253,7 +253,7 @@ describe('SubtestsResultsView Component Tests', () => {
       expect(summarizeVisibleRows()).toEqual([
         'tablemutation.html: 0.98 %, Low',
         'dhtml.html: 1.14 %, Low',
-        'improvement.html: 1.44 %, Low',
+        'improvement.html: -1.44 %, Low',
         'regression.html: 1.04 %, High',
       ]);
       // It should have the "no sort" SVG.
@@ -268,7 +268,7 @@ describe('SubtestsResultsView Component Tests', () => {
       await user.click(subtestsButton);
       expect(summarizeVisibleRows()).toEqual([
         'dhtml.html: 1.14 %, Low',
-        'improvement.html: 1.44 %, Low',
+        'improvement.html: -1.44 %, Low',
         'regression.html: 1.04 %, High',
         'tablemutation.html: 0.98 %, Low',
       ]);
@@ -292,7 +292,7 @@ describe('SubtestsResultsView Component Tests', () => {
         'tablemutation.html: 0.98 %, Low',
         'regression.html: 1.04 %, High',
         'dhtml.html: 1.14 %, Low',
-        'improvement.html: 1.44 %, Low',
+        'improvement.html: -1.44 %, Low',
       ]);
       // It should have the "ascending" SVG.
       expect(screen.getByRole('button', { name: /Delta/ })).toMatchSnapshot();
@@ -305,7 +305,7 @@ describe('SubtestsResultsView Component Tests', () => {
         'tablemutation.html: 0.98 %, Low',
         'regression.html: 1.04 %, High',
         'dhtml.html: 1.14 %, Low',
-        'improvement.html: 1.44 %, Low',
+        'improvement.html: -1.44 %, Low',
       ]);
       // It should have the "ascending" SVG.
       expect(screen.getByRole('button', { name: /Delta/ })).toMatchSnapshot();
@@ -314,7 +314,7 @@ describe('SubtestsResultsView Component Tests', () => {
     it('initializes the sort from the URL at load time for a descending sort', async () => {
       await setupForSorting({ extraParameters: 'sort=delta|desc' });
       expect(summarizeVisibleRows()).toEqual([
-        'improvement.html: 1.44 %, Low',
+        'improvement.html: -1.44 %, Low',
         'dhtml.html: 1.14 %, Low',
         'regression.html: 1.04 %, High',
         'tablemutation.html: 0.98 %, Low',

--- a/src/__tests__/CompareResults/SubtestsResultsView.test.tsx
+++ b/src/__tests__/CompareResults/SubtestsResultsView.test.tsx
@@ -219,19 +219,6 @@ describe('SubtestsResultsView Component Tests', () => {
       const deltaButton = screen.getByRole('button', { name: /Delta/ });
       expect(deltaButton).toMatchSnapshot();
       expect(window.location.search).not.toContain('sort=');
-      // Sort ascending
-      await user.click(deltaButton);
-      expect(summarizeVisibleRows()).toEqual([
-        'tablemutation.html: 0.98 %, Low',
-        'regression.html: 1.04 %, High',
-        'dhtml.html: 1.14 %, Low',
-        'improvement.html: -1.44 %, Low',
-      ]);
-      // It should have the "ascending" SVG.
-      expect(deltaButton).toMatchSnapshot();
-      // It should be persisted in the URL
-      expectParameterToHaveValue('sort', 'delta|asc');
-
       // Sort descending
       await user.click(deltaButton);
       expect(summarizeVisibleRows()).toEqual([
@@ -245,39 +232,52 @@ describe('SubtestsResultsView Component Tests', () => {
       // It should be persisted in the URL
       expectParameterToHaveValue('sort', 'delta|desc');
 
-      // Sort by Confidence ascending
+      // Sort ascending
+      await user.click(deltaButton);
+      expect(summarizeVisibleRows()).toEqual([
+        'tablemutation.html: 0.98 %, Low',
+        'regression.html: 1.04 %, High',
+        'dhtml.html: 1.14 %, Low',
+        'improvement.html: -1.44 %, Low',
+      ]);
+      // It should have the "ascending" SVG.
+      expect(deltaButton).toMatchSnapshot();
+      // It should be persisted in the URL
+      expectParameterToHaveValue('sort', 'delta|asc');
+
+      // Sort by Confidence descending
       const confidenceButton = screen.getByRole('button', {
         name: /Confidence.*sort/,
       });
       await user.click(confidenceButton);
       expect(summarizeVisibleRows()).toEqual([
-        'tablemutation.html: 0.98 %, Low',
-        'dhtml.html: 1.14 %, Low',
-        'improvement.html: -1.44 %, Low',
         'regression.html: 1.04 %, High',
+        'improvement.html: -1.44 %, Low',
+        'dhtml.html: 1.14 %, Low',
+        'tablemutation.html: 0.98 %, Low',
       ]);
       // It should have the "no sort" SVG.
       expect(deltaButton).toMatchSnapshot();
-      // It should have the "ascending" SVG.
+      // It should have the "descending" SVG.
       expect(confidenceButton).toMatchSnapshot();
       // It should be persisted in the URL
-      expectParameterToHaveValue('sort', 'confidence|asc');
+      expectParameterToHaveValue('sort', 'confidence|desc');
 
-      // Sort by subtest name ascending
+      // Sort by subtest name descending
       const subtestsButton = screen.getByRole('button', { name: /Subtests/ });
       await user.click(subtestsButton);
       expect(summarizeVisibleRows()).toEqual([
-        'dhtml.html: 1.14 %, Low',
-        'improvement.html: -1.44 %, Low',
-        'regression.html: 1.04 %, High',
         'tablemutation.html: 0.98 %, Low',
+        'regression.html: 1.04 %, High',
+        'improvement.html: -1.44 %, Low',
+        'dhtml.html: 1.14 %, Low',
       ]);
       // It should have the "no sort" SVG.
       expect(confidenceButton).toMatchSnapshot();
-      // It should have the "ascending" SVG.
+      // It should have the "descending" SVG.
       expect(subtestsButton).toMatchSnapshot();
       // It should be persisted in the URL
-      expectParameterToHaveValue('sort', 'subtests|asc');
+      expectParameterToHaveValue('sort', 'subtests|desc');
 
       // Clickince twice more should reset the URL.
       await user.click(subtestsButton);
@@ -285,7 +285,7 @@ describe('SubtestsResultsView Component Tests', () => {
       expect(window.location.search).not.toContain('sort=');
     });
 
-    it('initializes the sort from the URL at load time for an ascending sort', async () => {
+    it('initializes the sort from the URL at load time for a ascending sort', async () => {
       await setupForSorting({ extraParameters: 'sort=delta|asc' });
       await screen.findByText('dhtml.html');
       expect(summarizeVisibleRows()).toEqual([
@@ -298,16 +298,16 @@ describe('SubtestsResultsView Component Tests', () => {
       expect(screen.getByRole('button', { name: /Delta/ })).toMatchSnapshot();
     });
 
-    it('initializes the sort from the URL at load time for an implicit ascending sort', async () => {
+    it('initializes the sort from the URL at load time for an implicit descending sort', async () => {
       await setupForSorting({ extraParameters: 'sort=delta' });
       await screen.findByText('dhtml.html');
       expect(summarizeVisibleRows()).toEqual([
-        'tablemutation.html: 0.98 %, Low',
-        'regression.html: 1.04 %, High',
-        'dhtml.html: 1.14 %, Low',
         'improvement.html: -1.44 %, Low',
+        'dhtml.html: 1.14 %, Low',
+        'regression.html: 1.04 %, High',
+        'tablemutation.html: 0.98 %, Low',
       ]);
-      // It should have the "ascending" SVG.
+      // It should have the "descending" SVG.
       expect(screen.getByRole('button', { name: /Delta/ })).toMatchSnapshot();
     });
 

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -1298,7 +1298,7 @@ exports[`SubtestsResultsView Component Tests table sorting can sort the table an
   type="button"
 >
   <svg
-    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-xzeo75-MuiSvgIcon-root"
+    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-1bpn2x6-MuiSvgIcon-root"
     data-testid="StraightIcon"
     focusable="false"
     role="img"
@@ -1308,7 +1308,7 @@ exports[`SubtestsResultsView Component Tests table sorting can sort the table an
       d="M11 6.83 9.41 8.41 8 7l4-4 4 4-1.41 1.41L13 6.83V21h-2z"
     />
     <title>
-      Sorted by Delta in ascending order
+      Sorted by Delta in descending order
     </title>
   </svg>
   Delta
@@ -1335,7 +1335,7 @@ exports[`SubtestsResultsView Component Tests table sorting can sort the table an
   type="button"
 >
   <svg
-    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-1bpn2x6-MuiSvgIcon-root"
+    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-xzeo75-MuiSvgIcon-root"
     data-testid="StraightIcon"
     focusable="false"
     role="img"
@@ -1345,7 +1345,7 @@ exports[`SubtestsResultsView Component Tests table sorting can sort the table an
       d="M11 6.83 9.41 8.41 8 7l4-4 4 4-1.41 1.41L13 6.83V21h-2z"
     />
     <title>
-      Sorted by Delta in descending order
+      Sorted by Delta in ascending order
     </title>
   </svg>
   Delta
@@ -1425,7 +1425,7 @@ exports[`SubtestsResultsView Component Tests table sorting can sort the table an
   type="button"
 >
   <svg
-    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-1mecf1h-MuiSvgIcon-root"
+    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-jmu928-MuiSvgIcon-root"
     data-testid="StraightIcon"
     focusable="false"
     role="img"
@@ -1435,7 +1435,7 @@ exports[`SubtestsResultsView Component Tests table sorting can sort the table an
       d="M11 6.83 9.41 8.41 8 7l4-4 4 4-1.41 1.41L13 6.83V21h-2z"
     />
     <title>
-      Sorted by Confidence in ascending order
+      Sorted by Confidence in descending order
     </title>
   </svg>
   <span
@@ -1497,7 +1497,7 @@ exports[`SubtestsResultsView Component Tests table sorting can sort the table an
   type="button"
 >
   <svg
-    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-xzeo75-MuiSvgIcon-root"
+    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-1bpn2x6-MuiSvgIcon-root"
     data-testid="StraightIcon"
     focusable="false"
     role="img"
@@ -1507,7 +1507,7 @@ exports[`SubtestsResultsView Component Tests table sorting can sort the table an
       d="M11 6.83 9.41 8.41 8 7l4-4 4 4-1.41 1.41L13 6.83V21h-2z"
     />
     <title>
-      Sorted by Subtests in ascending order
+      Sorted by Subtests in descending order
     </title>
   </svg>
   Subtests
@@ -1523,6 +1523,34 @@ exports[`SubtestsResultsView Component Tests table sorting can sort the table an
       />
     </span>
   </span>
+</button>
+`;
+
+exports[`SubtestsResultsView Component Tests table sorting initializes the sort from the URL at load time for a ascending sort 1`] = `
+<button
+  aria-label="Delta (Currently sorted by this column. Click to change)"
+  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-1awls4w-MuiButtonBase-root-MuiButton-root"
+  tabindex="0"
+  type="button"
+>
+  <svg
+    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-xzeo75-MuiSvgIcon-root"
+    data-testid="StraightIcon"
+    focusable="false"
+    role="img"
+    viewBox="0 0 24 24"
+  >
+    <path
+      d="M11 6.83 9.41 8.41 8 7l4-4 4 4-1.41 1.41L13 6.83V21h-2z"
+    />
+    <title>
+      Sorted by Delta in ascending order
+    </title>
+  </svg>
+  Delta
+  <span
+    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+  />
 </button>
 `;
 
@@ -1554,7 +1582,7 @@ exports[`SubtestsResultsView Component Tests table sorting initializes the sort 
 </button>
 `;
 
-exports[`SubtestsResultsView Component Tests table sorting initializes the sort from the URL at load time for an ascending sort 1`] = `
+exports[`SubtestsResultsView Component Tests table sorting initializes the sort from the URL at load time for an implicit descending sort 1`] = `
 <button
   aria-label="Delta (Currently sorted by this column. Click to change)"
   class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-1awls4w-MuiButtonBase-root-MuiButton-root"
@@ -1562,7 +1590,7 @@ exports[`SubtestsResultsView Component Tests table sorting initializes the sort 
   type="button"
 >
   <svg
-    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-xzeo75-MuiSvgIcon-root"
+    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-1bpn2x6-MuiSvgIcon-root"
     data-testid="StraightIcon"
     focusable="false"
     role="img"
@@ -1572,35 +1600,7 @@ exports[`SubtestsResultsView Component Tests table sorting initializes the sort 
       d="M11 6.83 9.41 8.41 8 7l4-4 4 4-1.41 1.41L13 6.83V21h-2z"
     />
     <title>
-      Sorted by Delta in ascending order
-    </title>
-  </svg>
-  Delta
-  <span
-    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-  />
-</button>
-`;
-
-exports[`SubtestsResultsView Component Tests table sorting initializes the sort from the URL at load time for an implicit ascending sort 1`] = `
-<button
-  aria-label="Delta (Currently sorted by this column. Click to change)"
-  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-1awls4w-MuiButtonBase-root-MuiButton-root"
-  tabindex="0"
-  type="button"
->
-  <svg
-    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-xzeo75-MuiSvgIcon-root"
-    data-testid="StraightIcon"
-    focusable="false"
-    role="img"
-    viewBox="0 0 24 24"
-  >
-    <path
-      d="M11 6.83 9.41 8.41 8 7l4-4 4 4-1.41 1.41L13 6.83V21h-2z"
-    />
-    <title>
-      Sorted by Delta in ascending order
+      Sorted by Delta in descending order
     </title>
   </svg>
   Delta

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -818,7 +818,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   role="cell"
                 >
                    
-                  1.44
+                  -1.44
                    %
                    
                 </div>
@@ -2421,7 +2421,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   role="cell"
                 >
                    
-                  1.44
+                  -1.44
                    %
                    
                 </div>

--- a/src/__tests__/utils/fixtures.ts
+++ b/src/__tests__/utils/fixtures.ts
@@ -2478,8 +2478,8 @@ const getTestData = () => {
       confidence_text: 'Low',
       graphs_link:
         'https://treeherder.mozilla.org/perfherder/graphs?highlightedRevisions=d775409d7c6a&highlightedRevisions=22f4cf67e8ad&series=mozilla-central%2C5c47b31c38f7214a07fad2e0d41fb901cdc18eae%2C1%2C1&timerange=604800',
-      delta_value: 13.03,
-      delta_percentage: 1.44,
+      delta_value: -13.03,
+      delta_percentage: -1.44,
       magnitude: 5.68,
       new_is_better: false,
       lower_is_better: true,

--- a/src/components/CompareResults/SubtestsResults/SubtestsResultsTable.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsResultsTable.tsx
@@ -97,7 +97,9 @@ const columnsConfiguration: CompareResultsTableConfig = [
     key: 'delta',
     gridWidth: '1fr',
     sortFunction(resultA, resultB) {
-      return resultA.delta_percentage - resultB.delta_percentage;
+      return (
+        Math.abs(resultA.delta_percentage) - Math.abs(resultB.delta_percentage)
+      );
     },
   },
   {

--- a/src/components/CompareResults/TableHeader.tsx
+++ b/src/components/CompareResults/TableHeader.tsx
@@ -199,14 +199,14 @@ function SortableColumnHeader({
   function onButtonClick() {
     let newSortDirection: typeof sortDirection;
     switch (sortDirection) {
-      case 'asc':
-        newSortDirection = 'desc';
-        break;
       case 'desc':
+        newSortDirection = 'asc';
+        break;
+      case 'asc':
         newSortDirection = null;
         break;
       default:
-        newSortDirection = 'asc';
+        newSortDirection = 'desc';
     }
 
     onToggle(newSortDirection);

--- a/src/hooks/useTableSort.ts
+++ b/src/hooks/useTableSort.ts
@@ -31,7 +31,7 @@ const useTableSort = (columnsConfiguration: CompareResultsTableConfig) => {
     }
 
     if (direction !== 'asc' && direction !== 'desc') {
-      return [columnId, 'asc'];
+      return [columnId, 'desc'];
     }
 
     return [columnId, direction];


### PR DESCRIPTION
This PR contains 2 simple commits:
1. For the "delta" column, this uses the absolute value instead of the signed value. Indeed it makes sense that when sorting descending (for example) the high negative values are also shown close to the top. This was an oversight from the initial implementation.
2. When clicking on the sorting button first, the direction is "descending" instead of "ascending", so that the highest values are shown at the top. I believe this is what the users are looking for usually, that's why it makes sense to get this with less clicks. Of course it's still possible to sort "ascending" with another click.

[deploy preview](https://deploy-preview-837--mozilla-perfcompare.netlify.app/subtests-compare-results?baseRev=d140333670bcd3103a668a5ec04ed438bb192368&baseRepo=mozilla-central&newRev=250be4ca3c669db9a397456402f68249aa15d8d5&newRepo=mozilla-central&framework=13&baseParentSignature=92557&newParentSignature=92557)

Tell me what you think @Carla-Moz !