### PR TITLE
Add a copy icon to easily copy revisions

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -534,6 +534,7 @@ exports[`Results View The table should match snapshot and other elements should 
                   <button
                     aria-label="Copy the revision to the clipboard"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                    data-testid="copy-icon"
                     tabindex="0"
                     type="button"
                   >

--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -528,27 +528,31 @@ exports[`Results View The table should match snapshot and other elements should 
                 >
                   spam
                 </a>
-                <button
-                  aria-label="Copy the revision to the clipboard"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                  tabindex="0"
-                  type="button"
+                <span
+                  class="MuiBox-root css-79elbk"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                    data-testid="ContentCopyIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
+                  <button
+                    aria-label="Copy the revision to the clipboard"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                    tabindex="0"
+                    type="button"
                   >
-                    <path
-                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                      data-testid="ContentCopyIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                      />
+                    </svg>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                     />
-                  </svg>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
+                  </button>
+                </span>
               </div>
               <div
                 class="f1oxa67k"

--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -528,6 +528,27 @@ exports[`Results View The table should match snapshot and other elements should 
                 >
                   spam
                 </a>
+                <button
+                  aria-label="Copy the revision to the clipboard"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                    data-testid="ContentCopyIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
               </div>
               <div
                 class="f1oxa67k"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -310,6 +310,27 @@ exports[`Results Table Should match snapshot 1`] = `
                                 >
                                   coconut
                                 </a>
+                                <button
+                                  aria-label="Copy the revision to the clipboard"
+                                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                                  tabindex="0"
+                                  type="button"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                                    data-testid="ContentCopyIcon"
+                                    focusable="false"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <path
+                                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                                    />
+                                  </svg>
+                                  <span
+                                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                                  />
+                                </button>
                               </span>
                               <div
                                 class="info-caption"
@@ -572,6 +593,27 @@ exports[`Results Table Should match snapshot 1`] = `
                                 >
                                   coconut
                                 </a>
+                                <button
+                                  aria-label="Copy the revision to the clipboard"
+                                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                                  tabindex="0"
+                                  type="button"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                                    data-testid="ContentCopyIcon"
+                                    focusable="false"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <path
+                                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                                    />
+                                  </svg>
+                                  <span
+                                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                                  />
+                                </button>
                               </span>
                               <div
                                 class="info-caption"
@@ -1252,6 +1294,27 @@ exports[`Results Table Should match snapshot 1`] = `
                             >
                               spam
                             </a>
+                            <button
+                              aria-label="Copy the revision to the clipboard"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                              tabindex="0"
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                                data-testid="ContentCopyIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                                />
+                              </svg>
+                              <span
+                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                              />
+                            </button>
                           </div>
                           <div
                             class="f1oxa67k"
@@ -1992,6 +2055,27 @@ exports[`Results Table Should match snapshot 1`] = `
                             >
                               spam
                             </a>
+                            <button
+                              aria-label="Copy the revision to the clipboard"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                              tabindex="0"
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                                data-testid="ContentCopyIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                                />
+                              </svg>
+                              <span
+                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                              />
+                            </button>
                           </div>
                           <div
                             class="f1oxa67k"
@@ -2537,6 +2621,27 @@ exports[`Results Table should render different blocks when rendering several rev
     >
       spam
     </a>
+    <button
+      aria-label="Copy the revision to the clipboard"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+      tabindex="0"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+        data-testid="ContentCopyIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+        />
+      </svg>
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
     <div
       class="revisionRow fqyfrhr f1vh4jdk MuiBox-root css-1txhl5e"
       role="row"
@@ -2775,6 +2880,27 @@ exports[`Results Table should render different blocks when rendering several rev
     >
       devilrabbit
     </a>
+    <button
+      aria-label="Copy the revision to the clipboard"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+      tabindex="0"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+        data-testid="ContentCopyIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+        />
+      </svg>
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
     <div
       class="revisionRow fqyfrhr f1vh4jdk MuiBox-root css-1txhl5e"
       role="row"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -310,27 +310,31 @@ exports[`Results Table Should match snapshot 1`] = `
                                 >
                                   coconut
                                 </a>
-                                <button
-                                  aria-label="Copy the revision to the clipboard"
-                                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                                  tabindex="0"
-                                  type="button"
+                                <span
+                                  class="MuiBox-root css-79elbk"
                                 >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                                    data-testid="ContentCopyIcon"
-                                    focusable="false"
-                                    viewBox="0 0 24 24"
+                                  <button
+                                    aria-label="Copy the revision to the clipboard"
+                                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                                    tabindex="0"
+                                    type="button"
                                   >
-                                    <path
-                                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                                    <svg
+                                      aria-hidden="true"
+                                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                                      data-testid="ContentCopyIcon"
+                                      focusable="false"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                                      />
+                                    </svg>
+                                    <span
+                                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                                     />
-                                  </svg>
-                                  <span
-                                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                                  />
-                                </button>
+                                  </button>
+                                </span>
                               </span>
                               <div
                                 class="info-caption"
@@ -593,27 +597,31 @@ exports[`Results Table Should match snapshot 1`] = `
                                 >
                                   coconut
                                 </a>
-                                <button
-                                  aria-label="Copy the revision to the clipboard"
-                                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                                  tabindex="0"
-                                  type="button"
+                                <span
+                                  class="MuiBox-root css-79elbk"
                                 >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                                    data-testid="ContentCopyIcon"
-                                    focusable="false"
-                                    viewBox="0 0 24 24"
+                                  <button
+                                    aria-label="Copy the revision to the clipboard"
+                                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                                    tabindex="0"
+                                    type="button"
                                   >
-                                    <path
-                                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                                    <svg
+                                      aria-hidden="true"
+                                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                                      data-testid="ContentCopyIcon"
+                                      focusable="false"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                                      />
+                                    </svg>
+                                    <span
+                                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                                     />
-                                  </svg>
-                                  <span
-                                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                                  />
-                                </button>
+                                  </button>
+                                </span>
                               </span>
                               <div
                                 class="info-caption"
@@ -1294,27 +1302,31 @@ exports[`Results Table Should match snapshot 1`] = `
                             >
                               spam
                             </a>
-                            <button
-                              aria-label="Copy the revision to the clipboard"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                              tabindex="0"
-                              type="button"
+                            <span
+                              class="MuiBox-root css-79elbk"
                             >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                                data-testid="ContentCopyIcon"
-                                focusable="false"
-                                viewBox="0 0 24 24"
+                              <button
+                                aria-label="Copy the revision to the clipboard"
+                                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                                tabindex="0"
+                                type="button"
                               >
-                                <path
-                                  d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                                  data-testid="ContentCopyIcon"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                                  />
+                                </svg>
+                                <span
+                                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                                 />
-                              </svg>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </button>
+                              </button>
+                            </span>
                           </div>
                           <div
                             class="f1oxa67k"
@@ -2055,27 +2067,31 @@ exports[`Results Table Should match snapshot 1`] = `
                             >
                               spam
                             </a>
-                            <button
-                              aria-label="Copy the revision to the clipboard"
-                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                              tabindex="0"
-                              type="button"
+                            <span
+                              class="MuiBox-root css-79elbk"
                             >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                                data-testid="ContentCopyIcon"
-                                focusable="false"
-                                viewBox="0 0 24 24"
+                              <button
+                                aria-label="Copy the revision to the clipboard"
+                                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                                tabindex="0"
+                                type="button"
                               >
-                                <path
-                                  d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                                  data-testid="ContentCopyIcon"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                                  />
+                                </svg>
+                                <span
+                                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                                 />
-                              </svg>
-                              <span
-                                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                              />
-                            </button>
+                              </button>
+                            </span>
                           </div>
                           <div
                             class="f1oxa67k"
@@ -2621,27 +2637,31 @@ exports[`Results Table should render different blocks when rendering several rev
     >
       spam
     </a>
-    <button
-      aria-label="Copy the revision to the clipboard"
-      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-      tabindex="0"
-      type="button"
+    <span
+      class="MuiBox-root css-79elbk"
     >
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-        data-testid="ContentCopyIcon"
-        focusable="false"
-        viewBox="0 0 24 24"
+      <button
+        aria-label="Copy the revision to the clipboard"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+        tabindex="0"
+        type="button"
       >
-        <path
-          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+          data-testid="ContentCopyIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+          />
+        </svg>
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
         />
-      </svg>
-      <span
-        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-      />
-    </button>
+      </button>
+    </span>
     <div
       class="revisionRow fqyfrhr f1vh4jdk MuiBox-root css-1txhl5e"
       role="row"
@@ -2880,27 +2900,31 @@ exports[`Results Table should render different blocks when rendering several rev
     >
       devilrabbit
     </a>
-    <button
-      aria-label="Copy the revision to the clipboard"
-      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-      tabindex="0"
-      type="button"
+    <span
+      class="MuiBox-root css-79elbk"
     >
-      <svg
-        aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-        data-testid="ContentCopyIcon"
-        focusable="false"
-        viewBox="0 0 24 24"
+      <button
+        aria-label="Copy the revision to the clipboard"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+        tabindex="0"
+        type="button"
       >
-        <path
-          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+          data-testid="ContentCopyIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+          />
+        </svg>
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
         />
-      </svg>
-      <span
-        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-      />
-    </button>
+      </button>
+    </span>
     <div
       class="revisionRow fqyfrhr f1vh4jdk MuiBox-root css-1txhl5e"
       role="row"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -316,6 +316,7 @@ exports[`Results Table Should match snapshot 1`] = `
                                   <button
                                     aria-label="Copy the revision to the clipboard"
                                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                                    data-testid="copy-icon"
                                     tabindex="0"
                                     type="button"
                                   >
@@ -603,6 +604,7 @@ exports[`Results Table Should match snapshot 1`] = `
                                   <button
                                     aria-label="Copy the revision to the clipboard"
                                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                                    data-testid="copy-icon"
                                     tabindex="0"
                                     type="button"
                                   >
@@ -1308,6 +1310,7 @@ exports[`Results Table Should match snapshot 1`] = `
                               <button
                                 aria-label="Copy the revision to the clipboard"
                                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                                data-testid="copy-icon"
                                 tabindex="0"
                                 type="button"
                               >
@@ -2073,6 +2076,7 @@ exports[`Results Table Should match snapshot 1`] = `
                               <button
                                 aria-label="Copy the revision to the clipboard"
                                 class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                                data-testid="copy-icon"
                                 tabindex="0"
                                 type="button"
                               >
@@ -2643,6 +2647,7 @@ exports[`Results Table should render different blocks when rendering several rev
       <button
         aria-label="Copy the revision to the clipboard"
         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+        data-testid="copy-icon"
         tabindex="0"
         type="button"
       >
@@ -2906,6 +2911,7 @@ exports[`Results Table should render different blocks when rendering several rev
       <button
         aria-label="Copy the revision to the clipboard"
         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+        data-testid="copy-icon"
         tabindex="0"
         type="button"
       >

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -1344,6 +1344,27 @@ exports[`Results View The table should match snapshot and other elements should 
                 >
                   spam
                 </a>
+                <button
+                  aria-label="Copy the revision to the clipboard"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                    data-testid="ContentCopyIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                    />
+                  </svg>
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
               </div>
               <div
                 class="f1oxa67k"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -1350,6 +1350,7 @@ exports[`Results View The table should match snapshot and other elements should 
                   <button
                     aria-label="Copy the revision to the clipboard"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                    data-testid="copy-icon"
                     tabindex="0"
                     type="button"
                   >

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -1344,27 +1344,31 @@ exports[`Results View The table should match snapshot and other elements should 
                 >
                   spam
                 </a>
-                <button
-                  aria-label="Copy the revision to the clipboard"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                  tabindex="0"
-                  type="button"
+                <span
+                  class="MuiBox-root css-79elbk"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                    data-testid="ContentCopyIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
+                  <button
+                    aria-label="Copy the revision to the clipboard"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                    tabindex="0"
+                    type="button"
                   >
-                    <path
-                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                      data-testid="ContentCopyIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                      />
+                    </svg>
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                     />
-                  </svg>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
-                </button>
+                  </button>
+                </span>
               </div>
               <div
                 class="f1oxa67k"

--- a/src/__tests__/Search/SelectedRevision.test.tsx
+++ b/src/__tests__/Search/SelectedRevision.test.tsx
@@ -93,4 +93,18 @@ describe('SelectedRevision', () => {
     });
     expect(alertIcon).toBeInTheDocument();
   });
+
+  it('should copy hash number when copyicon is clicked', async () => {
+    const user = userEvent.setup({ delay: null });
+    await renderComponent();
+    const searchInput = screen.getAllByRole('textbox')[0];
+    await user.click(searchInput);
+    const noArmsLeft = await screen.findByRole('button', {
+      name: /you've got no arms left!/,
+    });
+    await user.click(noArmsLeft);
+    const copyIcon = screen.getByTestId('copy-icon');
+    await user.click(copyIcon);
+    expect(screen.getByText('Copied')).toBeInTheDocument();
+  });
 });

--- a/src/__tests__/Search/SelectedRevision.test.tsx
+++ b/src/__tests__/Search/SelectedRevision.test.tsx
@@ -107,4 +107,32 @@ describe('SelectedRevision', () => {
     await user.click(copyIcon);
     expect(screen.getByText('Copied')).toBeInTheDocument();
   });
+
+  it('should handle copy failure when clipboard API fails', async () => {
+    const user = userEvent.setup({ delay: null });
+    await renderComponent();
+    const searchInput = screen.getAllByRole('textbox')[0];
+    await user.click(searchInput);
+    const noArmsLeft = await screen.findByRole('button', {
+      name: /you've got no arms left!/,
+    });
+    await user.click(noArmsLeft);
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    // Mock clipboard writeText to throw an error
+    jest
+      .spyOn(navigator.clipboard, 'writeText')
+      .mockRejectedValue(new Error('Clipboard write failed'));
+    const copyIcon = screen.getByTestId('copy-icon');
+    await user.click(copyIcon);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Failed to copy text to clipboard:',
+      expect.any(Error),
+    );
+
+    // Restore clipboard function after test
+    jest.restoreAllMocks();
+  });
 });

