### PR TITLE
Implement loading spinner for Subtests Results Page 

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -68,7 +68,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-z2teic-MuiGrid-root"
         >
           <div
-            class="MuiContainer-root fjvfn2t css-1avmhz-MuiContainer-root"
+            class="MuiContainer-root MuiContainer-maxWidthLg fjvfn2t css-1oqqzyl-MuiContainer-root"
             data-testid="subtests-main"
           >
             <header>
@@ -304,7 +304,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                           aria-invalid="false"
                           aria-label="Search by title, platform, revision or options"
                           class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-rg83rj-MuiInputBase-input-MuiOutlinedInput-input"
-                          id=":r1:"
+                          id=":ra:"
                           placeholder="Search results"
                           type="text"
                           value=""
@@ -789,7 +789,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   role="cell"
                 >
                   <button
-                    aria-controls=":ra:"
+                    aria-controls=":rd:"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -947,7 +947,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   role="cell"
                 >
                   <button
-                    aria-controls=":rb:"
+                    aria-controls=":re:"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -1116,7 +1116,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   role="cell"
                 >
                   <button
-                    aria-controls=":rc:"
+                    aria-controls=":rf:"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -1285,7 +1285,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   role="cell"
                 >
                   <button
-                    aria-controls=":rd:"
+                    aria-controls=":rg:"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -1443,7 +1443,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   role="cell"
                 >
                   <button
-                    aria-controls=":re:"
+                    aria-controls=":rh:"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -1893,7 +1893,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-z2teic-MuiGrid-root"
         >
           <div
-            class="MuiContainer-root fjvfn2t css-1avmhz-MuiContainer-root"
+            class="MuiContainer-root MuiContainer-maxWidthLg fjvfn2t css-1oqqzyl-MuiContainer-root"
             data-testid="subtests-main"
           >
             <header>
@@ -2121,7 +2121,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                           aria-invalid="false"
                           aria-label="Search by title, platform, revision or options"
                           class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-rg83rj-MuiInputBase-input-MuiOutlinedInput-input"
-                          id=":r3a:"
+                          id=":r4h:"
                           placeholder="Search results"
                           type="text"
                           value=""
@@ -2606,7 +2606,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   role="cell"
                 >
                   <button
-                    aria-controls=":r3j:"
+                    aria-controls=":r4k:"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -2764,7 +2764,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   role="cell"
                 >
                   <button
-                    aria-controls=":r3k:"
+                    aria-controls=":r4l:"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -2933,7 +2933,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   role="cell"
                 >
                   <button
-                    aria-controls=":r3l:"
+                    aria-controls=":r4m:"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -3102,7 +3102,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   role="cell"
                 >
                   <button
-                    aria-controls=":r3m:"
+                    aria-controls=":r4n:"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -3260,7 +3260,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   role="cell"
                 >
                   <button
-                    aria-controls=":r3n:"
+                    aria-controls=":r4o:"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1itd531-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"

--- a/src/components/CompareResults/Retrigger/RetriggerButton.tsx
+++ b/src/components/CompareResults/Retrigger/RetriggerButton.tsx
@@ -24,21 +24,21 @@ import SnackbarCloseButton from '../../Shared/SnackbarCloseButton';
 type Status = 'pending' | 'signin-modal' | 'retrigger-modal';
 
 interface RetriggerButtonProps {
-  result: CompareResultsItem;
+  result?: CompareResultsItem;
   variant: 'icon' | 'text';
 }
 
 function RetriggerButton({ result, variant }: RetriggerButtonProps) {
   const {
-    base_repository_name: baseRepository,
-    base_retriggerable_job_ids: baseRetriggerableJobIds,
-    new_repository_name: newRepository,
-    new_retriggerable_job_ids: newRetriggerableJobIds,
-    base_rev: baseRev,
-    new_rev: newRev,
-    base_repository_name: baseRepo,
-    new_repository_name: newRepo,
-  } = result;
+    base_repository_name: baseRepository = '',
+    base_retriggerable_job_ids: baseRetriggerableJobIds = [],
+    new_repository_name: newRepository = '',
+    new_retriggerable_job_ids: newRetriggerableJobIds = [],
+    base_rev: baseRev = '',
+    new_rev: newRev = '',
+    base_repository_name: baseRepo = 'try',
+    new_repository_name: newRepo = 'try',
+  } = result ?? {};
 
   const [status, setStatus] = useState('pending' as Status);
   const { enqueueSnackbar } = useSnackbar();
@@ -164,6 +164,7 @@ function RetriggerButton({ result, variant }: RetriggerButtonProps) {
           variant='text'
           onClick={() => void onRetriggerButtonClick()}
           startIcon={<RefreshOutlinedIcon />}
+          disabled={!result}
         >
           Retrigger test
         </Button>
@@ -173,6 +174,7 @@ function RetriggerButton({ result, variant }: RetriggerButtonProps) {
           color='primary'
           size='small'
           onClick={() => void onRetriggerButtonClick()}
+          disabled={!result}
         >
           <RefreshOutlinedIcon />
         </IconButton>

--- a/src/components/CompareResults/subtestsLoader.ts
+++ b/src/components/CompareResults/subtestsLoader.ts
@@ -107,7 +107,7 @@ function checkValues({
 // by React Router DOM when the compare-results path is requested.
 // It uses the URL parameters as inputs, and returns all the fetched data to the
 // React components through React Router's useLoaderData hook.
-export async function loader({ request }: { request: Request }) {
+export function loader({ request }: { request: Request }) {
   const url = new URL(request.url);
 
   const baseRevFromUrl = url.searchParams.get('baseRev');
@@ -143,7 +143,7 @@ export async function loader({ request }: { request: Request }) {
     newParentSignature: newParentSignatureFromUrl,
   });
 
-  const results = await fetchSubtestsCompareResults({
+  const results = fetchSubtestsCompareResults({
     baseRev,
     baseRepo,
     newRev,


### PR DESCRIPTION
# Add Loading Spinner for Subtests Results  
[Bug 1917858](https://bugzilla.mozilla.org/show_bug.cgi?id=1917858) 

## Description  
This PR introduces a loading state for the `SubtestsResultsMain` component, improving the user experience while results are being fetched. Previously, the component relied on the raw promise resolution, which could lead to a blank screen before data was available. Now, a `Skeleton` loader and a loading indicator are displayed while the results are being fetched.  

## Changes  
- Implemented `useState` hooks for `isLoading` and `error` states.  
- Wrapped the results promise with `.then()` and `.catch()` to handle loading and error states properly within a useEffect().  
- Displayed a `Skeleton` loader and UI placeholders while data is being retrieved.
- Made the `result` prop optional for the retrigger button so the button can be displayed as a placeholder even when the results are not available.
- Ensured proper cleanup using `isMounted` to avoid state updates on unmounted components.  
- Maintained existing search functionality and table rendering.  

## Testing  
- Verified that the spinner appears while waiting for results.  
- Checked that data loads correctly once available.  
- Ensured proper error handling and UI fallback in case of failures.  

## Screenshots  

| Spinner in action|
|--------|
| ![header-only-skeleton2](https://github.com/user-attachments/assets/8093432c-6642-473a-8c47-6d2572ffff8e) |