### PR TITLE
Rename OSX to macOS to better reflect the newest naming for this platform

### DIFF
--- a/src/__tests__/CompareResults/ResultsTable.test.tsx
+++ b/src/__tests__/CompareResults/ResultsTable.test.tsx
@@ -218,7 +218,7 @@ describe('Results Table', () => {
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({});
 
-    await clickMenuItem(user, /Platform/, /OSX/);
+    await clickMenuItem(user, /Platform/, /macOS/);
     expect(summarizeVisibleRows()).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
       '  - Linux 18.04, Regression, Medium',

--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -25,7 +25,7 @@ const columnsConfiguration: CompareResultsTableConfig = [
     gridWidth: '2fr',
     possibleValues: [
       { label: 'Windows', key: 'windows' },
-      { label: 'OSX', key: 'osx' },
+      { label: 'macOS', key: 'osx' },
       { label: 'Linux', key: 'linux' },
       { label: 'Android', key: 'android' },
     ],

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -207,7 +207,7 @@ function determineSign(baseMedianValue: number, newMedianValue: number) {
 
 const platformIcons: Record<PlatformShortName, ReactNode> = {
   Linux: <LinuxIcon />,
-  OSX: <AppleIcon />,
+  macOS: <AppleIcon />,
   Windows: <WindowsIcon />,
   Android: <AndroidIcon />,
   Unspecified: '',

--- a/src/components/CompareResults/SubtestsResults/SubtestsRevisionHeader.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsRevisionHeader.tsx
@@ -133,7 +133,7 @@ function SubtestsRevisionHeader(props: SubtestsRevisionHeaderProps) {
   );
   const platformIcons: Record<PlatformShortName, ReactNode> = {
     Linux: <LinuxIcon />,
-    OSX: <AppleIcon />,
+    macOS: <AppleIcon />,
     Windows: <WindowsIcon />,
     Android: <AndroidIcon />,
     Unspecified: '',

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -121,7 +121,7 @@ export type SelectedRevisionsState = {
 
 export type PlatformShortName =
   | 'Linux'
-  | 'OSX'
+  | 'macOS'
   | 'Windows'
   | 'Android'
   | 'Unspecified';

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -8,7 +8,7 @@ export const getPlatformShortName = (
     platformName.toLowerCase().includes('osx') ||
     platformName.toLowerCase().includes('os x')
   )
-    return 'OSX';
+    return 'macOS';
   if (platformName.toLowerCase().includes('windows')) return 'Windows';
   if (platformName.toLowerCase().includes('android')) return 'Android';
   return 'Unspecified';


### PR DESCRIPTION
This mostly just changes the option in the menu, to be more consistent after @esanuandra 's changes in #816 :
![image](https://github.com/user-attachments/assets/f64713e6-2767-4853-8a4c-277fc29137de)

This will also change the displayed platform from `OSX` to `macOS` when a platform isn't in the platform map.

I was also considering changing these to `macOS` as well for consistency: https://github.com/mozilla/perfcompare/blob/bee2cf6332a400ed477ebf2e415150d309cb1d96/src/utils/platform.ts#L23-L26

What do you think?

[deploy preview](http://localhost:3000/compare-results?baseRev=d140333670bcd3103a668a5ec04ed438bb192368&baseRepo=mozilla-central&newRev=250be4ca3c669db9a397456402f68249aa15d8d5&newRepo=mozilla-central&framework=1&sort=delta%7Cdesc&search=speedome)