### PR TITLE
Pin our node version to v20 due to test errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,14 @@ orbs:
   node: circleci/node@5.1.0
   codecov: codecov/codecov@3.2.2
 
+executors:
+  node:
+    docker:
+      - image: cimg/node:20.18
+
 jobs:
   tests:
-    executor: node/default
+    executor: node
     steps:
       - checkout
       - node/install-packages
@@ -20,7 +25,7 @@ jobs:
       - codecov/upload
 
   lint:
-    executor: node/default
+    executor: node
     steps:
       - checkout
       - node/install-packages
@@ -32,7 +37,7 @@ jobs:
           command: npm run format:check
 
   typescript:
-    executor: node/default
+    executor: node
     steps:
       - checkout
       - node/install-packages

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ PerfCompare is hosted on Netlify, and is updated every time commits are pushed t
 ### Requirements
 
 - [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-- [nodejs](https://nodejs.org/en/download/), at least version 20.
+- [nodejs](https://nodejs.org/en/download/), version 20. Note that version 22 is
+  known to produce test errors.
 
 ### Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,7 +103,7 @@
         "webpack-merge": "^5.8.0"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 20 < 21"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "version": "0.9.0",
   "private": true,
   "engines": {
-    "node": ">= 20"
+    "node": ">= 20 < 21"
   },
   "devEngines": {
     "runtime": {
       "name": "node",
-      "version": ">= 20"
+      "version": ">= 20 < 21"
     },
     "packageManager": {
       "name": "npm"


### PR DESCRIPTION
It looks like v22 brought ICU changes, that make our test fail. Let's pin our node version to v20.
We'll move to v22 a bit later in the year.