--- a/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
@@ -579,27 +579,31 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
                     >
                       coconut
                     </a>
-                    <button
-                      aria-label="Copy the revision to the clipboard"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                      tabindex="0"
-                      type="button"
+                    <span
+                      class="MuiBox-root css-79elbk"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                        data-testid="ContentCopyIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <button
+                        aria-label="Copy the revision to the clipboard"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
                       >
-                        <path
-                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                         />
-                      </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </button>
+                      </button>
+                    </span>
                   </span>
                   <div
                     class="info-caption"
@@ -1241,27 +1245,31 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
                     >
                       coconut
                     </a>
-                    <button
-                      aria-label="Copy the revision to the clipboard"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                      tabindex="0"
-                      type="button"
+                    <span
+                      class="MuiBox-root css-79elbk"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                        data-testid="ContentCopyIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <button
+                        aria-label="Copy the revision to the clipboard"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
                       >
-                        <path
-                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                         />
-                      </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </button>
+                      </button>
+                    </span>
                   </span>
                   <div
                     class="info-caption"
@@ -1572,27 +1580,31 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
                     >
                       coconut
                     </a>
-                    <button
-                      aria-label="Copy the revision to the clipboard"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                      tabindex="0"
-                      type="button"
+                    <span
+                      class="MuiBox-root css-79elbk"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                        data-testid="ContentCopyIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <button
+                        aria-label="Copy the revision to the clipboard"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
                       >
