### PR TITLE
Add tooltip to subtest platform name

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -185,6 +185,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-g8z9fn-MuiTypography-root-MuiLink-root"
                       href="https://firefox-source-docs.mozilla.org/testing/perfdocs/talos.html#a11yr"
                       target="_blank"
+                      title="Link to suite documentation  "
                     >
                       a11yr
                     </a>
@@ -1803,6 +1804,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-g8z9fn-MuiTypography-root-MuiLink-root"
                       href="https://firefox-source-docs.mozilla.org/testing/perfdocs/talos.html#a11yr"
                       target="_blank"
+                      title="Link to suite documentation  "
                     >
                       a11yr
                     </a>

--- a/src/components/CompareResults/SubtestsResults/SubtestsRevisionHeader.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsRevisionHeader.tsx
@@ -78,6 +78,7 @@ function getSuite(
   docsURL: string,
   isLinkSupported: boolean,
 ) {
+  const suiteLink = Strings.components.revisionRow.title.suiteLink;
   if (isLinkSupported) {
     return (
       <>
@@ -86,6 +87,7 @@ function getSuite(
           underline='hover'
           target='_blank'
           href={docsURL}
+          title={suiteLink}
         >
           {header.suite}
         </Link>


### PR DESCRIPTION
[Bugzilla number](https://bugzilla.mozilla.org/show_bug.cgi?id=1946315)

[Deploy link]()

This PR adds a tooltip to the subtests' platform name. Similar to what was done for the results view here [PR](https://github.com/mozilla/perfcompare/pull/832)

![SDD](https://github.com/user-attachments/assets/83ee31cd-dd91-4434-9fd9-f80b7190b7f7)

![SDD](https://github.com/user-attachments/assets/0a48f79c-f517-43ae-a455-a379270a4124)