-                        <path
-                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                         />
-                      </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </button>
+                      </button>
+                    </span>
                   </span>
                   <div
                     class="info-caption"
@@ -2269,27 +2281,31 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                     >
                       coconut
                     </a>
-                    <button
-                      aria-label="Copy the revision to the clipboard"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                      tabindex="0"
-                      type="button"
+                    <span
+                      class="MuiBox-root css-79elbk"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                        data-testid="ContentCopyIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <button
+                        aria-label="Copy the revision to the clipboard"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
                       >
-                        <path
-                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                         />
-                      </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </button>
+                      </button>
+                    </span>
                   </span>
                   <div
                     class="info-caption"
@@ -2407,27 +2423,31 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                     >
                       spamspamspam
                     </a>
-                    <button
-                      aria-label="Copy the revision to the clipboard"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                      tabindex="0"
-                      type="button"
+                    <span
+                      class="MuiBox-root css-79elbk"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                        data-testid="ContentCopyIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <button
+                        aria-label="Copy the revision to the clipboard"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
                       >
-                        <path
-                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                         />
-                      </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </button>
+                      </button>
+                    </span>
                   </span>
                   <div
                     class="info-caption"
@@ -2891,27 +2911,31 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                     >
                       coconut
                     </a>
-                    <button
-                      aria-label="Copy the revision to the clipboard"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                      tabindex="0"
-                      type="button"
+                    <span
+                      class="MuiBox-root css-79elbk"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                        data-testid="ContentCopyIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <button
+                        aria-label="Copy the revision to the clipboard"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
                       >
-                        <path
-                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                         />
-                      </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </button>
+                      </button>
+                    </span>
                   </span>
                   <div
                     class="info-caption"
@@ -3222,27 +3246,31 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                     >
                       coconut
                     </a>
-                    <button
-                      aria-label="Copy the revision to the clipboard"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                      tabindex="0"
-                      type="button"
+                    <span
+                      class="MuiBox-root css-79elbk"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                        data-testid="ContentCopyIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <button
+                        aria-label="Copy the revision to the clipboard"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
                       >
-                        <path
-                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                         />
-                      </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </button>
+                      </button>
+                    </span>
                   </span>
                   <div
                     class="info-caption"

--- a/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
@@ -579,6 +579,27 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
                     >
                       coconut
                     </a>
+                    <button
+                      aria-label="Copy the revision to the clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
                   </span>
                   <div
                     class="info-caption"
@@ -1220,6 +1241,27 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
                     >
                       coconut
                     </a>
+                    <button
+                      aria-label="Copy the revision to the clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
                   </span>
                   <div
                     class="info-caption"
@@ -1530,6 +1572,27 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
                     >
                       coconut
                     </a>
+                    <button
+                      aria-label="Copy the revision to the clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
                   </span>
                   <div
                     class="info-caption"
@@ -2206,6 +2269,27 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                     >
                       coconut
                     </a>
+                    <button
+                      aria-label="Copy the revision to the clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
                   </span>
                   <div
                     class="info-caption"
@@ -2323,6 +2407,27 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                     >
                       spamspamspam
                     </a>
+                    <button
+                      aria-label="Copy the revision to the clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
                   </span>
                   <div
                     class="info-caption"
@@ -2786,6 +2891,27 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                     >
                       coconut
                     </a>
+                    <button
+                      aria-label="Copy the revision to the clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
                   </span>
                   <div
                     class="info-caption"
@@ -3096,6 +3222,27 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                     >
                       coconut
                     </a>
+                    <button
+                      aria-label="Copy the revision to the clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
                   </span>
                   <div
                     class="info-caption"

--- a/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
@@ -585,6 +585,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
                       <button
                         aria-label="Copy the revision to the clipboard"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        data-testid="copy-icon"
                         tabindex="0"
                         type="button"
                       >
@@ -1251,6 +1252,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
                       <button
                         aria-label="Copy the revision to the clipboard"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        data-testid="copy-icon"
                         tabindex="0"
                         type="button"
                       >
@@ -1586,6 +1588,7 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
                       <button
                         aria-label="Copy the revision to the clipboard"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        data-testid="copy-icon"
                         tabindex="0"
                         type="button"
                       >
@@ -2287,6 +2290,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                       <button
                         aria-label="Copy the revision to the clipboard"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        data-testid="copy-icon"
                         tabindex="0"
                         type="button"
                       >
@@ -2429,6 +2433,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                       <button
                         aria-label="Copy the revision to the clipboard"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        data-testid="copy-icon"
                         tabindex="0"
                         type="button"
                       >
@@ -2917,6 +2922,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                       <button
                         aria-label="Copy the revision to the clipboard"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        data-testid="copy-icon"
                         tabindex="0"
                         type="button"
                       >
@@ -3252,6 +3258,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                       <button
                         aria-label="Copy the revision to the clipboard"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        data-testid="copy-icon"
                         tabindex="0"
                         type="button"
                       >

--- a/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
@@ -234,6 +234,27 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
                     >
                       coconut
                     </a>
+                    <button
+                      aria-label="Copy the revision to the clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
                   </span>
                   <div
                     class="info-caption"
@@ -516,6 +537,27 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
                     >
                       coconut
                     </a>
+                    <button
+                      aria-label="Copy the revision to the clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
                   </span>
                   <div
                     class="info-caption"
@@ -993,6 +1035,27 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                     >
                       coconut
                     </a>
+                    <button
+                      aria-label="Copy the revision to the clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
                   </span>
                   <div
                     class="info-caption"
@@ -1468,6 +1531,27 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                     >
                       coconut
                     </a>
+                    <button
+                      aria-label="Copy the revision to the clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
                   </span>
                   <div
                     class="info-caption"
@@ -1750,6 +1834,27 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                     >
                       coconut
                     </a>
+                    <button
+                      aria-label="Copy the revision to the clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
                   </span>
                   <div
                     class="info-caption"
@@ -2102,6 +2207,27 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
                     >
                       coconut
                     </a>
+                    <button
+                      aria-label="Copy the revision to the clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
                   </span>
                   <div
                     class="info-caption"
@@ -2384,6 +2510,27 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
                     >
                       coconut
                     </a>
+                    <button
+                      aria-label="Copy the revision to the clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
                   </span>
                   <div
                     class="info-caption"
@@ -2867,6 +3014,27 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
                     >
                       coconut
                     </a>
+                    <button
+                      aria-label="Copy the revision to the clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
                   </span>
                   <div
                     class="info-caption"
@@ -3244,6 +3412,27 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
                     >
                       coconut
                     </a>
+                    <button
+                      aria-label="Copy the revision to the clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
                   </span>
                   <div
                     class="info-caption"

--- a/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
@@ -234,27 +234,31 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
                     >
                       coconut
                     </a>
-                    <button
-                      aria-label="Copy the revision to the clipboard"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                      tabindex="0"
-                      type="button"
+                    <span
+                      class="MuiBox-root css-79elbk"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                        data-testid="ContentCopyIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <button
+                        aria-label="Copy the revision to the clipboard"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
                       >
-                        <path
-                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                         />
-                      </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </button>
+                      </button>
+                    </span>
                   </span>
                   <div
                     class="info-caption"
@@ -537,27 +541,31 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
                     >
                       coconut
                     </a>
-                    <button
-                      aria-label="Copy the revision to the clipboard"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                      tabindex="0"
-                      type="button"
+                    <span
+                      class="MuiBox-root css-79elbk"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                        data-testid="ContentCopyIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <button
+                        aria-label="Copy the revision to the clipboard"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
                       >
-                        <path
-                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                         />
-                      </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </button>
+                      </button>
+                    </span>
                   </span>
                   <div
                     class="info-caption"
@@ -1035,27 +1043,31 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                     >
                       coconut
                     </a>
-                    <button
-                      aria-label="Copy the revision to the clipboard"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                      tabindex="0"
-                      type="button"
+                    <span
+                      class="MuiBox-root css-79elbk"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                        data-testid="ContentCopyIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <button
+                        aria-label="Copy the revision to the clipboard"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
                       >
-                        <path
-                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                         />
-                      </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </button>
+                      </button>
+                    </span>
                   </span>
                   <div
                     class="info-caption"
@@ -1531,27 +1543,31 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                     >
                       coconut
                     </a>
-                    <button
-                      aria-label="Copy the revision to the clipboard"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                      tabindex="0"
-                      type="button"
+                    <span
+                      class="MuiBox-root css-79elbk"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                        data-testid="ContentCopyIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <button
+                        aria-label="Copy the revision to the clipboard"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
                       >
-                        <path
-                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                         />
-                      </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </button>
+                      </button>
+                    </span>
                   </span>
                   <div
                     class="info-caption"
@@ -1834,27 +1850,31 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                     >
                       coconut
                     </a>
-                    <button
-                      aria-label="Copy the revision to the clipboard"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                      tabindex="0"
-                      type="button"
+                    <span
+                      class="MuiBox-root css-79elbk"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                        data-testid="ContentCopyIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <button
+                        aria-label="Copy the revision to the clipboard"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
                       >
-                        <path
-                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                         />
-                      </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </button>
+                      </button>
+                    </span>
                   </span>
                   <div
                     class="info-caption"
@@ -2207,27 +2227,31 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
                     >
                       coconut
                     </a>
-                    <button
-                      aria-label="Copy the revision to the clipboard"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                      tabindex="0"
-                      type="button"
+                    <span
+                      class="MuiBox-root css-79elbk"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                        data-testid="ContentCopyIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <button
+                        aria-label="Copy the revision to the clipboard"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
                       >
-                        <path
-                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                         />
-                      </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </button>
+                      </button>
+                    </span>
                   </span>
                   <div
                     class="info-caption"
@@ -2510,27 +2534,31 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
                     >
                       coconut
                     </a>
-                    <button
-                      aria-label="Copy the revision to the clipboard"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                      tabindex="0"
-                      type="button"
+                    <span
+                      class="MuiBox-root css-79elbk"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                        data-testid="ContentCopyIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <button
+                        aria-label="Copy the revision to the clipboard"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
                       >
-                        <path
-                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                         />
-                      </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </button>
+                      </button>
+                    </span>
                   </span>
                   <div
                     class="info-caption"
@@ -3014,27 +3042,31 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
                     >
                       coconut
                     </a>
-                    <button
-                      aria-label="Copy the revision to the clipboard"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                      tabindex="0"
-                      type="button"
+                    <span
+                      class="MuiBox-root css-79elbk"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                        data-testid="ContentCopyIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <button
+                        aria-label="Copy the revision to the clipboard"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
                       >
-                        <path
-                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                         />
-                      </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </button>
+                      </button>
+                    </span>
                   </span>
                   <div
                     class="info-caption"
@@ -3412,27 +3444,31 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
                     >
                       coconut
                     </a>
-                    <button
-                      aria-label="Copy the revision to the clipboard"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                      tabindex="0"
-                      type="button"
+                    <span
+                      class="MuiBox-root css-79elbk"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                        data-testid="ContentCopyIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <button
+                        aria-label="Copy the revision to the clipboard"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
                       >
-                        <path
-                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                         />
-                      </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </button>
+                      </button>
+                    </span>
                   </span>
                   <div
                     class="info-caption"

--- a/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
@@ -240,6 +240,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
                       <button
                         aria-label="Copy the revision to the clipboard"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        data-testid="copy-icon"
                         tabindex="0"
                         type="button"
                       >
@@ -547,6 +548,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
                       <button
                         aria-label="Copy the revision to the clipboard"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        data-testid="copy-icon"
                         tabindex="0"
                         type="button"
                       >
@@ -1049,6 +1051,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                       <button
                         aria-label="Copy the revision to the clipboard"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        data-testid="copy-icon"
                         tabindex="0"
                         type="button"
                       >
@@ -1549,6 +1552,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                       <button
                         aria-label="Copy the revision to the clipboard"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        data-testid="copy-icon"
                         tabindex="0"
                         type="button"
                       >
@@ -1856,6 +1860,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                       <button
                         aria-label="Copy the revision to the clipboard"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        data-testid="copy-icon"
                         tabindex="0"
                         type="button"
                       >
@@ -2233,6 +2238,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
                       <button
                         aria-label="Copy the revision to the clipboard"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        data-testid="copy-icon"
                         tabindex="0"
                         type="button"
                       >
@@ -2540,6 +2546,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
                       <button
                         aria-label="Copy the revision to the clipboard"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        data-testid="copy-icon"
                         tabindex="0"
                         type="button"
                       >
@@ -3048,6 +3055,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
                       <button
                         aria-label="Copy the revision to the clipboard"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        data-testid="copy-icon"
                         tabindex="0"
                         type="button"
                       >
@@ -3450,6 +3458,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
                       <button
                         aria-label="Copy the revision to the clipboard"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        data-testid="copy-icon"
                         tabindex="0"
                         type="button"
                       >

--- a/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
@@ -1269,6 +1269,27 @@ exports[`With search parameters both search components are populated as expected
                     >
                       spamspam
                     </a>
+                    <button
+                      aria-label="Copy the revision to the clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
                   </span>
                   <div
                     class="info-caption"
@@ -1766,6 +1787,27 @@ exports[`With search parameters both search components are populated as expected
                     >
                       spamspam
                     </a>
+                    <button
+                      aria-label="Copy the revision to the clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
                   </span>
                   <div
                     class="info-caption"
@@ -2271,6 +2313,27 @@ exports[`With search parameters both search components are populated as expected
                     >
                       spamspamspam
                     </a>
+                    <button
+                      aria-label="Copy the revision to the clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
                   </span>
                   <div
                     class="info-caption"
@@ -2768,6 +2831,27 @@ exports[`With search parameters both search components are populated as expected
                     >
                       spamspamspam
                     </a>
+                    <button
+                      aria-label="Copy the revision to the clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
                   </span>
                   <div
                     class="info-caption"
@@ -3273,6 +3357,27 @@ exports[`With search parameters displays the default value for framework if the 
                     >
                       spamspam
                     </a>
+                    <button
+                      aria-label="Copy the revision to the clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
                   </span>
                   <div
                     class="info-caption"
@@ -3770,6 +3875,27 @@ exports[`With search parameters displays the default value for framework if the 
                     >
                       spamspam
                     </a>
+                    <button
+                      aria-label="Copy the revision to the clipboard"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                        data-testid="ContentCopyIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        />
+                      </svg>
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </button>
                   </span>
                   <div
                     class="info-caption"

--- a/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
@@ -1269,27 +1269,31 @@ exports[`With search parameters both search components are populated as expected
                     >
                       spamspam
                     </a>
-                    <button
-                      aria-label="Copy the revision to the clipboard"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                      tabindex="0"
-                      type="button"
+                    <span
+                      class="MuiBox-root css-79elbk"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                        data-testid="ContentCopyIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <button
+                        aria-label="Copy the revision to the clipboard"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
                       >
-                        <path
-                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                         />
-                      </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </button>
+                      </button>
+                    </span>
                   </span>
                   <div
                     class="info-caption"
@@ -1787,27 +1791,31 @@ exports[`With search parameters both search components are populated as expected
                     >
                       spamspam
                     </a>
-                    <button
-                      aria-label="Copy the revision to the clipboard"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                      tabindex="0"
-                      type="button"
+                    <span
+                      class="MuiBox-root css-79elbk"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                        data-testid="ContentCopyIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <button
+                        aria-label="Copy the revision to the clipboard"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
                       >
-                        <path
-                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                         />
-                      </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </button>
+                      </button>
+                    </span>
                   </span>
                   <div
                     class="info-caption"
@@ -2313,27 +2321,31 @@ exports[`With search parameters both search components are populated as expected
                     >
                       spamspamspam
                     </a>
-                    <button
-                      aria-label="Copy the revision to the clipboard"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                      tabindex="0"
-                      type="button"
+                    <span
+                      class="MuiBox-root css-79elbk"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                        data-testid="ContentCopyIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <button
+                        aria-label="Copy the revision to the clipboard"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
                       >
-                        <path
-                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                         />
-                      </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </button>
+                      </button>
+                    </span>
                   </span>
                   <div
                     class="info-caption"
@@ -2831,27 +2843,31 @@ exports[`With search parameters both search components are populated as expected
                     >
                       spamspamspam
                     </a>
-                    <button
-                      aria-label="Copy the revision to the clipboard"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                      tabindex="0"
-                      type="button"
+                    <span
+                      class="MuiBox-root css-79elbk"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                        data-testid="ContentCopyIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <button
+                        aria-label="Copy the revision to the clipboard"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
                       >
-                        <path
-                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                         />
-                      </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </button>
+                      </button>
+                    </span>
                   </span>
                   <div
                     class="info-caption"
@@ -3357,27 +3373,31 @@ exports[`With search parameters displays the default value for framework if the 
                     >
                       spamspam
                     </a>
-                    <button
-                      aria-label="Copy the revision to the clipboard"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                      tabindex="0"
-                      type="button"
+                    <span
+                      class="MuiBox-root css-79elbk"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                        data-testid="ContentCopyIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <button
+                        aria-label="Copy the revision to the clipboard"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
                       >
-                        <path
-                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                         />
-                      </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </button>
+                      </button>
+                    </span>
                   </span>
                   <div
                     class="info-caption"
@@ -3875,27 +3895,31 @@ exports[`With search parameters displays the default value for framework if the 
                     >
                       spamspam
                     </a>
-                    <button
-                      aria-label="Copy the revision to the clipboard"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-                      tabindex="0"
-                      type="button"
+                    <span
+                      class="MuiBox-root css-79elbk"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-                        data-testid="ContentCopyIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <button
+                        aria-label="Copy the revision to the clipboard"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
                       >
-                        <path
-                          d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                          data-testid="ContentCopyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                          />
+                        </svg>
+                        <span
+                          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
                         />
-                      </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
-                    </button>
+                      </button>
+                    </span>
                   </span>
                   <div
                     class="info-caption"

--- a/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
@@ -1275,6 +1275,7 @@ exports[`With search parameters both search components are populated as expected
                       <button
                         aria-label="Copy the revision to the clipboard"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        data-testid="copy-icon"
                         tabindex="0"
                         type="button"
                       >
@@ -1797,6 +1798,7 @@ exports[`With search parameters both search components are populated as expected
                       <button
                         aria-label="Copy the revision to the clipboard"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        data-testid="copy-icon"
                         tabindex="0"
                         type="button"
                       >
@@ -2327,6 +2329,7 @@ exports[`With search parameters both search components are populated as expected
                       <button
                         aria-label="Copy the revision to the clipboard"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        data-testid="copy-icon"
                         tabindex="0"
                         type="button"
                       >
@@ -2849,6 +2852,7 @@ exports[`With search parameters both search components are populated as expected
                       <button
                         aria-label="Copy the revision to the clipboard"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        data-testid="copy-icon"
                         tabindex="0"
                         type="button"
                       >
@@ -3379,6 +3383,7 @@ exports[`With search parameters displays the default value for framework if the 
                       <button
                         aria-label="Copy the revision to the clipboard"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        data-testid="copy-icon"
                         tabindex="0"
                         type="button"
                       >
@@ -3901,6 +3906,7 @@ exports[`With search parameters displays the default value for framework if the 
                       <button
                         aria-label="Copy the revision to the clipboard"
                         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+                        data-testid="copy-icon"
                         tabindex="0"
                         type="button"
                       >

--- a/src/__tests__/Search/__snapshots__/SelectedRevision.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SelectedRevision.test.tsx.snap
@@ -42,27 +42,31 @@ exports[`SelectedRevision should show the selected checked revisions once a resu
           >
             coconut
           </a>
-          <button
-            aria-label="Copy the revision to the clipboard"
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
-            tabindex="0"
-            type="button"
+          <span
+            class="MuiBox-root css-79elbk"
           >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
-              data-testid="ContentCopyIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
+            <button
+              aria-label="Copy the revision to the clipboard"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+              tabindex="0"
+              type="button"
             >
-              <path
-                d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+                data-testid="ContentCopyIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                />
+              </svg>
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
               />
-            </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
-          </button>
+            </button>
+          </span>
         </span>
         <div
           class="info-caption"

--- a/src/__tests__/Search/__snapshots__/SelectedRevision.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SelectedRevision.test.tsx.snap
@@ -48,6 +48,7 @@ exports[`SelectedRevision should show the selected checked revisions once a resu
             <button
               aria-label="Copy the revision to the clipboard"
               class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1c5fh40-MuiButtonBase-root-MuiIconButton-root"
+              data-testid="copy-icon"
               tabindex="0"
               type="button"
             >

--- a/src/__tests__/Search/__snapshots__/SelectedRevision.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SelectedRevision.test.tsx.snap
@@ -42,6 +42,27 @@ exports[`SelectedRevision should show the selected checked revisions once a resu
           >
             coconut
           </a>
+          <button
+            aria-label="Copy the revision to the clipboard"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-vpdfv9-MuiButtonBase-root-MuiIconButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-2fbsan-MuiSvgIcon-root"
+              data-testid="ContentCopyIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+              />
+            </svg>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
         </span>
         <div
           class="info-caption"

--- a/src/components/CompareResults/LinkToRevision.tsx
+++ b/src/components/CompareResults/LinkToRevision.tsx
@@ -26,19 +26,19 @@ export default function LinkToRevision(props: LinkToRevisionProps) {
   const shortHash = truncateHash(result.new_rev);
   return (
     <>
-    <Link
-      href={getTreeherderURL(result.new_rev, result.new_repository_name)}
-      target='_blank'
-      title={`${Strings.components.revisionRow.title.jobLink} ${shortHash}`}
-      className={styles.typography}
-    >
-      {shortHash}
-    </Link>
-       <CopyIcon
-       text={shortHash}
-       arialLabel='Copy the revision to the clipboard'
-     />
-     </>
+      <Link
+        href={getTreeherderURL(result.new_rev, result.new_repository_name)}
+        target='_blank'
+        title={`${Strings.components.revisionRow.title.jobLink} ${shortHash}`}
+        className={styles.typography}
+      >
+        {shortHash}
+      </Link>
+      <CopyIcon
+        text={shortHash}
+        arialLabel='Copy the revision to the clipboard'
+      />
+    </>
   );
 }
 

--- a/src/components/CompareResults/LinkToRevision.tsx
+++ b/src/components/CompareResults/LinkToRevision.tsx
@@ -4,6 +4,7 @@ import { style } from 'typestyle';
 import { Strings } from '../../resources/Strings';
 import type { CompareResultsItem } from '../../types/state';
 import { getTreeherderURL, truncateHash } from '../../utils/helpers';
+import CopyIcon from '../Shared/CopyIcon';
 
 const styles = {
   typography: style({
@@ -24,6 +25,7 @@ export default function LinkToRevision(props: LinkToRevisionProps) {
   const { result } = props;
   const shortHash = truncateHash(result.new_rev);
   return (
+    <>
     <Link
       href={getTreeherderURL(result.new_rev, result.new_repository_name)}
       target='_blank'
@@ -32,6 +34,11 @@ export default function LinkToRevision(props: LinkToRevisionProps) {
     >
       {shortHash}
     </Link>
+       <CopyIcon
+       text={shortHash}
+       arialLabel='Copy the revision to the clipboard'
+     />
+     </>
   );
 }
 

--- a/src/components/Search/SelectedRevisionItem.tsx
+++ b/src/components/Search/SelectedRevisionItem.tsx
@@ -22,6 +22,7 @@ import {
   getLatestCommitMessage,
   getTreeherderURL,
 } from '../../utils/helpers';
+import CopyIcon from '../Shared/CopyIcon';
 
 const base = Strings.components.searchDefault.base;
 const warning = base.collapsed.warnings.comparison;
@@ -34,6 +35,8 @@ interface SelectedRevisionItemProps {
   iconClassName: string;
   onRemoveRevision: (item: Changeset) => void;
 }
+
+
 
 function SelectedRevisionItem({
   index,
@@ -92,7 +95,12 @@ function SelectedRevisionItem({
                 >
                   {revisionHash}
                 </Link>
+                <CopyIcon
+                  text={revisionHash}
+                  arialLabel='Copy the revision to the clipboard'
+                />
               </Typography>
+
               <div className='info-caption'>
                 <div className='info-caption-item item-author'>
                   {' '}

--- a/src/components/Search/SelectedRevisionItem.tsx
+++ b/src/components/Search/SelectedRevisionItem.tsx
@@ -36,8 +36,6 @@ interface SelectedRevisionItemProps {
   onRemoveRevision: (item: Changeset) => void;
 }
 
-
-
 function SelectedRevisionItem({
   index,
   item,

--- a/src/components/Shared/CopyIcon.tsx
+++ b/src/components/Shared/CopyIcon.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState } from 'react';
 
 import { ContentCopy } from '@mui/icons-material';
 import { Typography } from '@mui/material';
@@ -7,21 +7,19 @@ import IconButton from '@mui/material/IconButton';
 type CopyIconProps = {
   text: string;
   arialLabel: string;
-}
-const CopyIcon = ({
-  text,
-  arialLabel,
-}: CopyIconProps) => {
+};
+const CopyIcon = ({ text, arialLabel }: CopyIconProps) => {
   const [copied, setCopied] = useState<boolean>(false);
   const handleClick = () => {
-    navigator.clipboard.writeText(text)
-    .then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1000); 
-    })
-    .catch((err) => {
-      console.error('Failed to copy text to clipboard:', err);
-    });
+    navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1000);
+      })
+      .catch((err) => {
+        console.error('Failed to copy text to clipboard:', err);
+      });
   };
   return (
     <>
@@ -29,7 +27,12 @@ const CopyIcon = ({
         <ContentCopy fontSize='inherit' />
       </IconButton>
       {copied && (
-        <Typography sx={{fontSize: '0.7rem'}} component='span' variant='body2' color='text.primary'>
+        <Typography
+          sx={{ fontSize: '0.7rem' }}
+          component='span'
+          variant='body2'
+          color='text.primary'
+        >
           Copied
         </Typography>
       )}
@@ -37,4 +40,4 @@ const CopyIcon = ({
   );
 };
 
-export default CopyIcon
+export default CopyIcon;

--- a/src/components/Shared/CopyIcon.tsx
+++ b/src/components/Shared/CopyIcon.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { ContentCopy } from '@mui/icons-material';
-import { Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import IconButton from '@mui/material/IconButton';
 
 type CopyIconProps = {
@@ -11,32 +11,49 @@ type CopyIconProps = {
 const CopyIcon = ({ text, arialLabel }: CopyIconProps) => {
   const [copied, setCopied] = useState<boolean>(false);
   const handleClick = () => {
-    navigator.clipboard
-      .writeText(text)
-      .then(() => {
-        setCopied(true);
-        setTimeout(() => setCopied(false), 1000);
-      })
-      .catch((err) => {
-        console.error('Failed to copy text to clipboard:', err);
-      });
+    const copyText = async () => {
+      await navigator.clipboard.writeText(text);
+    };
+    try {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1000);
+    } catch (err) {
+      console.error('Failed to copy text to clipboard:', err);
+    }
+    // To resolve this eslint error https://typescript-eslint.io/rules/no-misused-promises/#checksvoidreturn-1
+    copyText().catch((error) =>
+      console.error('Failed to copy text to clipboard:', error),
+    );
   };
   return (
-    <>
-      <IconButton size='small' aria-label={arialLabel} onClick={handleClick}>
-        <ContentCopy fontSize='inherit' />
-      </IconButton>
+    <Box
+      component='span'
+      sx={{
+        position: 'relative',
+      }}
+    >
       {copied && (
         <Typography
-          sx={{ fontSize: '0.7rem' }}
-          component='span'
+          sx={{
+            fontSize: '0.7rem',
+            position: 'absolute',
+            top: '-1rem',
+          }}
           variant='body2'
           color='text.primary'
         >
           Copied
         </Typography>
       )}
-    </>
+      <IconButton
+        sx={{ padding: '4px' }}
+        size='small'
+        aria-label={arialLabel}
+        onClick={handleClick}
+      >
+        <ContentCopy fontSize='inherit' />
+      </IconButton>
+    </Box>
   );
 };
 

--- a/src/components/Shared/CopyIcon.tsx
+++ b/src/components/Shared/CopyIcon.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react'
+
+import { ContentCopy } from '@mui/icons-material';
+import { Typography } from '@mui/material';
+import IconButton from '@mui/material/IconButton';
+
+type CopyIconProps = {
+  text: string;
+  arialLabel: string;
+}
+const CopyIcon = ({
+  text,
+  arialLabel,
+}: CopyIconProps) => {
+  const [copied, setCopied] = useState<boolean>(false);
+  const handleClick = () => {
+    navigator.clipboard.writeText(text)
+    .then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1000); 
+    })
+    .catch((err) => {
+      console.error('Failed to copy text to clipboard:', err);
+    });
+  };
+  return (
+    <>
+      <IconButton size='small' aria-label={arialLabel} onClick={handleClick}>
+        <ContentCopy fontSize='inherit' />
+      </IconButton>
+      {copied && (
+        <Typography sx={{fontSize: '0.7rem'}} component='span' variant='body2' color='text.primary'>
+          Copied
+        </Typography>
+      )}
+    </>
+  );
+};
+
+export default CopyIcon

--- a/src/components/Shared/CopyIcon.tsx
+++ b/src/components/Shared/CopyIcon.tsx
@@ -35,12 +35,13 @@ const CopyIcon = ({ text, arialLabel }: CopyIconProps) => {
       {copied && (
         <Typography
           sx={{
-            fontSize: '0.7rem',
+            fontSize: '0.75rem',
             position: 'absolute',
             top: '-1rem',
           }}
           variant='body2'
           color='text.primary'
+          data-testid='copied-text'
         >
           Copied
         </Typography>
@@ -50,6 +51,7 @@ const CopyIcon = ({ text, arialLabel }: CopyIconProps) => {
         size='small'
         aria-label={arialLabel}
         onClick={handleClick}
+        data-testid='copy-icon'
       >
         <ContentCopy fontSize='inherit' />
       </IconButton>


### PR DESCRIPTION
[Bugzilla link](https://bugzilla.mozilla.org/show_bug.cgi?id=1938295)

[Deploy link](https://deploy-preview-841--mozilla-perfcompare.netlify.app/)

### Description

This PR adds a copy icon to easily copy revision hash

Changes:
- Created a `CopyIcon` component in `/components/Shared` folder
-  This component was used in `SelectedRevisionItem` and  `LinkToRevision` components to copy revision hash

Before

https://github.com/user-attachments/assets/cb73749e-b570-4a32-8006-69cc8c06b4bf

After 

https://github.com/user-attachments/assets/2ddd876e-1fb8-472c-a708-337b0b7dd1b2






