### PR TITLE
Increase `lineHeight` to `1.5`

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -249,7 +249,7 @@ exports[`Results View The table should match snapshot and other elements should 
       </div>
     </div>
     <div
-      class="f75bkdv fr2n4tx"
+      class="f75bkdv f19sido0"
       data-testid="table-header"
       role="row"
     >
@@ -508,7 +508,7 @@ exports[`Results View The table should match snapshot and other elements should 
               class="fh103jg"
             >
               <div
-                class="f897l9y"
+                class="f1mgfhdi"
               >
                 <strong>
                   <a
@@ -524,7 +524,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </strong>
                  
                 <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways f897l9y css-1qhous5-MuiTypography-root-MuiLink-root"
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways f1mgfhdi css-1qhous5-MuiTypography-root-MuiLink-root"
                   href="https://treeherder.mozilla.org/jobs?repo=mozilla-central&revision=spam"
                   target="_blank"
                   title="open treeherder view for spam"
@@ -566,7 +566,7 @@ exports[`Results View The table should match snapshot and other elements should 
               class="fw0pvlu"
             >
               <div
-                class="revisionRow fqyfrhr fp4ugv1 MuiBox-root css-1txhl5e"
+                class="revisionRow fqyfrhr f1vh4jdk MuiBox-root css-1txhl5e"
                 role="row"
               >
                 <div
@@ -791,7 +791,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow fqyfrhr fp4ugv1 MuiBox-root css-1txhl5e"
+                class="revisionRow fqyfrhr f1vh4jdk MuiBox-root css-1txhl5e"
                 role="row"
               >
                 <div
@@ -1017,7 +1017,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow fqyfrhr fp4ugv1 MuiBox-root css-1txhl5e"
+                class="revisionRow fqyfrhr f1vh4jdk MuiBox-root css-1txhl5e"
                 role="row"
               >
                 <div
@@ -1221,7 +1221,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow fqyfrhr fp4ugv1 MuiBox-root css-1txhl5e"
+                class="revisionRow fqyfrhr f1vh4jdk MuiBox-root css-1txhl5e"
                 role="row"
               >
                 <div

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Results Table Should match snapshot 1`] = `
         class="MuiGrid-root header-container container_f1ocj467 css-plh9qo-MuiGrid-root"
       >
         <div
-          class="toggle-dark-mode f10ie5uy MuiBox-root css-0"
+          class="toggle-dark-mode fc950xb MuiBox-root css-0"
         >
           <div
             class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -44,7 +44,7 @@ exports[`Results Table Should match snapshot 1`] = `
                 />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-13qdlub-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1m50to5-MuiTypography-root"
               >
                 Dark mode
               </span>
@@ -62,7 +62,7 @@ exports[`Results Table Should match snapshot 1`] = `
         </div>
       </div>
       <section
-        class="container_fk3n580"
+        class="container_frwb35k"
       >
         <a
           aria-label="link to home"
@@ -132,7 +132,7 @@ exports[`Results Table Should match snapshot 1`] = `
                 class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -159,7 +159,7 @@ exports[`Results Table Should match snapshot 1`] = `
                   id="base-search-container"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9 small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
                     id="base_search-dropdown"
                   >
                     <div
@@ -207,7 +207,7 @@ exports[`Results Table Should match snapshot 1`] = `
                       class="MuiBox-root css-0"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+                        class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
                       >
                         <div
                           class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -264,7 +264,7 @@ exports[`Results Table Should match snapshot 1`] = `
                   data-testid="base-selected-revision"
                 >
                   <div
-                    class="box_fobrng5 base-box MuiBox-root css-0"
+                    class="box_f1yxlro0 base-box MuiBox-root css-0"
                   >
                     <ul
                       class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -291,13 +291,13 @@ exports[`Results Table Should match snapshot 1`] = `
                           </div>
                         </div>
                         <div
-                          class="selectedRevision_fd452xz MuiBox-root css-0"
+                          class="selectedRevision_f1jffy9s MuiBox-root css-0"
                         >
                           <div
                             class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
                           >
                             <span
-                              class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                              class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                             >
                               <span
                                 class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -394,7 +394,7 @@ exports[`Results Table Should match snapshot 1`] = `
                 class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -421,7 +421,7 @@ exports[`Results Table Should match snapshot 1`] = `
                   id="new-search-container"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
                     id="new_search-dropdown"
                   >
                     <div
@@ -469,7 +469,7 @@ exports[`Results Table Should match snapshot 1`] = `
                       class="MuiBox-root css-0"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+                        class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
                       >
                         <div
                           class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -526,7 +526,7 @@ exports[`Results Table Should match snapshot 1`] = `
                   data-testid="new-selected-revision"
                 >
                   <div
-                    class="box_fobrng5 new-box MuiBox-root css-0"
+                    class="box_f1yxlro0 new-box MuiBox-root css-0"
                   >
                     <ul
                       class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -553,13 +553,13 @@ exports[`Results Table Should match snapshot 1`] = `
                           </div>
                         </div>
                         <div
-                          class="selectedRevision_fd452xz MuiBox-root css-0"
+                          class="selectedRevision_f1jffy9s MuiBox-root css-0"
                         >
                           <div
                             class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
                           >
                             <span
-                              class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                              class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                             >
                               <span
                                 class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -676,12 +676,12 @@ exports[`Results Table Should match snapshot 1`] = `
                 class="MuiGrid-root MuiGrid-container fau5w0k css-jryjzr-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-item f1q8wx css-j8gwlw-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item f166i79l css-j8gwlw-MuiGrid-root"
                 >
                   Results
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item f1it3pp1 css-j8gwlw-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item f3zbktx css-j8gwlw-MuiGrid-root"
                 >
                   Compare with a base
                 </div>
@@ -973,7 +973,7 @@ exports[`Results Table Should match snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="f75bkdv fr2n4tx"
+                  class="f75bkdv f19sido0"
                   data-testid="table-header"
                   role="row"
                 >
@@ -1232,7 +1232,7 @@ exports[`Results Table Should match snapshot 1`] = `
                           class="fh103jg"
                         >
                           <div
-                            class="f897l9y"
+                            class="f1mgfhdi"
                           >
                             <strong>
                               <a
@@ -1248,7 +1248,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </strong>
                              
                             <a
-                              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways f897l9y css-1qhous5-MuiTypography-root-MuiLink-root"
+                              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways f1mgfhdi css-1qhous5-MuiTypography-root-MuiLink-root"
                               href="https://treeherder.mozilla.org/jobs?repo=mozilla-central&revision=spam"
                               target="_blank"
                               title="open treeherder view for spam"
@@ -1290,7 +1290,7 @@ exports[`Results Table Should match snapshot 1`] = `
                           class="fw0pvlu"
                         >
                           <div
-                            class="revisionRow fqyfrhr fp4ugv1 MuiBox-root css-1txhl5e"
+                            class="revisionRow fqyfrhr f1vh4jdk MuiBox-root css-1txhl5e"
                             role="row"
                           >
                             <div
@@ -1515,7 +1515,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </div>
                           </div>
                           <div
-                            class="revisionRow fqyfrhr fp4ugv1 MuiBox-root css-1txhl5e"
+                            class="revisionRow fqyfrhr f1vh4jdk MuiBox-root css-1txhl5e"
                             role="row"
                           >
                             <div
@@ -1741,7 +1741,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </div>
                           </div>
                           <div
-                            class="revisionRow fqyfrhr fp4ugv1 MuiBox-root css-1txhl5e"
+                            class="revisionRow fqyfrhr f1vh4jdk MuiBox-root css-1txhl5e"
                             role="row"
                           >
                             <div
@@ -1972,7 +1972,7 @@ exports[`Results Table Should match snapshot 1`] = `
                           class="fh103jg"
                         >
                           <div
-                            class="f897l9y"
+                            class="f1mgfhdi"
                           >
                             <strong>
                               <a
@@ -1988,7 +1988,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </strong>
                              
                             <a
-                              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways f897l9y css-1qhous5-MuiTypography-root-MuiLink-root"
+                              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways f1mgfhdi css-1qhous5-MuiTypography-root-MuiLink-root"
                               href="https://treeherder.mozilla.org/jobs?repo=mozilla-central&revision=spam"
                               target="_blank"
                               title="open treeherder view for spam"
@@ -2010,7 +2010,7 @@ exports[`Results Table Should match snapshot 1`] = `
                           class="fw0pvlu"
                         >
                           <div
-                            class="revisionRow fqyfrhr fp4ugv1 MuiBox-root css-1txhl5e"
+                            class="revisionRow fqyfrhr f1vh4jdk MuiBox-root css-1txhl5e"
                             role="row"
                           >
                             <div
@@ -2484,7 +2484,7 @@ exports[`Results Table should render different blocks when rendering several rev
     class="fh103jg"
   >
     <div
-      class="f897l9y"
+      class="f1mgfhdi"
     >
       <strong>
         <a
@@ -2533,7 +2533,7 @@ exports[`Results Table should render different blocks when rendering several rev
     class="fw0pvlu"
   >
     <a
-      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways f897l9y css-1qhous5-MuiTypography-root-MuiLink-root"
+      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways f1mgfhdi css-1qhous5-MuiTypography-root-MuiLink-root"
       href="https://treeherder.mozilla.org/jobs?repo=mozilla-central&revision=spam"
       target="_blank"
       title="open treeherder view for spam"
@@ -2541,7 +2541,7 @@ exports[`Results Table should render different blocks when rendering several rev
       spam
     </a>
     <div
-      class="revisionRow fqyfrhr fp4ugv1 MuiBox-root css-1txhl5e"
+      class="revisionRow fqyfrhr f1vh4jdk MuiBox-root css-1txhl5e"
       role="row"
     >
       <div
@@ -2771,7 +2771,7 @@ exports[`Results Table should render different blocks when rendering several rev
     class="fw0pvlu"
   >
     <a
-      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways f897l9y css-1qhous5-MuiTypography-root-MuiLink-root"
+      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways f1mgfhdi css-1qhous5-MuiTypography-root-MuiLink-root"
       href="https://treeherder.mozilla.org/jobs?repo=mozilla-central&revision=devilrabbit"
       target="_blank"
       title="open treeherder view for devilrabbit"
@@ -2779,7 +2779,7 @@ exports[`Results Table should render different blocks when rendering several rev
       devilrabbit
     </a>
     <div
-      class="revisionRow fqyfrhr fp4ugv1 MuiBox-root css-1txhl5e"
+      class="revisionRow fqyfrhr f1vh4jdk MuiBox-root css-1txhl5e"
       role="row"
     >
       <div

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Results Table Should match snapshot 1`] = `
         class="MuiGrid-root header-container container_f1ocj467 css-plh9qo-MuiGrid-root"
       >
         <div
-          class="toggle-dark-mode fc950xb MuiBox-root css-0"
+          class="toggle-dark-mode fkud7h4 MuiBox-root css-0"
         >
           <div
             class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -44,7 +44,7 @@ exports[`Results Table Should match snapshot 1`] = `
                 />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1m50to5-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-smpupv-MuiTypography-root"
               >
                 Dark mode
               </span>
@@ -55,14 +55,14 @@ exports[`Results Table Should match snapshot 1`] = `
           class="header-text MuiBox-root css-0"
         >
           <h1
-            class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-160ox9e-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-eaa0qe-MuiTypography-root"
           >
             PerfCompare
           </h1>
         </div>
       </div>
       <section
-        class="container_frwb35k"
+        class="container_fdgf30v"
       >
         <a
           aria-label="link to home"
@@ -132,7 +132,7 @@ exports[`Results Table Should match snapshot 1`] = `
                 class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -159,7 +159,7 @@ exports[`Results Table Should match snapshot 1`] = `
                   id="base-search-container"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
                     id="base_search-dropdown"
                   >
                     <div
@@ -207,7 +207,7 @@ exports[`Results Table Should match snapshot 1`] = `
                       class="MuiBox-root css-0"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+                        class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
                       >
                         <div
                           class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -264,7 +264,7 @@ exports[`Results Table Should match snapshot 1`] = `
                   data-testid="base-selected-revision"
                 >
                   <div
-                    class="box_f1yxlro0 base-box MuiBox-root css-0"
+                    class="box_ffdb50n base-box MuiBox-root css-0"
                   >
                     <ul
                       class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -291,13 +291,13 @@ exports[`Results Table Should match snapshot 1`] = `
                           </div>
                         </div>
                         <div
-                          class="selectedRevision_f1jffy9s MuiBox-root css-0"
+                          class="selectedRevision_fmpcdiu MuiBox-root css-0"
                         >
                           <div
                             class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
                           >
                             <span
-                              class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                              class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                             >
                               <span
                                 class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -394,7 +394,7 @@ exports[`Results Table Should match snapshot 1`] = `
                 class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -421,7 +421,7 @@ exports[`Results Table Should match snapshot 1`] = `
                   id="new-search-container"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
                     id="new_search-dropdown"
                   >
                     <div
@@ -469,7 +469,7 @@ exports[`Results Table Should match snapshot 1`] = `
                       class="MuiBox-root css-0"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+                        class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
                       >
                         <div
                           class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -526,7 +526,7 @@ exports[`Results Table Should match snapshot 1`] = `
                   data-testid="new-selected-revision"
                 >
                   <div
-                    class="box_f1yxlro0 new-box MuiBox-root css-0"
+                    class="box_ffdb50n new-box MuiBox-root css-0"
                   >
                     <ul
                       class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -553,13 +553,13 @@ exports[`Results Table Should match snapshot 1`] = `
                           </div>
                         </div>
                         <div
-                          class="selectedRevision_f1jffy9s MuiBox-root css-0"
+                          class="selectedRevision_fmpcdiu MuiBox-root css-0"
                         >
                           <div
                             class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
                           >
                             <span
-                              class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                              class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                             >
                               <span
                                 class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -676,12 +676,12 @@ exports[`Results Table Should match snapshot 1`] = `
                 class="MuiGrid-root MuiGrid-container fau5w0k css-jryjzr-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-item f166i79l css-j8gwlw-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item f1sq1266 css-j8gwlw-MuiGrid-root"
                 >
                   Results
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item f3zbktx css-j8gwlw-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item f1rv70v6 css-j8gwlw-MuiGrid-root"
                 >
                   Compare with a base
                 </div>

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -1065,7 +1065,7 @@ exports[`Results View The table should match snapshot and other elements should 
       </div>
     </div>
     <div
-      class="f75bkdv fr2n4tx"
+      class="f75bkdv f19sido0"
       data-testid="table-header"
       role="row"
     >
@@ -1324,7 +1324,7 @@ exports[`Results View The table should match snapshot and other elements should 
               class="fh103jg"
             >
               <div
-                class="f897l9y"
+                class="f1mgfhdi"
               >
                 <strong>
                   <a
@@ -1340,7 +1340,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </strong>
                  
                 <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways f897l9y css-1qhous5-MuiTypography-root-MuiLink-root"
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways f1mgfhdi css-1qhous5-MuiTypography-root-MuiLink-root"
                   href="https://treeherder.mozilla.org/jobs?repo=mozilla-central&revision=spam"
                   target="_blank"
                   title="open treeherder view for spam"
@@ -1382,7 +1382,7 @@ exports[`Results View The table should match snapshot and other elements should 
               class="fw0pvlu"
             >
               <div
-                class="revisionRow fqyfrhr fp4ugv1 MuiBox-root css-1txhl5e"
+                class="revisionRow fqyfrhr f1vh4jdk MuiBox-root css-1txhl5e"
                 role="row"
               >
                 <div
@@ -1607,7 +1607,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow fqyfrhr fp4ugv1 MuiBox-root css-1txhl5e"
+                class="revisionRow fqyfrhr f1vh4jdk MuiBox-root css-1txhl5e"
                 role="row"
               >
                 <div
@@ -1833,7 +1833,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow fqyfrhr fp4ugv1 MuiBox-root css-1txhl5e"
+                class="revisionRow fqyfrhr f1vh4jdk MuiBox-root css-1txhl5e"
                 role="row"
               >
                 <div
@@ -2037,7 +2037,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow fqyfrhr fp4ugv1 MuiBox-root css-1txhl5e"
+                class="revisionRow fqyfrhr f1vh4jdk MuiBox-root css-1txhl5e"
                 role="row"
               >
                 <div

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
         class="MuiGrid-root header-container container_f1ocj467 css-plh9qo-MuiGrid-root"
       >
         <div
-          class="toggle-dark-mode fc950xb MuiBox-root css-0"
+          class="toggle-dark-mode fkud7h4 MuiBox-root css-0"
         >
           <div
             class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -44,7 +44,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1m50to5-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-smpupv-MuiTypography-root"
               >
                 Dark mode
               </span>
@@ -55,7 +55,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
           class="header-text MuiBox-root css-0"
         >
           <h1
-            class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-160ox9e-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-eaa0qe-MuiTypography-root"
           >
             PerfCompare
           </h1>
@@ -73,7 +73,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
           >
             <header>
               <nav
-                class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-1tbt47c-MuiTypography-root-MuiBreadcrumbs-root"
+                class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-dr2htm-MuiTypography-root-MuiBreadcrumbs-root"
               >
                 <ol
                   class="MuiBreadcrumbs-ol css-4pdmu4-MuiBreadcrumbs-ol"
@@ -1659,7 +1659,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
         class="MuiGrid-root header-container container_f1ocj467 css-plh9qo-MuiGrid-root"
       >
         <div
-          class="toggle-dark-mode fc950xb MuiBox-root css-0"
+          class="toggle-dark-mode fkud7h4 MuiBox-root css-0"
         >
           <div
             class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -1692,7 +1692,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1m50to5-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-smpupv-MuiTypography-root"
               >
                 Dark mode
               </span>
@@ -1703,7 +1703,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
           class="header-text MuiBox-root css-0"
         >
           <h1
-            class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-160ox9e-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-eaa0qe-MuiTypography-root"
           >
             PerfCompare
           </h1>
@@ -1721,7 +1721,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
           >
             <header>
               <nav
-                class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-1tbt47c-MuiTypography-root-MuiBreadcrumbs-root"
+                class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-dr2htm-MuiTypography-root-MuiBreadcrumbs-root"
               >
                 <ol
                   class="MuiBreadcrumbs-ol css-4pdmu4-MuiBreadcrumbs-ol"

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
         class="MuiGrid-root header-container container_f1ocj467 css-plh9qo-MuiGrid-root"
       >
         <div
-          class="toggle-dark-mode f10ie5uy MuiBox-root css-0"
+          class="toggle-dark-mode fc950xb MuiBox-root css-0"
         >
           <div
             class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -44,7 +44,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-13qdlub-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1m50to5-MuiTypography-root"
               >
                 Dark mode
               </span>
@@ -73,7 +73,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
           >
             <header>
               <nav
-                class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-arz7ur-MuiTypography-root-MuiBreadcrumbs-root"
+                class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-1tbt47c-MuiTypography-root-MuiBreadcrumbs-root"
               >
                 <ol
                   class="MuiBreadcrumbs-ol css-4pdmu4-MuiBreadcrumbs-ol"
@@ -177,7 +177,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 class="fcqhb81"
               >
                 <div
-                  class="f897l9y"
+                  class="f1mgfhdi"
                 >
                   <strong>
                     <a
@@ -402,7 +402,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
               role="table"
             >
               <div
-                class="f1ptnq46 fr2n4tx"
+                class="f1ptnq46 f19sido0"
                 data-testid="table-header"
                 role="row"
               >
@@ -629,7 +629,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 />
               </div>
               <div
-                class="revisionRow f15pv6go fp4ugv1 MuiBox-root css-ux85ba"
+                class="revisionRow f15pv6go f1vh4jdk MuiBox-root css-ux85ba"
                 role="row"
               >
                 <div
@@ -789,7 +789,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow f15pv6go fp4ugv1 MuiBox-root css-ux85ba"
+                class="revisionRow f15pv6go f1vh4jdk MuiBox-root css-ux85ba"
                 role="row"
               >
                 <div
@@ -960,7 +960,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow f15pv6go fp4ugv1 MuiBox-root css-ux85ba"
+                class="revisionRow f15pv6go f1vh4jdk MuiBox-root css-ux85ba"
                 role="row"
               >
                 <div
@@ -1131,7 +1131,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow f15pv6go fp4ugv1 MuiBox-root css-ux85ba"
+                class="revisionRow f15pv6go f1vh4jdk MuiBox-root css-ux85ba"
                 role="row"
               >
                 <div
@@ -1659,7 +1659,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
         class="MuiGrid-root header-container container_f1ocj467 css-plh9qo-MuiGrid-root"
       >
         <div
-          class="toggle-dark-mode f10ie5uy MuiBox-root css-0"
+          class="toggle-dark-mode fc950xb MuiBox-root css-0"
         >
           <div
             class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -1692,7 +1692,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-13qdlub-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1m50to5-MuiTypography-root"
               >
                 Dark mode
               </span>
@@ -1721,7 +1721,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
           >
             <header>
               <nav
-                class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-arz7ur-MuiTypography-root-MuiBreadcrumbs-root"
+                class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-1tbt47c-MuiTypography-root-MuiBreadcrumbs-root"
               >
                 <ol
                   class="MuiBreadcrumbs-ol css-4pdmu4-MuiBreadcrumbs-ol"
@@ -1825,7 +1825,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 class="fcqhb81"
               >
                 <div
-                  class="f897l9y"
+                  class="f1mgfhdi"
                 >
                   <strong>
                     <a
@@ -2042,7 +2042,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
               role="table"
             >
               <div
-                class="f1ptnq46 fr2n4tx"
+                class="f1ptnq46 f19sido0"
                 data-testid="table-header"
                 role="row"
               >
@@ -2269,7 +2269,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 />
               </div>
               <div
-                class="revisionRow f15pv6go fp4ugv1 MuiBox-root css-ux85ba"
+                class="revisionRow f15pv6go f1vh4jdk MuiBox-root css-ux85ba"
                 role="row"
               >
                 <div
@@ -2429,7 +2429,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow f15pv6go fp4ugv1 MuiBox-root css-ux85ba"
+                class="revisionRow f15pv6go f1vh4jdk MuiBox-root css-ux85ba"
                 role="row"
               >
                 <div
@@ -2600,7 +2600,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow f15pv6go fp4ugv1 MuiBox-root css-ux85ba"
+                class="revisionRow f15pv6go f1vh4jdk MuiBox-root css-ux85ba"
                 role="row"
               >
                 <div
@@ -2771,7 +2771,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow f15pv6go fp4ugv1 MuiBox-root css-ux85ba"
+                class="revisionRow f15pv6go f1vh4jdk MuiBox-root css-ux85ba"
                 role="row"
               >
                 <div

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsRevisionRow.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsRevisionRow.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`SubtestsRevisionRow Component renders the component with correct data 1
 <body>
   <div>
     <div
-      class="revisionRow f15pv6go fp4ugv1 MuiBox-root css-1ykk23q"
+      class="revisionRow f15pv6go f1vh4jdk MuiBox-root css-1ykk23q"
       role="row"
     >
       <div

--- a/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f5zlgu9 css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -108,7 +108,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f5zlgu9   css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1mtgqas   css-1t7ybvx-MuiGrid-root"
         id="time-range"
         style="max-width: 365px;"
       >
@@ -162,7 +162,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -190,7 +190,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9  -new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -238,7 +238,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -294,7 +294,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_fobrng5 new-box MuiBox-root css-0"
+        class="box_f1yxlro0 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -303,7 +303,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f5zlgu9 css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -423,7 +423,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f5zlgu9 css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -477,7 +477,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
       id="time-search-container--readonly"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_f5zlgu9  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_f1mtgqas  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
         style="max-width: 415px;"
       >
         <span
@@ -507,7 +507,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -533,7 +533,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_fobrng5 new-box MuiBox-root css-0"
+        class="box_f1yxlro0 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -560,13 +560,13 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
               </div>
             </div>
             <div
-              class="selectedRevision_fd452xz MuiBox-root css-0"
+              class="selectedRevision_f1jffy9s MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -890,7 +890,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f5zlgu9 css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -988,7 +988,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown small dropDown_f5zlgu9   css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown small dropDown_f1mtgqas   css-1t7ybvx-MuiGrid-root"
         id="time-range"
         style="max-width: 415px;"
       >
@@ -1042,7 +1042,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1070,7 +1070,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 small compare-over-time-results-new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas small compare-over-time-results-new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -1118,7 +1118,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -1174,7 +1174,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_fobrng5 new-box MuiBox-root css-0"
+        class="box_f1yxlro0 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1201,13 +1201,13 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
               </div>
             </div>
             <div
-              class="selectedRevision_fd452xz MuiBox-root css-0"
+              class="selectedRevision_f1jffy9s MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -1301,7 +1301,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f5zlgu9 css-13jteey-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-13jteey-MuiGrid-root"
   >
     <div
       class="fs9pw6x cancel-compare"
@@ -1374,7 +1374,7 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f5zlgu9 css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -1428,7 +1428,7 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
       id="time-search-container--readonly"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_f5zlgu9  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_f1mtgqas  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
         style="max-width: 415px;"
       >
         <span
@@ -1458,7 +1458,7 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1484,7 +1484,7 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_fobrng5 new-box MuiBox-root css-0"
+        class="box_f1yxlro0 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1511,13 +1511,13 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
               </div>
             </div>
             <div
-              class="selectedRevision_fd452xz MuiBox-root css-0"
+              class="selectedRevision_f1jffy9s MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -1628,7 +1628,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f5zlgu9 css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -1726,7 +1726,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f5zlgu9   css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1mtgqas   css-1t7ybvx-MuiGrid-root"
         id="time-range"
         style="max-width: 365px;"
       >
@@ -1780,7 +1780,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1808,7 +1808,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9  -new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -1856,7 +1856,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -1912,7 +1912,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_fobrng5 new-box MuiBox-root css-0"
+        class="box_f1yxlro0 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1921,7 +1921,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f5zlgu9 css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -2050,7 +2050,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f5zlgu9 css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -2104,7 +2104,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       id="time-search-container--readonly"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_f5zlgu9  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_f1mtgqas  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
         style="max-width: 415px;"
       >
         <span
@@ -2134,7 +2134,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -2160,7 +2160,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_fobrng5 new-box MuiBox-root css-0"
+        class="box_f1yxlro0 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2187,13 +2187,13 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
               </div>
             </div>
             <div
-              class="selectedRevision_fd452xz MuiBox-root css-0"
+              class="selectedRevision_f1jffy9s MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -2304,13 +2304,13 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
               </div>
             </div>
             <div
-              class="selectedRevision_fd452xz MuiBox-root css-0"
+              class="selectedRevision_f1jffy9s MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -2456,7 +2456,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f5zlgu9 css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -2554,7 +2554,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown small dropDown_f5zlgu9   css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown small dropDown_f1mtgqas   css-1t7ybvx-MuiGrid-root"
         id="time-range"
         style="max-width: 415px;"
       >
@@ -2608,7 +2608,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -2636,7 +2636,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 small compare-over-time-results-new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas small compare-over-time-results-new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -2684,7 +2684,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -2740,7 +2740,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_fobrng5 new-box MuiBox-root css-0"
+        class="box_f1yxlro0 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2767,13 +2767,13 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
               </div>
             </div>
             <div
-              class="selectedRevision_fd452xz MuiBox-root css-0"
+              class="selectedRevision_f1jffy9s MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -2867,7 +2867,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f5zlgu9 css-13jteey-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-13jteey-MuiGrid-root"
   >
     <div
       class="fs9pw6x cancel-compare"
@@ -2940,7 +2940,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f5zlgu9 css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -2994,7 +2994,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       id="time-search-container--readonly"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_f5zlgu9  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_f1mtgqas  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
         style="max-width: 415px;"
       >
         <span
@@ -3024,7 +3024,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -3050,7 +3050,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_fobrng5 new-box MuiBox-root css-0"
+        class="box_f1yxlro0 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -3077,13 +3077,13 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
               </div>
             </div>
             <div
-              class="selectedRevision_fd452xz MuiBox-root css-0"
+              class="selectedRevision_f1jffy9s MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"

--- a/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_fgr49yr css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -108,7 +108,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1mtgqas   css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_fgr49yr   css-1t7ybvx-MuiGrid-root"
         id="time-range"
         style="max-width: 365px;"
       >
@@ -162,7 +162,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -190,7 +190,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr  -new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -238,7 +238,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -294,7 +294,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_f1yxlro0 new-box MuiBox-root css-0"
+        class="box_ffdb50n new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -303,7 +303,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fgr49yr css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -423,7 +423,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_fgr49yr css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -477,7 +477,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
       id="time-search-container--readonly"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_f1mtgqas  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_fgr49yr  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
         style="max-width: 415px;"
       >
         <span
@@ -507,7 +507,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -533,7 +533,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_f1yxlro0 new-box MuiBox-root css-0"
+        class="box_ffdb50n new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -560,13 +560,13 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
               </div>
             </div>
             <div
-              class="selectedRevision_f1jffy9s MuiBox-root css-0"
+              class="selectedRevision_fmpcdiu MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -890,7 +890,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_fgr49yr css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -988,7 +988,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown small dropDown_f1mtgqas   css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown small dropDown_fgr49yr   css-1t7ybvx-MuiGrid-root"
         id="time-range"
         style="max-width: 415px;"
       >
@@ -1042,7 +1042,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1070,7 +1070,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas small compare-over-time-results-new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr small compare-over-time-results-new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -1118,7 +1118,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -1174,7 +1174,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_f1yxlro0 new-box MuiBox-root css-0"
+        class="box_ffdb50n new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1201,13 +1201,13 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
               </div>
             </div>
             <div
-              class="selectedRevision_f1jffy9s MuiBox-root css-0"
+              class="selectedRevision_fmpcdiu MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -1301,7 +1301,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-13jteey-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fgr49yr css-13jteey-MuiGrid-root"
   >
     <div
       class="fs9pw6x cancel-compare"
@@ -1374,7 +1374,7 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_fgr49yr css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -1428,7 +1428,7 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
       id="time-search-container--readonly"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_f1mtgqas  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_fgr49yr  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
         style="max-width: 415px;"
       >
         <span
@@ -1458,7 +1458,7 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1484,7 +1484,7 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_f1yxlro0 new-box MuiBox-root css-0"
+        class="box_ffdb50n new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1511,13 +1511,13 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
               </div>
             </div>
             <div
-              class="selectedRevision_f1jffy9s MuiBox-root css-0"
+              class="selectedRevision_fmpcdiu MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -1628,7 +1628,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_fgr49yr css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -1726,7 +1726,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1mtgqas   css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_fgr49yr   css-1t7ybvx-MuiGrid-root"
         id="time-range"
         style="max-width: 365px;"
       >
@@ -1780,7 +1780,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1808,7 +1808,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr  -new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -1856,7 +1856,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -1912,7 +1912,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_f1yxlro0 new-box MuiBox-root css-0"
+        class="box_ffdb50n new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1921,7 +1921,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fgr49yr css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -2050,7 +2050,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_fgr49yr css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -2104,7 +2104,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       id="time-search-container--readonly"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_f1mtgqas  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_fgr49yr  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
         style="max-width: 415px;"
       >
         <span
@@ -2134,7 +2134,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -2160,7 +2160,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_f1yxlro0 new-box MuiBox-root css-0"
+        class="box_ffdb50n new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2187,13 +2187,13 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
               </div>
             </div>
             <div
-              class="selectedRevision_f1jffy9s MuiBox-root css-0"
+              class="selectedRevision_fmpcdiu MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -2304,13 +2304,13 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
               </div>
             </div>
             <div
-              class="selectedRevision_f1jffy9s MuiBox-root css-0"
+              class="selectedRevision_fmpcdiu MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -2456,7 +2456,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_fgr49yr css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -2554,7 +2554,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown small dropDown_f1mtgqas   css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown small dropDown_fgr49yr   css-1t7ybvx-MuiGrid-root"
         id="time-range"
         style="max-width: 415px;"
       >
@@ -2608,7 +2608,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -2636,7 +2636,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas small compare-over-time-results-new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr small compare-over-time-results-new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -2684,7 +2684,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -2740,7 +2740,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_f1yxlro0 new-box MuiBox-root css-0"
+        class="box_ffdb50n new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2767,13 +2767,13 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
               </div>
             </div>
             <div
-              class="selectedRevision_f1jffy9s MuiBox-root css-0"
+              class="selectedRevision_fmpcdiu MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -2867,7 +2867,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-13jteey-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fgr49yr css-13jteey-MuiGrid-root"
   >
     <div
       class="fs9pw6x cancel-compare"
@@ -2940,7 +2940,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_fgr49yr css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -2994,7 +2994,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       id="time-search-container--readonly"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_f1mtgqas  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_fgr49yr  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
         style="max-width: 415px;"
       >
         <span
@@ -3024,7 +3024,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -3050,7 +3050,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_f1yxlro0 new-box MuiBox-root css-0"
+        class="box_ffdb50n new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -3077,13 +3077,13 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
               </div>
             </div>
             <div
-              class="selectedRevision_f1jffy9s MuiBox-root css-0"
+              class="selectedRevision_fmpcdiu MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"

--- a/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -63,7 +63,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -111,7 +111,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -168,7 +168,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
       data-testid="base-selected-revision"
     >
       <div
-        class="box_f1yxlro0 base-box MuiBox-root css-0"
+        class="box_ffdb50n base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -215,13 +215,13 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
               </div>
             </div>
             <div
-              class="selectedRevision_f1jffy9s MuiBox-root css-0"
+              class="selectedRevision_fmpcdiu MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -318,7 +318,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -345,7 +345,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -393,7 +393,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -450,7 +450,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
       data-testid="new-selected-revision"
     >
       <div
-        class="box_f1yxlro0 new-box MuiBox-root css-0"
+        class="box_ffdb50n new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -497,13 +497,13 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
               </div>
             </div>
             <div
-              class="selectedRevision_f1jffy9s MuiBox-root css-0"
+              class="selectedRevision_fmpcdiu MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -795,7 +795,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -822,7 +822,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -870,7 +870,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -927,7 +927,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
       data-testid="base-selected-revision"
     >
       <div
-        class="box_f1yxlro0 base-box MuiBox-root css-0"
+        class="box_ffdb50n base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -974,13 +974,13 @@ exports[`Compare With Base should have an edit mode in Results View: After click
               </div>
             </div>
             <div
-              class="selectedRevision_f1jffy9s MuiBox-root css-0"
+              class="selectedRevision_fmpcdiu MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -1077,7 +1077,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1104,7 +1104,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -1152,7 +1152,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -1209,7 +1209,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
       data-testid="new-selected-revision"
     >
       <div
-        class="box_f1yxlro0 new-box MuiBox-root css-0"
+        class="box_ffdb50n new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1270,7 +1270,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1297,7 +1297,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -1345,7 +1345,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -1402,7 +1402,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
       data-testid="base-selected-revision"
     >
       <div
-        class="box_f1yxlro0 base-box MuiBox-root css-0"
+        class="box_ffdb50n base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1449,13 +1449,13 @@ exports[`Compare With Base should have an edit mode in Results View: After click
               </div>
             </div>
             <div
-              class="selectedRevision_f1jffy9s MuiBox-root css-0"
+              class="selectedRevision_fmpcdiu MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -1552,7 +1552,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1579,7 +1579,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -1627,7 +1627,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -1684,7 +1684,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
       data-testid="new-selected-revision"
     >
       <div
-        class="box_f1yxlro0 new-box MuiBox-root css-0"
+        class="box_ffdb50n new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1731,13 +1731,13 @@ exports[`Compare With Base should have an edit mode in Results View: After click
               </div>
             </div>
             <div
-              class="selectedRevision_f1jffy9s MuiBox-root css-0"
+              class="selectedRevision_fmpcdiu MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -1831,7 +1831,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-13jteey-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fgr49yr css-13jteey-MuiGrid-root"
   >
     <div
       class="fs9pw6x cancel-compare"
@@ -1904,7 +1904,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1931,7 +1931,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -1979,7 +1979,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -2036,7 +2036,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
       data-testid="base-selected-revision"
     >
       <div
-        class="box_f1yxlro0 base-box MuiBox-root css-0"
+        class="box_ffdb50n base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2083,13 +2083,13 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
               </div>
             </div>
             <div
-              class="selectedRevision_f1jffy9s MuiBox-root css-0"
+              class="selectedRevision_fmpcdiu MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -2186,7 +2186,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -2213,7 +2213,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -2261,7 +2261,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -2318,7 +2318,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
       data-testid="new-selected-revision"
     >
       <div
-        class="box_f1yxlro0 new-box MuiBox-root css-0"
+        class="box_ffdb50n new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2365,13 +2365,13 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
               </div>
             </div>
             <div
-              class="selectedRevision_f1jffy9s MuiBox-root css-0"
+              class="selectedRevision_fmpcdiu MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -2525,7 +2525,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -2552,7 +2552,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -2600,7 +2600,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -2657,7 +2657,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
       data-testid="base-selected-revision"
     >
       <div
-        class="box_f1yxlro0 base-box MuiBox-root css-0"
+        class="box_ffdb50n base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2669,7 +2669,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -2696,7 +2696,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -2744,7 +2744,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -2801,7 +2801,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
       data-testid="new-selected-revision"
     >
       <div
-        class="box_f1yxlro0 new-box MuiBox-root css-0"
+        class="box_ffdb50n new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2848,13 +2848,13 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
               </div>
             </div>
             <div
-              class="selectedRevision_f1jffy9s MuiBox-root css-0"
+              class="selectedRevision_fmpcdiu MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -2948,7 +2948,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-13jteey-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fgr49yr css-13jteey-MuiGrid-root"
   >
     <div
       class="fs9pw6x cancel-compare"
@@ -3046,7 +3046,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -3073,7 +3073,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -3121,7 +3121,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -3178,7 +3178,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
       data-testid="base-selected-revision"
     >
       <div
-        class="box_f1yxlro0 base-box MuiBox-root css-0"
+        class="box_ffdb50n base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -3225,13 +3225,13 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
               </div>
             </div>
             <div
-              class="selectedRevision_f1jffy9s MuiBox-root css-0"
+              class="selectedRevision_fmpcdiu MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -3328,7 +3328,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -3355,7 +3355,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -3403,7 +3403,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -3460,7 +3460,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
       data-testid="new-selected-revision"
     >
       <div
-        class="box_f1yxlro0 new-box MuiBox-root css-0"
+        class="box_ffdb50n new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -3469,7 +3469,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-13jteey-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fgr49yr css-13jteey-MuiGrid-root"
   >
     <div
       class="fs9pw6x cancel-compare"
@@ -3525,7 +3525,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
         class="MuiGrid-root header-container container_fllbiki css-plh9qo-MuiGrid-root"
       >
         <div
-          class="toggle-dark-mode fc950xb MuiBox-root css-0"
+          class="toggle-dark-mode fkud7h4 MuiBox-root css-0"
         >
           <div
             class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -3558,7 +3558,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                 />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1m50to5-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-smpupv-MuiTypography-root"
               >
                 Dark mode
               </span>
@@ -3569,12 +3569,12 @@ exports[`Compare With Base should remove the checked revision once X button is c
           class="header-text MuiBox-root css-0"
         >
           <h1
-            class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-160ox9e-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-eaa0qe-MuiTypography-root"
           >
             PerfCompare
           </h1>
           <div
-            class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-tagline css-1bmo7ho-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-tagline css-gfol4k-MuiTypography-root"
           >
             Analyze results of performance tests to detect regressions and identify opportunities for improvement.
           </div>
@@ -3591,11 +3591,11 @@ exports[`Compare With Base should remove the checked revision once X button is c
         </div>
       </div>
       <section
-        class="container_fwl891g"
+        class="container_fyuz3mb"
         data-testid="search-section"
       >
         <span
-          class="MuiTypography-root MuiTypography-body1 search-default-title css-1m50to5-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 search-default-title css-smpupv-MuiTypography-root"
         >
           Compare with a base or over time
         </span>
@@ -3605,7 +3605,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
             data-testid="base-state"
           >
             <div
-              class="compare-card-text cardText_fpjtghi"
+              class="compare-card-text cardText_fuie4ja"
             >
               <h2
                 class="MuiTypography-root MuiTypography-h2 compare-card-title css-gja6vo-MuiTypography-root"
@@ -3641,7 +3641,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                   class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -3668,7 +3668,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                     id="base-search-container"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr  -base-dropdown css-1awobkc-MuiGrid-root"
                       id="base_search-dropdown"
                     >
                       <div
@@ -3716,7 +3716,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                         class="MuiBox-root css-0"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+                          class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
                         >
                           <div
                             class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -3773,7 +3773,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                     data-testid="base-selected-revision"
                   >
                     <div
-                      class="box_f1yxlro0 base-box MuiBox-root css-0"
+                      class="box_ffdb50n base-box MuiBox-root css-0"
                     >
                       <ul
                         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -3785,7 +3785,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                   class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -3812,7 +3812,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                     id="new-search-container"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr  -base-dropdown css-1awobkc-MuiGrid-root"
                       id="new_search-dropdown"
                     >
                       <div
@@ -3860,7 +3860,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                         class="MuiBox-root css-0"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+                          class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
                         >
                           <div
                             class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -3917,7 +3917,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                     data-testid="new-selected-revision"
                   >
                     <div
-                      class="box_f1yxlro0 new-box MuiBox-root css-0"
+                      class="box_ffdb50n new-box MuiBox-root css-0"
                     >
                       <ul
                         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -3926,7 +3926,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                   </div>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fgr49yr css-bwiycy-MuiGrid-root"
                 >
                   <div
                     class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -4017,7 +4017,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
             data-testid="time-state"
           >
             <div
-              class="compare-card-text cardText_fpjtghi"
+              class="compare-card-text cardText_fuie4ja"
             >
               <h2
                 class="MuiTypography-root MuiTypography-h2 compare-card-title css-gja6vo-MuiTypography-root"
@@ -4053,7 +4053,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                   class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_fgr49yr css-1e9xsub-MuiGrid-root"
                   >
                     <div
                       class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -4151,7 +4151,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1mtgqas   css-1t7ybvx-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_fgr49yr   css-1t7ybvx-MuiGrid-root"
                       id="time-range"
                       style="max-width: 365px;"
                     >
@@ -4205,7 +4205,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr css-13eijkh-MuiGrid-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -4233,7 +4233,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                     id="new-search-container--time"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -new-dropdown css-1awobkc-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr  -new-dropdown css-1awobkc-MuiGrid-root"
                       id="new_search-dropdown--time"
                     >
                       <div
@@ -4281,7 +4281,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                         class="MuiBox-root css-0"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+                          class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
                         >
                           <div
                             class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -4337,7 +4337,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                     class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
                   >
                     <div
-                      class="box_f1yxlro0 new-box MuiBox-root css-0"
+                      class="box_ffdb50n new-box MuiBox-root css-0"
                     >
                       <ul
                         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -4346,7 +4346,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                   </div>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fgr49yr css-bwiycy-MuiGrid-root"
                 >
                   <div
                     class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"

--- a/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -63,7 +63,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9 small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -111,7 +111,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -168,7 +168,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
       data-testid="base-selected-revision"
     >
       <div
-        class="box_fobrng5 base-box MuiBox-root css-0"
+        class="box_f1yxlro0 base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -215,13 +215,13 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
               </div>
             </div>
             <div
-              class="selectedRevision_fd452xz MuiBox-root css-0"
+              class="selectedRevision_f1jffy9s MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -318,7 +318,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -345,7 +345,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -393,7 +393,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -450,7 +450,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
       data-testid="new-selected-revision"
     >
       <div
-        class="box_fobrng5 new-box MuiBox-root css-0"
+        class="box_f1yxlro0 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -497,13 +497,13 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
               </div>
             </div>
             <div
-              class="selectedRevision_fd452xz MuiBox-root css-0"
+              class="selectedRevision_f1jffy9s MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -795,7 +795,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -822,7 +822,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9 small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -870,7 +870,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -927,7 +927,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
       data-testid="base-selected-revision"
     >
       <div
-        class="box_fobrng5 base-box MuiBox-root css-0"
+        class="box_f1yxlro0 base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -974,13 +974,13 @@ exports[`Compare With Base should have an edit mode in Results View: After click
               </div>
             </div>
             <div
-              class="selectedRevision_fd452xz MuiBox-root css-0"
+              class="selectedRevision_f1jffy9s MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -1077,7 +1077,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1104,7 +1104,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -1152,7 +1152,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -1209,7 +1209,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
       data-testid="new-selected-revision"
     >
       <div
-        class="box_fobrng5 new-box MuiBox-root css-0"
+        class="box_f1yxlro0 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1270,7 +1270,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1297,7 +1297,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9 small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -1345,7 +1345,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -1402,7 +1402,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
       data-testid="base-selected-revision"
     >
       <div
-        class="box_fobrng5 base-box MuiBox-root css-0"
+        class="box_f1yxlro0 base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1449,13 +1449,13 @@ exports[`Compare With Base should have an edit mode in Results View: After click
               </div>
             </div>
             <div
-              class="selectedRevision_fd452xz MuiBox-root css-0"
+              class="selectedRevision_f1jffy9s MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -1552,7 +1552,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1579,7 +1579,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -1627,7 +1627,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -1684,7 +1684,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
       data-testid="new-selected-revision"
     >
       <div
-        class="box_fobrng5 new-box MuiBox-root css-0"
+        class="box_f1yxlro0 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1731,13 +1731,13 @@ exports[`Compare With Base should have an edit mode in Results View: After click
               </div>
             </div>
             <div
-              class="selectedRevision_fd452xz MuiBox-root css-0"
+              class="selectedRevision_f1jffy9s MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -1831,7 +1831,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f5zlgu9 css-13jteey-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-13jteey-MuiGrid-root"
   >
     <div
       class="fs9pw6x cancel-compare"
@@ -1904,7 +1904,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1931,7 +1931,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9 small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -1979,7 +1979,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -2036,7 +2036,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
       data-testid="base-selected-revision"
     >
       <div
-        class="box_fobrng5 base-box MuiBox-root css-0"
+        class="box_f1yxlro0 base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2083,13 +2083,13 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
               </div>
             </div>
             <div
-              class="selectedRevision_fd452xz MuiBox-root css-0"
+              class="selectedRevision_f1jffy9s MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -2186,7 +2186,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -2213,7 +2213,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -2261,7 +2261,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -2318,7 +2318,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
       data-testid="new-selected-revision"
     >
       <div
-        class="box_fobrng5 new-box MuiBox-root css-0"
+        class="box_f1yxlro0 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2365,13 +2365,13 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
               </div>
             </div>
             <div
-              class="selectedRevision_fd452xz MuiBox-root css-0"
+              class="selectedRevision_f1jffy9s MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -2525,7 +2525,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -2552,7 +2552,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9 small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -2600,7 +2600,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -2657,7 +2657,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
       data-testid="base-selected-revision"
     >
       <div
-        class="box_fobrng5 base-box MuiBox-root css-0"
+        class="box_f1yxlro0 base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2669,7 +2669,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -2696,7 +2696,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -2744,7 +2744,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -2801,7 +2801,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
       data-testid="new-selected-revision"
     >
       <div
-        class="box_fobrng5 new-box MuiBox-root css-0"
+        class="box_f1yxlro0 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2848,13 +2848,13 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
               </div>
             </div>
             <div
-              class="selectedRevision_fd452xz MuiBox-root css-0"
+              class="selectedRevision_f1jffy9s MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -2948,7 +2948,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f5zlgu9 css-13jteey-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-13jteey-MuiGrid-root"
   >
     <div
       class="fs9pw6x cancel-compare"
@@ -3046,7 +3046,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -3073,7 +3073,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9 small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -3121,7 +3121,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -3178,7 +3178,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
       data-testid="base-selected-revision"
     >
       <div
-        class="box_fobrng5 base-box MuiBox-root css-0"
+        class="box_f1yxlro0 base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -3225,13 +3225,13 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
               </div>
             </div>
             <div
-              class="selectedRevision_fd452xz MuiBox-root css-0"
+              class="selectedRevision_f1jffy9s MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -3328,7 +3328,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -3355,7 +3355,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -3403,7 +3403,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -3460,7 +3460,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
       data-testid="new-selected-revision"
     >
       <div
-        class="box_fobrng5 new-box MuiBox-root css-0"
+        class="box_f1yxlro0 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -3469,7 +3469,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f5zlgu9 css-13jteey-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-13jteey-MuiGrid-root"
   >
     <div
       class="fs9pw6x cancel-compare"
@@ -3525,7 +3525,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
         class="MuiGrid-root header-container container_fllbiki css-plh9qo-MuiGrid-root"
       >
         <div
-          class="toggle-dark-mode f10ie5uy MuiBox-root css-0"
+          class="toggle-dark-mode fc950xb MuiBox-root css-0"
         >
           <div
             class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -3558,7 +3558,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                 />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-13qdlub-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1m50to5-MuiTypography-root"
               >
                 Dark mode
               </span>
@@ -3574,7 +3574,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
             PerfCompare
           </h1>
           <div
-            class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-tagline css-hbzfo1-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-tagline css-1bmo7ho-MuiTypography-root"
           >
             Analyze results of performance tests to detect regressions and identify opportunities for improvement.
           </div>
@@ -3591,11 +3591,11 @@ exports[`Compare With Base should remove the checked revision once X button is c
         </div>
       </div>
       <section
-        class="container_fsocifg"
+        class="container_fwl891g"
         data-testid="search-section"
       >
         <span
-          class="MuiTypography-root MuiTypography-body1 search-default-title css-13qdlub-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 search-default-title css-1m50to5-MuiTypography-root"
         >
           Compare with a base or over time
         </span>
@@ -3605,10 +3605,10 @@ exports[`Compare With Base should remove the checked revision once X button is c
             data-testid="base-state"
           >
             <div
-              class="compare-card-text cardText_f17sylv5"
+              class="compare-card-text cardText_fpjtghi"
             >
               <h2
-                class="MuiTypography-root MuiTypography-h2 compare-card-title css-15umudq-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-h2 compare-card-title css-gja6vo-MuiTypography-root"
               >
                 Compare with a base
               </h2>
@@ -3641,7 +3641,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                   class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -3668,7 +3668,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                     id="base-search-container"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9  -base-dropdown css-1awobkc-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
                       id="base_search-dropdown"
                     >
                       <div
@@ -3716,7 +3716,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                         class="MuiBox-root css-0"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+                          class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
                         >
                           <div
                             class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -3773,7 +3773,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                     data-testid="base-selected-revision"
                   >
                     <div
-                      class="box_fobrng5 base-box MuiBox-root css-0"
+                      class="box_f1yxlro0 base-box MuiBox-root css-0"
                     >
                       <ul
                         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -3785,7 +3785,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                   class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -3812,7 +3812,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                     id="new-search-container"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9  -base-dropdown css-1awobkc-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
                       id="new_search-dropdown"
                     >
                       <div
@@ -3860,7 +3860,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                         class="MuiBox-root css-0"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+                          class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
                         >
                           <div
                             class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -3917,7 +3917,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                     data-testid="new-selected-revision"
                   >
                     <div
-                      class="box_fobrng5 new-box MuiBox-root css-0"
+                      class="box_f1yxlro0 new-box MuiBox-root css-0"
                     >
                       <ul
                         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -3926,7 +3926,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                   </div>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f5zlgu9 css-bwiycy-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
                 >
                   <div
                     class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -4017,10 +4017,10 @@ exports[`Compare With Base should remove the checked revision once X button is c
             data-testid="time-state"
           >
             <div
-              class="compare-card-text cardText_f17sylv5"
+              class="compare-card-text cardText_fpjtghi"
             >
               <h2
-                class="MuiTypography-root MuiTypography-h2 compare-card-title css-15umudq-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-h2 compare-card-title css-gja6vo-MuiTypography-root"
               >
                 Compare over time
               </h2>
@@ -4053,7 +4053,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                   class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f5zlgu9 css-1e9xsub-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
                   >
                     <div
                       class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -4151,7 +4151,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f5zlgu9   css-1t7ybvx-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1mtgqas   css-1t7ybvx-MuiGrid-root"
                       id="time-range"
                       style="max-width: 365px;"
                     >
@@ -4205,7 +4205,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 css-13eijkh-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -4233,7 +4233,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                     id="new-search-container--time"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9  -new-dropdown css-1awobkc-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -new-dropdown css-1awobkc-MuiGrid-root"
                       id="new_search-dropdown--time"
                     >
                       <div
@@ -4281,7 +4281,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                         class="MuiBox-root css-0"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+                          class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
                         >
                           <div
                             class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -4337,7 +4337,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                     class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
                   >
                     <div
-                      class="box_fobrng5 new-box MuiBox-root css-0"
+                      class="box_f1yxlro0 new-box MuiBox-root css-0"
                     >
                       <ul
                         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -4346,7 +4346,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                   </div>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f5zlgu9 css-bwiycy-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
                 >
                   <div
                     class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"

--- a/src/__tests__/Search/__snapshots__/SearchContainer.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchContainer.test.tsx.snap
@@ -4,11 +4,11 @@ exports[`Search Containter should match snapshot 1`] = `
 <body>
   <div>
     <section
-      class="container_fwl891g"
+      class="container_fyuz3mb"
       data-testid="search-section"
     >
       <span
-        class="MuiTypography-root MuiTypography-body1 search-default-title css-1m50to5-MuiTypography-root"
+        class="MuiTypography-root MuiTypography-body1 search-default-title css-smpupv-MuiTypography-root"
       >
         Compare with a base or over time
       </span>
@@ -18,7 +18,7 @@ exports[`Search Containter should match snapshot 1`] = `
           data-testid="base-state"
         >
           <div
-            class="compare-card-text cardText_fpjtghi"
+            class="compare-card-text cardText_fuie4ja"
           >
             <h2
               class="MuiTypography-root MuiTypography-h2 compare-card-title css-gja6vo-MuiTypography-root"
@@ -54,7 +54,7 @@ exports[`Search Containter should match snapshot 1`] = `
                 class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -81,7 +81,7 @@ exports[`Search Containter should match snapshot 1`] = `
                   id="base-search-container"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr  -base-dropdown css-1awobkc-MuiGrid-root"
                     id="base_search-dropdown"
                   >
                     <div
@@ -129,7 +129,7 @@ exports[`Search Containter should match snapshot 1`] = `
                       class="MuiBox-root css-0"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+                        class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
                       >
                         <div
                           class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -186,7 +186,7 @@ exports[`Search Containter should match snapshot 1`] = `
                   data-testid="base-selected-revision"
                 >
                   <div
-                    class="box_f1yxlro0 base-box MuiBox-root css-0"
+                    class="box_ffdb50n base-box MuiBox-root css-0"
                   >
                     <ul
                       class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -198,7 +198,7 @@ exports[`Search Containter should match snapshot 1`] = `
                 class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -225,7 +225,7 @@ exports[`Search Containter should match snapshot 1`] = `
                   id="new-search-container"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr  -base-dropdown css-1awobkc-MuiGrid-root"
                     id="new_search-dropdown"
                   >
                     <div
@@ -273,7 +273,7 @@ exports[`Search Containter should match snapshot 1`] = `
                       class="MuiBox-root css-0"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+                        class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
                       >
                         <div
                           class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -330,7 +330,7 @@ exports[`Search Containter should match snapshot 1`] = `
                   data-testid="new-selected-revision"
                 >
                   <div
-                    class="box_f1yxlro0 new-box MuiBox-root css-0"
+                    class="box_ffdb50n new-box MuiBox-root css-0"
                   >
                     <ul
                       class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -339,7 +339,7 @@ exports[`Search Containter should match snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fgr49yr css-bwiycy-MuiGrid-root"
               >
                 <div
                   class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -430,7 +430,7 @@ exports[`Search Containter should match snapshot 1`] = `
           data-testid="time-state"
         >
           <div
-            class="compare-card-text cardText_fpjtghi"
+            class="compare-card-text cardText_fuie4ja"
           >
             <h2
               class="MuiTypography-root MuiTypography-h2 compare-card-title css-gja6vo-MuiTypography-root"
@@ -466,7 +466,7 @@ exports[`Search Containter should match snapshot 1`] = `
                 class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_fgr49yr css-1e9xsub-MuiGrid-root"
                 >
                   <div
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -564,7 +564,7 @@ exports[`Search Containter should match snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1mtgqas   css-1t7ybvx-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_fgr49yr   css-1t7ybvx-MuiGrid-root"
                     id="time-range"
                     style="max-width: 365px;"
                   >
@@ -618,7 +618,7 @@ exports[`Search Containter should match snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr css-13eijkh-MuiGrid-root"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -646,7 +646,7 @@ exports[`Search Containter should match snapshot 1`] = `
                   id="new-search-container--time"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -new-dropdown css-1awobkc-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr  -new-dropdown css-1awobkc-MuiGrid-root"
                     id="new_search-dropdown--time"
                   >
                     <div
@@ -694,7 +694,7 @@ exports[`Search Containter should match snapshot 1`] = `
                       class="MuiBox-root css-0"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+                        class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
                       >
                         <div
                           class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -750,7 +750,7 @@ exports[`Search Containter should match snapshot 1`] = `
                   class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="box_f1yxlro0 new-box MuiBox-root css-0"
+                    class="box_ffdb50n new-box MuiBox-root css-0"
                   >
                     <ul
                       class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -759,7 +759,7 @@ exports[`Search Containter should match snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fgr49yr css-bwiycy-MuiGrid-root"
               >
                 <div
                   class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"

--- a/src/__tests__/Search/__snapshots__/SearchContainer.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchContainer.test.tsx.snap
@@ -4,11 +4,11 @@ exports[`Search Containter should match snapshot 1`] = `
 <body>
   <div>
     <section
-      class="container_fsocifg"
+      class="container_fwl891g"
       data-testid="search-section"
     >
       <span
-        class="MuiTypography-root MuiTypography-body1 search-default-title css-13qdlub-MuiTypography-root"
+        class="MuiTypography-root MuiTypography-body1 search-default-title css-1m50to5-MuiTypography-root"
       >
         Compare with a base or over time
       </span>
@@ -18,10 +18,10 @@ exports[`Search Containter should match snapshot 1`] = `
           data-testid="base-state"
         >
           <div
-            class="compare-card-text cardText_f17sylv5"
+            class="compare-card-text cardText_fpjtghi"
           >
             <h2
-              class="MuiTypography-root MuiTypography-h2 compare-card-title css-15umudq-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h2 compare-card-title css-gja6vo-MuiTypography-root"
             >
               Compare with a base
             </h2>
@@ -54,7 +54,7 @@ exports[`Search Containter should match snapshot 1`] = `
                 class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -81,7 +81,7 @@ exports[`Search Containter should match snapshot 1`] = `
                   id="base-search-container"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9  -base-dropdown css-1awobkc-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
                     id="base_search-dropdown"
                   >
                     <div
@@ -129,7 +129,7 @@ exports[`Search Containter should match snapshot 1`] = `
                       class="MuiBox-root css-0"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+                        class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
                       >
                         <div
                           class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -186,7 +186,7 @@ exports[`Search Containter should match snapshot 1`] = `
                   data-testid="base-selected-revision"
                 >
                   <div
-                    class="box_fobrng5 base-box MuiBox-root css-0"
+                    class="box_f1yxlro0 base-box MuiBox-root css-0"
                   >
                     <ul
                       class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -198,7 +198,7 @@ exports[`Search Containter should match snapshot 1`] = `
                 class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -225,7 +225,7 @@ exports[`Search Containter should match snapshot 1`] = `
                   id="new-search-container"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9  -base-dropdown css-1awobkc-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
                     id="new_search-dropdown"
                   >
                     <div
@@ -273,7 +273,7 @@ exports[`Search Containter should match snapshot 1`] = `
                       class="MuiBox-root css-0"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+                        class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
                       >
                         <div
                           class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -330,7 +330,7 @@ exports[`Search Containter should match snapshot 1`] = `
                   data-testid="new-selected-revision"
                 >
                   <div
-                    class="box_fobrng5 new-box MuiBox-root css-0"
+                    class="box_f1yxlro0 new-box MuiBox-root css-0"
                   >
                     <ul
                       class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -339,7 +339,7 @@ exports[`Search Containter should match snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f5zlgu9 css-bwiycy-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
               >
                 <div
                   class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -430,10 +430,10 @@ exports[`Search Containter should match snapshot 1`] = `
           data-testid="time-state"
         >
           <div
-            class="compare-card-text cardText_f17sylv5"
+            class="compare-card-text cardText_fpjtghi"
           >
             <h2
-              class="MuiTypography-root MuiTypography-h2 compare-card-title css-15umudq-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-h2 compare-card-title css-gja6vo-MuiTypography-root"
             >
               Compare over time
             </h2>
@@ -466,7 +466,7 @@ exports[`Search Containter should match snapshot 1`] = `
                 class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f5zlgu9 css-1e9xsub-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
                 >
                   <div
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -564,7 +564,7 @@ exports[`Search Containter should match snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f5zlgu9   css-1t7ybvx-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1mtgqas   css-1t7ybvx-MuiGrid-root"
                     id="time-range"
                     style="max-width: 365px;"
                   >
@@ -618,7 +618,7 @@ exports[`Search Containter should match snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 css-13eijkh-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -646,7 +646,7 @@ exports[`Search Containter should match snapshot 1`] = `
                   id="new-search-container--time"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9  -new-dropdown css-1awobkc-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -new-dropdown css-1awobkc-MuiGrid-root"
                     id="new_search-dropdown--time"
                   >
                     <div
@@ -694,7 +694,7 @@ exports[`Search Containter should match snapshot 1`] = `
                       class="MuiBox-root css-0"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+                        class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
                       >
                         <div
                           class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -750,7 +750,7 @@ exports[`Search Containter should match snapshot 1`] = `
                   class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="box_fobrng5 new-box MuiBox-root css-0"
+                    class="box_f1yxlro0 new-box MuiBox-root css-0"
                   >
                     <ul
                       class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -759,7 +759,7 @@ exports[`Search Containter should match snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f5zlgu9 css-bwiycy-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
               >
                 <div
                   class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"

--- a/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`SearchResultsList Should apply dark and light mode styles when theme button is toggled: after toggling dark mode 1`] = `
 <div
-  class="fluj5ii results-list-dark MuiBox-root css-y1kcm0"
+  class="fcrjm0d results-list-dark MuiBox-root css-y1kcm0"
   data-testid="list-mode"
   id="search-results-list"
 >
@@ -62,7 +62,7 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
           class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
         >
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
           >
             <span
               class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -178,7 +178,7 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
           class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
         >
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
           >
             <span
               class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -294,7 +294,7 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
           class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
         >
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
           >
             <span
               class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -410,7 +410,7 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
           class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
         >
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
           >
             <span
               class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -526,7 +526,7 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
           class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
         >
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
           >
             <span
               class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -610,7 +610,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
         class="MuiGrid-root header-container container_fllbiki css-plh9qo-MuiGrid-root"
       >
         <div
-          class="toggle-dark-mode f10ie5uy MuiBox-root css-0"
+          class="toggle-dark-mode fc950xb MuiBox-root css-0"
         >
           <div
             class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -643,7 +643,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                 />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-13qdlub-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1m50to5-MuiTypography-root"
               >
                 Dark mode
               </span>
@@ -659,7 +659,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
             PerfCompare
           </h1>
           <div
-            class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-tagline css-hbzfo1-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-tagline css-1bmo7ho-MuiTypography-root"
           >
             Analyze results of performance tests to detect regressions and identify opportunities for improvement.
           </div>
@@ -676,11 +676,11 @@ exports[`SearchResultsList should match snapshot 1`] = `
         </div>
       </div>
       <section
-        class="container_fsocifg"
+        class="container_fwl891g"
         data-testid="search-section"
       >
         <span
-          class="MuiTypography-root MuiTypography-body1 search-default-title css-13qdlub-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 search-default-title css-1m50to5-MuiTypography-root"
         >
           Compare with a base or over time
         </span>
@@ -690,10 +690,10 @@ exports[`SearchResultsList should match snapshot 1`] = `
             data-testid="base-state"
           >
             <div
-              class="compare-card-text cardText_f17sylv5"
+              class="compare-card-text cardText_fpjtghi"
             >
               <h2
-                class="MuiTypography-root MuiTypography-h2 compare-card-title css-15umudq-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-h2 compare-card-title css-gja6vo-MuiTypography-root"
               >
                 Compare with a base
               </h2>
@@ -726,7 +726,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                   class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -753,7 +753,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                     id="base-search-container"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9  -base-dropdown css-1awobkc-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
                       id="base_search-dropdown"
                     >
                       <div
@@ -801,7 +801,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+                          class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
                         >
                           <div
                             class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -851,7 +851,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                           </div>
                         </div>
                         <div
-                          class="f7axog8 results-list-light MuiBox-root css-y1kcm0"
+                          class="f18x92i7 results-list-light MuiBox-root css-y1kcm0"
                           data-testid="list-mode"
                           id="search-results-list"
                         >
@@ -911,7 +911,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                   class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
                                 >
                                   <span
-                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                                   >
                                     <span
                                       class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -1027,7 +1027,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                   class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
                                 >
                                   <span
-                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                                   >
                                     <span
                                       class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -1143,7 +1143,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                   class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
                                 >
                                   <span
-                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                                   >
                                     <span
                                       class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -1259,7 +1259,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                   class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
                                 >
                                   <span
-                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                                   >
                                     <span
                                       class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -1375,7 +1375,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                   class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
                                 >
                                   <span
-                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                                   >
                                     <span
                                       class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -1448,7 +1448,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                     data-testid="base-selected-revision"
                   >
                     <div
-                      class="box_fobrng5 base-box MuiBox-root css-0"
+                      class="box_f1yxlro0 base-box MuiBox-root css-0"
                     >
                       <ul
                         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1460,7 +1460,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                   class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1487,7 +1487,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                     id="new-search-container"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9  -base-dropdown css-1awobkc-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
                       id="new_search-dropdown"
                     >
                       <div
@@ -1535,7 +1535,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+                          class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
                         >
                           <div
                             class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -1592,7 +1592,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                     data-testid="new-selected-revision"
                   >
                     <div
-                      class="box_fobrng5 new-box MuiBox-root css-0"
+                      class="box_f1yxlro0 new-box MuiBox-root css-0"
                     >
                       <ul
                         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1601,7 +1601,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f5zlgu9 css-bwiycy-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
                 >
                   <div
                     class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -1692,10 +1692,10 @@ exports[`SearchResultsList should match snapshot 1`] = `
             data-testid="time-state"
           >
             <div
-              class="compare-card-text cardText_f17sylv5"
+              class="compare-card-text cardText_fpjtghi"
             >
               <h2
-                class="MuiTypography-root MuiTypography-h2 compare-card-title css-15umudq-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-h2 compare-card-title css-gja6vo-MuiTypography-root"
               >
                 Compare over time
               </h2>
@@ -1728,7 +1728,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                   class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f5zlgu9 css-1e9xsub-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
                   >
                     <div
                       class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -1826,7 +1826,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f5zlgu9   css-1t7ybvx-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1mtgqas   css-1t7ybvx-MuiGrid-root"
                       id="time-range"
                       style="max-width: 365px;"
                     >
@@ -1880,7 +1880,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 css-13eijkh-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1908,7 +1908,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                     id="new-search-container--time"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9  -new-dropdown css-1awobkc-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -new-dropdown css-1awobkc-MuiGrid-root"
                       id="new_search-dropdown--time"
                     >
                       <div
@@ -1956,7 +1956,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+                          class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
                         >
                           <div
                             class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -2012,7 +2012,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                     class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
                   >
                     <div
-                      class="box_fobrng5 new-box MuiBox-root css-0"
+                      class="box_f1yxlro0 new-box MuiBox-root css-0"
                     >
                       <ul
                         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2021,7 +2021,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f5zlgu9 css-bwiycy-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
                 >
                   <div
                     class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"

--- a/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`SearchResultsList Should apply dark and light mode styles when theme button is toggled: after toggling dark mode 1`] = `
 <div
-  class="fcrjm0d results-list-dark MuiBox-root css-y1kcm0"
+  class="f13k6i9n results-list-dark MuiBox-root css-y1kcm0"
   data-testid="list-mode"
   id="search-results-list"
 >
@@ -62,7 +62,7 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
           class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
         >
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
           >
             <span
               class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -178,7 +178,7 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
           class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
         >
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
           >
             <span
               class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -294,7 +294,7 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
           class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
         >
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
           >
             <span
               class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -410,7 +410,7 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
           class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
         >
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
           >
             <span
               class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -526,7 +526,7 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
           class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
         >
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
           >
             <span
               class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -610,7 +610,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
         class="MuiGrid-root header-container container_fllbiki css-plh9qo-MuiGrid-root"
       >
         <div
-          class="toggle-dark-mode fc950xb MuiBox-root css-0"
+          class="toggle-dark-mode fkud7h4 MuiBox-root css-0"
         >
           <div
             class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -643,7 +643,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                 />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1m50to5-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-smpupv-MuiTypography-root"
               >
                 Dark mode
               </span>
@@ -654,12 +654,12 @@ exports[`SearchResultsList should match snapshot 1`] = `
           class="header-text MuiBox-root css-0"
         >
           <h1
-            class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-160ox9e-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-eaa0qe-MuiTypography-root"
           >
             PerfCompare
           </h1>
           <div
-            class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-tagline css-1bmo7ho-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-tagline css-gfol4k-MuiTypography-root"
           >
             Analyze results of performance tests to detect regressions and identify opportunities for improvement.
           </div>
@@ -676,11 +676,11 @@ exports[`SearchResultsList should match snapshot 1`] = `
         </div>
       </div>
       <section
-        class="container_fwl891g"
+        class="container_fyuz3mb"
         data-testid="search-section"
       >
         <span
-          class="MuiTypography-root MuiTypography-body1 search-default-title css-1m50to5-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 search-default-title css-smpupv-MuiTypography-root"
         >
           Compare with a base or over time
         </span>
@@ -690,7 +690,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
             data-testid="base-state"
           >
             <div
-              class="compare-card-text cardText_fpjtghi"
+              class="compare-card-text cardText_fuie4ja"
             >
               <h2
                 class="MuiTypography-root MuiTypography-h2 compare-card-title css-gja6vo-MuiTypography-root"
@@ -726,7 +726,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                   class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -753,7 +753,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                     id="base-search-container"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr  -base-dropdown css-1awobkc-MuiGrid-root"
                       id="base_search-dropdown"
                     >
                       <div
@@ -801,7 +801,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+                          class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
                         >
                           <div
                             class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -851,7 +851,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                           </div>
                         </div>
                         <div
-                          class="f18x92i7 results-list-light MuiBox-root css-y1kcm0"
+                          class="f1oen5ix results-list-light MuiBox-root css-y1kcm0"
                           data-testid="list-mode"
                           id="search-results-list"
                         >
@@ -911,7 +911,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                   class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
                                 >
                                   <span
-                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                                   >
                                     <span
                                       class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -1027,7 +1027,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                   class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
                                 >
                                   <span
-                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                                   >
                                     <span
                                       class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -1143,7 +1143,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                   class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
                                 >
                                   <span
-                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                                   >
                                     <span
                                       class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -1259,7 +1259,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                   class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
                                 >
                                   <span
-                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                                   >
                                     <span
                                       class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -1375,7 +1375,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                   class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
                                 >
                                   <span
-                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                                   >
                                     <span
                                       class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -1448,7 +1448,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                     data-testid="base-selected-revision"
                   >
                     <div
-                      class="box_f1yxlro0 base-box MuiBox-root css-0"
+                      class="box_ffdb50n base-box MuiBox-root css-0"
                     >
                       <ul
                         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1460,7 +1460,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                   class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1487,7 +1487,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                     id="new-search-container"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr  -base-dropdown css-1awobkc-MuiGrid-root"
                       id="new_search-dropdown"
                     >
                       <div
@@ -1535,7 +1535,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+                          class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
                         >
                           <div
                             class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -1592,7 +1592,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                     data-testid="new-selected-revision"
                   >
                     <div
-                      class="box_f1yxlro0 new-box MuiBox-root css-0"
+                      class="box_ffdb50n new-box MuiBox-root css-0"
                     >
                       <ul
                         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1601,7 +1601,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fgr49yr css-bwiycy-MuiGrid-root"
                 >
                   <div
                     class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -1692,7 +1692,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
             data-testid="time-state"
           >
             <div
-              class="compare-card-text cardText_fpjtghi"
+              class="compare-card-text cardText_fuie4ja"
             >
               <h2
                 class="MuiTypography-root MuiTypography-h2 compare-card-title css-gja6vo-MuiTypography-root"
@@ -1728,7 +1728,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                   class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_fgr49yr css-1e9xsub-MuiGrid-root"
                   >
                     <div
                       class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -1826,7 +1826,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1mtgqas   css-1t7ybvx-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_fgr49yr   css-1t7ybvx-MuiGrid-root"
                       id="time-range"
                       style="max-width: 365px;"
                     >
@@ -1880,7 +1880,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr css-13eijkh-MuiGrid-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1908,7 +1908,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                     id="new-search-container--time"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -new-dropdown css-1awobkc-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr  -new-dropdown css-1awobkc-MuiGrid-root"
                       id="new_search-dropdown--time"
                     >
                       <div
@@ -1956,7 +1956,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+                          class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
                         >
                           <div
                             class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -2012,7 +2012,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                     class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
                   >
                     <div
-                      class="box_f1yxlro0 new-box MuiBox-root css-0"
+                      class="box_ffdb50n new-box MuiBox-root css-0"
                     >
                       <ul
                         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2021,7 +2021,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fgr49yr css-bwiycy-MuiGrid-root"
                 >
                   <div
                     class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"

--- a/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
         class="MuiGrid-root header-container container_fllbiki css-plh9qo-MuiGrid-root"
       >
         <div
-          class="toggle-dark-mode fc950xb MuiBox-root css-0"
+          class="toggle-dark-mode fkud7h4 MuiBox-root css-0"
         >
           <div
             class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -50,7 +50,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                 />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1m50to5-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-smpupv-MuiTypography-root"
               >
                 Dark mode
               </span>
@@ -61,12 +61,12 @@ exports[`Search View renders correctly when there are no results 1`] = `
           class="header-text MuiBox-root css-0"
         >
           <h1
-            class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-160ox9e-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-eaa0qe-MuiTypography-root"
           >
             PerfCompare
           </h1>
           <div
-            class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-tagline css-1bmo7ho-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-tagline css-gfol4k-MuiTypography-root"
           >
             Analyze results of performance tests to detect regressions and identify opportunities for improvement.
           </div>
@@ -83,11 +83,11 @@ exports[`Search View renders correctly when there are no results 1`] = `
         </div>
       </div>
       <section
-        class="container_fwl891g"
+        class="container_fyuz3mb"
         data-testid="search-section"
       >
         <span
-          class="MuiTypography-root MuiTypography-body1 search-default-title css-1m50to5-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 search-default-title css-smpupv-MuiTypography-root"
         >
           Compare with a base or over time
         </span>
@@ -97,7 +97,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
             data-testid="base-state"
           >
             <div
-              class="compare-card-text cardText_fpjtghi"
+              class="compare-card-text cardText_fuie4ja"
             >
               <h2
                 class="MuiTypography-root MuiTypography-h2 compare-card-title css-gja6vo-MuiTypography-root"
@@ -133,7 +133,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                   class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -160,7 +160,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                     id="base-search-container"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr  -base-dropdown css-1awobkc-MuiGrid-root"
                       id="base_search-dropdown"
                     >
                       <div
@@ -208,7 +208,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+                          class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
                         >
                           <div
                             class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -265,7 +265,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                     data-testid="base-selected-revision"
                   >
                     <div
-                      class="box_f1yxlro0 base-box MuiBox-root css-0"
+                      class="box_ffdb50n base-box MuiBox-root css-0"
                     >
                       <ul
                         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -277,7 +277,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                   class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -304,7 +304,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                     id="new-search-container"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr  -base-dropdown css-1awobkc-MuiGrid-root"
                       id="new_search-dropdown"
                     >
                       <div
@@ -352,7 +352,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+                          class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
                         >
                           <div
                             class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -409,7 +409,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                     data-testid="new-selected-revision"
                   >
                     <div
-                      class="box_f1yxlro0 new-box MuiBox-root css-0"
+                      class="box_ffdb50n new-box MuiBox-root css-0"
                     >
                       <ul
                         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -418,7 +418,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                   </div>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fgr49yr css-bwiycy-MuiGrid-root"
                 >
                   <div
                     class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -509,7 +509,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
             data-testid="time-state"
           >
             <div
-              class="compare-card-text cardText_fpjtghi"
+              class="compare-card-text cardText_fuie4ja"
             >
               <h2
                 class="MuiTypography-root MuiTypography-h2 compare-card-title css-gja6vo-MuiTypography-root"
@@ -545,7 +545,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                   class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_fgr49yr css-1e9xsub-MuiGrid-root"
                   >
                     <div
                       class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -643,7 +643,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1mtgqas   css-1t7ybvx-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_fgr49yr   css-1t7ybvx-MuiGrid-root"
                       id="time-range"
                       style="max-width: 365px;"
                     >
@@ -697,7 +697,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr css-13eijkh-MuiGrid-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -725,7 +725,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                     id="new-search-container--time"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -new-dropdown css-1awobkc-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr  -new-dropdown css-1awobkc-MuiGrid-root"
                       id="new_search-dropdown--time"
                     >
                       <div
@@ -773,7 +773,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+                          class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
                         >
                           <div
                             class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -829,7 +829,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                     class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
                   >
                     <div
-                      class="box_f1yxlro0 new-box MuiBox-root css-0"
+                      class="box_ffdb50n new-box MuiBox-root css-0"
                     >
                       <ul
                         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -838,7 +838,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                   </div>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fgr49yr css-bwiycy-MuiGrid-root"
                 >
                   <div
                     class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -939,7 +939,7 @@ exports[`With search parameters both search components are populated as expected
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_fgr49yr css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -1037,7 +1037,7 @@ exports[`With search parameters both search components are populated as expected
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1mtgqas   css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_fgr49yr   css-1t7ybvx-MuiGrid-root"
         id="time-range"
         style="max-width: 365px;"
       >
@@ -1091,7 +1091,7 @@ exports[`With search parameters both search components are populated as expected
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1119,7 +1119,7 @@ exports[`With search parameters both search components are populated as expected
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr  -new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -1167,7 +1167,7 @@ exports[`With search parameters both search components are populated as expected
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -1223,7 +1223,7 @@ exports[`With search parameters both search components are populated as expected
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_f1yxlro0 new-box MuiBox-root css-0"
+        class="box_ffdb50n new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1250,13 +1250,13 @@ exports[`With search parameters both search components are populated as expected
               </div>
             </div>
             <div
-              class="selectedRevision_f1jffy9s MuiBox-root css-0"
+              class="selectedRevision_fmpcdiu MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -1350,7 +1350,7 @@ exports[`With search parameters both search components are populated as expected
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fgr49yr css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -1444,7 +1444,7 @@ exports[`With search parameters both search components are populated as expected
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1471,7 +1471,7 @@ exports[`With search parameters both search components are populated as expected
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr  -base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -1519,7 +1519,7 @@ exports[`With search parameters both search components are populated as expected
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -1576,7 +1576,7 @@ exports[`With search parameters both search components are populated as expected
       data-testid="base-selected-revision"
     >
       <div
-        class="box_f1yxlro0 base-box MuiBox-root css-0"
+        class="box_ffdb50n base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1588,7 +1588,7 @@ exports[`With search parameters both search components are populated as expected
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1615,7 +1615,7 @@ exports[`With search parameters both search components are populated as expected
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr  -base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -1663,7 +1663,7 @@ exports[`With search parameters both search components are populated as expected
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -1720,7 +1720,7 @@ exports[`With search parameters both search components are populated as expected
       data-testid="new-selected-revision"
     >
       <div
-        class="box_f1yxlro0 new-box MuiBox-root css-0"
+        class="box_ffdb50n new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1747,13 +1747,13 @@ exports[`With search parameters both search components are populated as expected
               </div>
             </div>
             <div
-              class="selectedRevision_f1jffy9s MuiBox-root css-0"
+              class="selectedRevision_fmpcdiu MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -1847,7 +1847,7 @@ exports[`With search parameters both search components are populated as expected
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fgr49yr css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -1941,7 +1941,7 @@ exports[`With search parameters both search components are populated as expected
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_fgr49yr css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -2039,7 +2039,7 @@ exports[`With search parameters both search components are populated as expected
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1mtgqas   css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_fgr49yr   css-1t7ybvx-MuiGrid-root"
         id="time-range"
         style="max-width: 365px;"
       >
@@ -2093,7 +2093,7 @@ exports[`With search parameters both search components are populated as expected
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -2121,7 +2121,7 @@ exports[`With search parameters both search components are populated as expected
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr  -new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -2169,7 +2169,7 @@ exports[`With search parameters both search components are populated as expected
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -2225,7 +2225,7 @@ exports[`With search parameters both search components are populated as expected
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_f1yxlro0 new-box MuiBox-root css-0"
+        class="box_ffdb50n new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2252,13 +2252,13 @@ exports[`With search parameters both search components are populated as expected
               </div>
             </div>
             <div
-              class="selectedRevision_f1jffy9s MuiBox-root css-0"
+              class="selectedRevision_fmpcdiu MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -2352,7 +2352,7 @@ exports[`With search parameters both search components are populated as expected
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fgr49yr css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -2446,7 +2446,7 @@ exports[`With search parameters both search components are populated as expected
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -2473,7 +2473,7 @@ exports[`With search parameters both search components are populated as expected
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr  -base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -2521,7 +2521,7 @@ exports[`With search parameters both search components are populated as expected
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -2578,7 +2578,7 @@ exports[`With search parameters both search components are populated as expected
       data-testid="base-selected-revision"
     >
       <div
-        class="box_f1yxlro0 base-box MuiBox-root css-0"
+        class="box_ffdb50n base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2590,7 +2590,7 @@ exports[`With search parameters both search components are populated as expected
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -2617,7 +2617,7 @@ exports[`With search parameters both search components are populated as expected
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr  -base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -2665,7 +2665,7 @@ exports[`With search parameters both search components are populated as expected
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -2722,7 +2722,7 @@ exports[`With search parameters both search components are populated as expected
       data-testid="new-selected-revision"
     >
       <div
-        class="box_f1yxlro0 new-box MuiBox-root css-0"
+        class="box_ffdb50n new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2749,13 +2749,13 @@ exports[`With search parameters both search components are populated as expected
               </div>
             </div>
             <div
-              class="selectedRevision_f1jffy9s MuiBox-root css-0"
+              class="selectedRevision_fmpcdiu MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -2849,7 +2849,7 @@ exports[`With search parameters both search components are populated as expected
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fgr49yr css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -2943,7 +2943,7 @@ exports[`With search parameters displays the default value for framework if the 
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_fgr49yr css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -3041,7 +3041,7 @@ exports[`With search parameters displays the default value for framework if the 
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1mtgqas   css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_fgr49yr   css-1t7ybvx-MuiGrid-root"
         id="time-range"
         style="max-width: 365px;"
       >
@@ -3095,7 +3095,7 @@ exports[`With search parameters displays the default value for framework if the 
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -3123,7 +3123,7 @@ exports[`With search parameters displays the default value for framework if the 
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr  -new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -3171,7 +3171,7 @@ exports[`With search parameters displays the default value for framework if the 
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -3227,7 +3227,7 @@ exports[`With search parameters displays the default value for framework if the 
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_f1yxlro0 new-box MuiBox-root css-0"
+        class="box_ffdb50n new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -3254,13 +3254,13 @@ exports[`With search parameters displays the default value for framework if the 
               </div>
             </div>
             <div
-              class="selectedRevision_f1jffy9s MuiBox-root css-0"
+              class="selectedRevision_fmpcdiu MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -3354,7 +3354,7 @@ exports[`With search parameters displays the default value for framework if the 
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fgr49yr css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -3448,7 +3448,7 @@ exports[`With search parameters displays the default value for framework if the 
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -3475,7 +3475,7 @@ exports[`With search parameters displays the default value for framework if the 
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr  -base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -3523,7 +3523,7 @@ exports[`With search parameters displays the default value for framework if the 
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -3580,7 +3580,7 @@ exports[`With search parameters displays the default value for framework if the 
       data-testid="base-selected-revision"
     >
       <div
-        class="box_f1yxlro0 base-box MuiBox-root css-0"
+        class="box_ffdb50n base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -3592,7 +3592,7 @@ exports[`With search parameters displays the default value for framework if the 
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -3619,7 +3619,7 @@ exports[`With search parameters displays the default value for framework if the 
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr  -base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -3667,7 +3667,7 @@ exports[`With search parameters displays the default value for framework if the 
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -3724,7 +3724,7 @@ exports[`With search parameters displays the default value for framework if the 
       data-testid="new-selected-revision"
     >
       <div
-        class="box_f1yxlro0 new-box MuiBox-root css-0"
+        class="box_ffdb50n new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -3751,13 +3751,13 @@ exports[`With search parameters displays the default value for framework if the 
               </div>
             </div>
             <div
-              class="selectedRevision_f1jffy9s MuiBox-root css-0"
+              class="selectedRevision_fmpcdiu MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -3851,7 +3851,7 @@ exports[`With search parameters displays the default value for framework if the 
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fgr49yr css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -3945,7 +3945,7 @@ exports[`With search parameters displays the default values if some values are b
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_fgr49yr css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -4043,7 +4043,7 @@ exports[`With search parameters displays the default values if some values are b
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1mtgqas   css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_fgr49yr   css-1t7ybvx-MuiGrid-root"
         id="time-range"
         style="max-width: 365px;"
       >
@@ -4097,7 +4097,7 @@ exports[`With search parameters displays the default values if some values are b
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -4125,7 +4125,7 @@ exports[`With search parameters displays the default values if some values are b
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr  -new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -4173,7 +4173,7 @@ exports[`With search parameters displays the default values if some values are b
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -4229,7 +4229,7 @@ exports[`With search parameters displays the default values if some values are b
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_f1yxlro0 new-box MuiBox-root css-0"
+        class="box_ffdb50n new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -4238,7 +4238,7 @@ exports[`With search parameters displays the default values if some values are b
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fgr49yr css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -4332,7 +4332,7 @@ exports[`With search parameters displays the default values if some values are b
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -4359,7 +4359,7 @@ exports[`With search parameters displays the default values if some values are b
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_fgr49yr  -base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -4407,7 +4407,7 @@ exports[`With search parameters displays the default values if some values are b
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -4464,7 +4464,7 @@ exports[`With search parameters displays the default values if some values are b
       data-testid="base-selected-revision"
     >
       <div
-        class="box_f1yxlro0 base-box MuiBox-root css-0"
+        class="box_ffdb50n base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -4476,7 +4476,7 @@ exports[`With search parameters displays the default values if some values are b
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -4503,7 +4503,7 @@ exports[`With search parameters displays the default values if some values are b
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_fgr49yr  -base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -4551,7 +4551,7 @@ exports[`With search parameters displays the default values if some values are b
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f11r6mh1 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -4608,7 +4608,7 @@ exports[`With search parameters displays the default values if some values are b
       data-testid="new-selected-revision"
     >
       <div
-        class="box_f1yxlro0 new-box MuiBox-root css-0"
+        class="box_ffdb50n new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -4617,7 +4617,7 @@ exports[`With search parameters displays the default values if some values are b
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_fgr49yr css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"

--- a/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
         class="MuiGrid-root header-container container_fllbiki css-plh9qo-MuiGrid-root"
       >
         <div
-          class="toggle-dark-mode f10ie5uy MuiBox-root css-0"
+          class="toggle-dark-mode fc950xb MuiBox-root css-0"
         >
           <div
             class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -50,7 +50,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                 />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-13qdlub-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1m50to5-MuiTypography-root"
               >
                 Dark mode
               </span>
@@ -66,7 +66,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
             PerfCompare
           </h1>
           <div
-            class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-tagline css-hbzfo1-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-tagline css-1bmo7ho-MuiTypography-root"
           >
             Analyze results of performance tests to detect regressions and identify opportunities for improvement.
           </div>
@@ -83,11 +83,11 @@ exports[`Search View renders correctly when there are no results 1`] = `
         </div>
       </div>
       <section
-        class="container_fsocifg"
+        class="container_fwl891g"
         data-testid="search-section"
       >
         <span
-          class="MuiTypography-root MuiTypography-body1 search-default-title css-13qdlub-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 search-default-title css-1m50to5-MuiTypography-root"
         >
           Compare with a base or over time
         </span>
@@ -97,10 +97,10 @@ exports[`Search View renders correctly when there are no results 1`] = `
             data-testid="base-state"
           >
             <div
-              class="compare-card-text cardText_f17sylv5"
+              class="compare-card-text cardText_fpjtghi"
             >
               <h2
-                class="MuiTypography-root MuiTypography-h2 compare-card-title css-15umudq-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-h2 compare-card-title css-gja6vo-MuiTypography-root"
               >
                 Compare with a base
               </h2>
@@ -133,7 +133,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                   class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -160,7 +160,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                     id="base-search-container"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9  -base-dropdown css-1awobkc-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
                       id="base_search-dropdown"
                     >
                       <div
@@ -208,7 +208,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+                          class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
                         >
                           <div
                             class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -265,7 +265,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                     data-testid="base-selected-revision"
                   >
                     <div
-                      class="box_fobrng5 base-box MuiBox-root css-0"
+                      class="box_f1yxlro0 base-box MuiBox-root css-0"
                     >
                       <ul
                         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -277,7 +277,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                   class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -304,7 +304,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                     id="new-search-container"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9  -base-dropdown css-1awobkc-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
                       id="new_search-dropdown"
                     >
                       <div
@@ -352,7 +352,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+                          class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
                         >
                           <div
                             class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -409,7 +409,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                     data-testid="new-selected-revision"
                   >
                     <div
-                      class="box_fobrng5 new-box MuiBox-root css-0"
+                      class="box_f1yxlro0 new-box MuiBox-root css-0"
                     >
                       <ul
                         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -418,7 +418,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                   </div>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f5zlgu9 css-bwiycy-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
                 >
                   <div
                     class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -509,10 +509,10 @@ exports[`Search View renders correctly when there are no results 1`] = `
             data-testid="time-state"
           >
             <div
-              class="compare-card-text cardText_f17sylv5"
+              class="compare-card-text cardText_fpjtghi"
             >
               <h2
-                class="MuiTypography-root MuiTypography-h2 compare-card-title css-15umudq-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-h2 compare-card-title css-gja6vo-MuiTypography-root"
               >
                 Compare over time
               </h2>
@@ -545,7 +545,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                   class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f5zlgu9 css-1e9xsub-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
                   >
                     <div
                       class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -643,7 +643,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f5zlgu9   css-1t7ybvx-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1mtgqas   css-1t7ybvx-MuiGrid-root"
                       id="time-range"
                       style="max-width: 365px;"
                     >
@@ -697,7 +697,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 css-13eijkh-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -725,7 +725,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                     id="new-search-container--time"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9  -new-dropdown css-1awobkc-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -new-dropdown css-1awobkc-MuiGrid-root"
                       id="new_search-dropdown--time"
                     >
                       <div
@@ -773,7 +773,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+                          class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
                         >
                           <div
                             class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -829,7 +829,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                     class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
                   >
                     <div
-                      class="box_fobrng5 new-box MuiBox-root css-0"
+                      class="box_f1yxlro0 new-box MuiBox-root css-0"
                     >
                       <ul
                         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -838,7 +838,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                   </div>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f5zlgu9 css-bwiycy-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
                 >
                   <div
                     class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -939,7 +939,7 @@ exports[`With search parameters both search components are populated as expected
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f5zlgu9 css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -1037,7 +1037,7 @@ exports[`With search parameters both search components are populated as expected
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f5zlgu9   css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1mtgqas   css-1t7ybvx-MuiGrid-root"
         id="time-range"
         style="max-width: 365px;"
       >
@@ -1091,7 +1091,7 @@ exports[`With search parameters both search components are populated as expected
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1119,7 +1119,7 @@ exports[`With search parameters both search components are populated as expected
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9  -new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -1167,7 +1167,7 @@ exports[`With search parameters both search components are populated as expected
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -1223,7 +1223,7 @@ exports[`With search parameters both search components are populated as expected
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_fobrng5 new-box MuiBox-root css-0"
+        class="box_f1yxlro0 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1250,13 +1250,13 @@ exports[`With search parameters both search components are populated as expected
               </div>
             </div>
             <div
-              class="selectedRevision_fd452xz MuiBox-root css-0"
+              class="selectedRevision_f1jffy9s MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -1350,7 +1350,7 @@ exports[`With search parameters both search components are populated as expected
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f5zlgu9 css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -1444,7 +1444,7 @@ exports[`With search parameters both search components are populated as expected
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1471,7 +1471,7 @@ exports[`With search parameters both search components are populated as expected
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9  -base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -1519,7 +1519,7 @@ exports[`With search parameters both search components are populated as expected
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -1576,7 +1576,7 @@ exports[`With search parameters both search components are populated as expected
       data-testid="base-selected-revision"
     >
       <div
-        class="box_fobrng5 base-box MuiBox-root css-0"
+        class="box_f1yxlro0 base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1588,7 +1588,7 @@ exports[`With search parameters both search components are populated as expected
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1615,7 +1615,7 @@ exports[`With search parameters both search components are populated as expected
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9  -base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -1663,7 +1663,7 @@ exports[`With search parameters both search components are populated as expected
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -1720,7 +1720,7 @@ exports[`With search parameters both search components are populated as expected
       data-testid="new-selected-revision"
     >
       <div
-        class="box_fobrng5 new-box MuiBox-root css-0"
+        class="box_f1yxlro0 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1747,13 +1747,13 @@ exports[`With search parameters both search components are populated as expected
               </div>
             </div>
             <div
-              class="selectedRevision_fd452xz MuiBox-root css-0"
+              class="selectedRevision_f1jffy9s MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -1847,7 +1847,7 @@ exports[`With search parameters both search components are populated as expected
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f5zlgu9 css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -1941,7 +1941,7 @@ exports[`With search parameters both search components are populated as expected
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f5zlgu9 css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -2039,7 +2039,7 @@ exports[`With search parameters both search components are populated as expected
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f5zlgu9   css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1mtgqas   css-1t7ybvx-MuiGrid-root"
         id="time-range"
         style="max-width: 365px;"
       >
@@ -2093,7 +2093,7 @@ exports[`With search parameters both search components are populated as expected
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -2121,7 +2121,7 @@ exports[`With search parameters both search components are populated as expected
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9  -new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -2169,7 +2169,7 @@ exports[`With search parameters both search components are populated as expected
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -2225,7 +2225,7 @@ exports[`With search parameters both search components are populated as expected
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_fobrng5 new-box MuiBox-root css-0"
+        class="box_f1yxlro0 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2252,13 +2252,13 @@ exports[`With search parameters both search components are populated as expected
               </div>
             </div>
             <div
-              class="selectedRevision_fd452xz MuiBox-root css-0"
+              class="selectedRevision_f1jffy9s MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -2352,7 +2352,7 @@ exports[`With search parameters both search components are populated as expected
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f5zlgu9 css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -2446,7 +2446,7 @@ exports[`With search parameters both search components are populated as expected
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -2473,7 +2473,7 @@ exports[`With search parameters both search components are populated as expected
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9  -base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -2521,7 +2521,7 @@ exports[`With search parameters both search components are populated as expected
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -2578,7 +2578,7 @@ exports[`With search parameters both search components are populated as expected
       data-testid="base-selected-revision"
     >
       <div
-        class="box_fobrng5 base-box MuiBox-root css-0"
+        class="box_f1yxlro0 base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2590,7 +2590,7 @@ exports[`With search parameters both search components are populated as expected
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -2617,7 +2617,7 @@ exports[`With search parameters both search components are populated as expected
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9  -base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -2665,7 +2665,7 @@ exports[`With search parameters both search components are populated as expected
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -2722,7 +2722,7 @@ exports[`With search parameters both search components are populated as expected
       data-testid="new-selected-revision"
     >
       <div
-        class="box_fobrng5 new-box MuiBox-root css-0"
+        class="box_f1yxlro0 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2749,13 +2749,13 @@ exports[`With search parameters both search components are populated as expected
               </div>
             </div>
             <div
-              class="selectedRevision_fd452xz MuiBox-root css-0"
+              class="selectedRevision_f1jffy9s MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -2849,7 +2849,7 @@ exports[`With search parameters both search components are populated as expected
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f5zlgu9 css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -2943,7 +2943,7 @@ exports[`With search parameters displays the default value for framework if the 
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f5zlgu9 css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -3041,7 +3041,7 @@ exports[`With search parameters displays the default value for framework if the 
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f5zlgu9   css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1mtgqas   css-1t7ybvx-MuiGrid-root"
         id="time-range"
         style="max-width: 365px;"
       >
@@ -3095,7 +3095,7 @@ exports[`With search parameters displays the default value for framework if the 
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -3123,7 +3123,7 @@ exports[`With search parameters displays the default value for framework if the 
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9  -new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -3171,7 +3171,7 @@ exports[`With search parameters displays the default value for framework if the 
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -3227,7 +3227,7 @@ exports[`With search parameters displays the default value for framework if the 
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_fobrng5 new-box MuiBox-root css-0"
+        class="box_f1yxlro0 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -3254,13 +3254,13 @@ exports[`With search parameters displays the default value for framework if the 
               </div>
             </div>
             <div
-              class="selectedRevision_fd452xz MuiBox-root css-0"
+              class="selectedRevision_f1jffy9s MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -3354,7 +3354,7 @@ exports[`With search parameters displays the default value for framework if the 
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f5zlgu9 css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -3448,7 +3448,7 @@ exports[`With search parameters displays the default value for framework if the 
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -3475,7 +3475,7 @@ exports[`With search parameters displays the default value for framework if the 
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9  -base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -3523,7 +3523,7 @@ exports[`With search parameters displays the default value for framework if the 
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -3580,7 +3580,7 @@ exports[`With search parameters displays the default value for framework if the 
       data-testid="base-selected-revision"
     >
       <div
-        class="box_fobrng5 base-box MuiBox-root css-0"
+        class="box_f1yxlro0 base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -3592,7 +3592,7 @@ exports[`With search parameters displays the default value for framework if the 
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -3619,7 +3619,7 @@ exports[`With search parameters displays the default value for framework if the 
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9  -base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -3667,7 +3667,7 @@ exports[`With search parameters displays the default value for framework if the 
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -3724,7 +3724,7 @@ exports[`With search parameters displays the default value for framework if the 
       data-testid="new-selected-revision"
     >
       <div
-        class="box_fobrng5 new-box MuiBox-root css-0"
+        class="box_f1yxlro0 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -3751,13 +3751,13 @@ exports[`With search parameters displays the default value for framework if the 
               </div>
             </div>
             <div
-              class="selectedRevision_fd452xz MuiBox-root css-0"
+              class="selectedRevision_f1jffy9s MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"
@@ -3851,7 +3851,7 @@ exports[`With search parameters displays the default value for framework if the 
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f5zlgu9 css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -3945,7 +3945,7 @@ exports[`With search parameters displays the default values if some values are b
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f5zlgu9 css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1mtgqas css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -4043,7 +4043,7 @@ exports[`With search parameters displays the default values if some values are b
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f5zlgu9   css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1mtgqas   css-1t7ybvx-MuiGrid-root"
         id="time-range"
         style="max-width: 365px;"
       >
@@ -4097,7 +4097,7 @@ exports[`With search parameters displays the default values if some values are b
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -4125,7 +4125,7 @@ exports[`With search parameters displays the default values if some values are b
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9  -new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -4173,7 +4173,7 @@ exports[`With search parameters displays the default values if some values are b
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -4229,7 +4229,7 @@ exports[`With search parameters displays the default values if some values are b
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_fobrng5 new-box MuiBox-root css-0"
+        class="box_f1yxlro0 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -4238,7 +4238,7 @@ exports[`With search parameters displays the default values if some values are b
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f5zlgu9 css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -4332,7 +4332,7 @@ exports[`With search parameters displays the default values if some values are b
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -4359,7 +4359,7 @@ exports[`With search parameters displays the default values if some values are b
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f5zlgu9  -base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -4407,7 +4407,7 @@ exports[`With search parameters displays the default values if some values are b
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -4464,7 +4464,7 @@ exports[`With search parameters displays the default values if some values are b
       data-testid="base-selected-revision"
     >
       <div
-        class="box_fobrng5 base-box MuiBox-root css-0"
+        class="box_f1yxlro0 base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -4476,7 +4476,7 @@ exports[`With search parameters displays the default values if some values are b
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9 label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -4503,7 +4503,7 @@ exports[`With search parameters displays the default values if some values are b
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f5zlgu9  -base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1mtgqas  -base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -4551,7 +4551,7 @@ exports[`With search parameters displays the default values if some values are b
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth fj0l9jr css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f9bdc42 css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -4608,7 +4608,7 @@ exports[`With search parameters displays the default values if some values are b
       data-testid="new-selected-revision"
     >
       <div
-        class="box_fobrng5 new-box MuiBox-root css-0"
+        class="box_f1yxlro0 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -4617,7 +4617,7 @@ exports[`With search parameters displays the default values if some values are b
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f5zlgu9 css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1mtgqas css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"

--- a/src/__tests__/Search/__snapshots__/SelectedRevision.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SelectedRevision.test.tsx.snap
@@ -23,13 +23,13 @@ exports[`SelectedRevision should show the selected checked revisions once a resu
     </div>
   </div>
   <div
-    class="selectedRevision_f1jffy9s MuiBox-root css-0"
+    class="selectedRevision_fmpcdiu MuiBox-root css-0"
   >
     <div
       class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
     >
       <span
-        class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
+        class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-10rb10z-MuiTypography-root"
       >
         <span
           class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"

--- a/src/__tests__/Search/__snapshots__/SelectedRevision.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SelectedRevision.test.tsx.snap
@@ -23,13 +23,13 @@ exports[`SelectedRevision should show the selected checked revisions once a resu
     </div>
   </div>
   <div
-    class="selectedRevision_fd452xz MuiBox-root css-0"
+    class="selectedRevision_f1jffy9s MuiBox-root css-0"
   >
     <div
       class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
     >
       <span
-        class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-6bdtsh-MuiTypography-root"
+        class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4an9f3-MuiTypography-root"
       >
         <span
           class="MuiTypography-root MuiTypography-body2 revision-hash css-1lnwygr-MuiTypography-root"

--- a/src/__tests__/TaskclusterAuth/__snapshots__/TaskclusterCallback.test.tsx.snap
+++ b/src/__tests__/TaskclusterAuth/__snapshots__/TaskclusterCallback.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Taskcluster Callback should show a spinner while waiting for the creden
       class="MuiBox-root css-vmdzdb"
     >
       <h2
-        class="MuiTypography-root MuiTypography-h2 css-15umudq-MuiTypography-root"
+        class="MuiTypography-root MuiTypography-h2 css-gja6vo-MuiTypography-root"
       >
         Retrieving Taskcluster credentials...
       </h2>

--- a/src/__tests__/__snapshots__/App.test.tsx.snap
+++ b/src/__tests__/__snapshots__/App.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
         class="MuiGrid-root header-container container_f1ocj467 css-plh9qo-MuiGrid-root"
       >
         <div
-          class="toggle-dark-mode f10ie5uy MuiBox-root css-0"
+          class="toggle-dark-mode fc950xb MuiBox-root css-0"
         >
           <div
             class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -96,7 +96,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
                 />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-13qdlub-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1m50to5-MuiTypography-root"
               >
                 Dark mode
               </span>
@@ -114,7 +114,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
         </div>
       </div>
       <section
-        class="container_fk3n580"
+        class="container_frwb35k"
       >
         <a
           aria-label="link to home"
@@ -321,7 +321,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
         class="MuiGrid-root header-container container_f1ocj467 css-plh9qo-MuiGrid-root"
       >
         <div
-          class="toggle-dark-mode f10ie5uy MuiBox-root css-0"
+          class="toggle-dark-mode fc950xb MuiBox-root css-0"
         >
           <div
             class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -354,7 +354,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
                 />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-13qdlub-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1m50to5-MuiTypography-root"
               >
                 Dark mode
               </span>
@@ -372,7 +372,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
         </div>
       </div>
       <section
-        class="container_fk3n580"
+        class="container_frwb35k"
       >
         <a
           aria-label="link to home"
@@ -474,7 +474,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
         class="MuiGrid-root header-container container_f1ocj467 css-plh9qo-MuiGrid-root"
       >
         <div
-          class="toggle-dark-mode f10ie5uy MuiBox-root css-0"
+          class="toggle-dark-mode fc950xb MuiBox-root css-0"
         >
           <div
             class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -507,7 +507,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
                 />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-13qdlub-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1m50to5-MuiTypography-root"
               >
                 Dark mode
               </span>
@@ -525,7 +525,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
         </div>
       </div>
       <section
-        class="container_fk3n580"
+        class="container_frwb35k"
       >
         <a
           aria-label="link to home"

--- a/src/__tests__/__snapshots__/App.test.tsx.snap
+++ b/src/__tests__/__snapshots__/App.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
         class="MuiGrid-root header-container container_f1ocj467 css-plh9qo-MuiGrid-root"
       >
         <div
-          class="toggle-dark-mode fc950xb MuiBox-root css-0"
+          class="toggle-dark-mode fkud7h4 MuiBox-root css-0"
         >
           <div
             class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -96,7 +96,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
                 />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1m50to5-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-smpupv-MuiTypography-root"
               >
                 Dark mode
               </span>
@@ -107,14 +107,14 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
           class="header-text MuiBox-root css-0"
         >
           <h1
-            class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-160ox9e-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-eaa0qe-MuiTypography-root"
           >
             PerfCompare
           </h1>
         </div>
       </div>
       <section
-        class="container_frwb35k"
+        class="container_fdgf30v"
       >
         <a
           aria-label="link to home"
@@ -321,7 +321,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
         class="MuiGrid-root header-container container_f1ocj467 css-plh9qo-MuiGrid-root"
       >
         <div
-          class="toggle-dark-mode fc950xb MuiBox-root css-0"
+          class="toggle-dark-mode fkud7h4 MuiBox-root css-0"
         >
           <div
             class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -354,7 +354,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
                 />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1m50to5-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-smpupv-MuiTypography-root"
               >
                 Dark mode
               </span>
@@ -365,14 +365,14 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
           class="header-text MuiBox-root css-0"
         >
           <h1
-            class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-160ox9e-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-eaa0qe-MuiTypography-root"
           >
             PerfCompare
           </h1>
         </div>
       </div>
       <section
-        class="container_frwb35k"
+        class="container_fdgf30v"
       >
         <a
           aria-label="link to home"
@@ -474,7 +474,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
         class="MuiGrid-root header-container container_f1ocj467 css-plh9qo-MuiGrid-root"
       >
         <div
-          class="toggle-dark-mode fc950xb MuiBox-root css-0"
+          class="toggle-dark-mode fkud7h4 MuiBox-root css-0"
         >
           <div
             class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -507,7 +507,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
                 />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1m50to5-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-smpupv-MuiTypography-root"
               >
                 Dark mode
               </span>
@@ -518,14 +518,14 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
           class="header-text MuiBox-root css-0"
         >
           <h1
-            class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-160ox9e-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-eaa0qe-MuiTypography-root"
           >
             PerfCompare
           </h1>
         </div>
       </div>
       <section
-        class="container_frwb35k"
+        class="container_fdgf30v"
       >
         <a
           aria-label="link to home"

--- a/src/components/CompareResults/LinkToRevision.tsx
+++ b/src/components/CompareResults/LinkToRevision.tsx
@@ -11,7 +11,7 @@ const styles = {
     fontStyle: 'normal',
     fontWeight: 590,
     fontSize: '15px',
-    lineHeight: '20px',
+    lineHeight: '1.5',
   }),
 };
 

--- a/src/components/CompareResults/ResultsMain.tsx
+++ b/src/components/CompareResults/ResultsMain.tsx
@@ -54,7 +54,6 @@ function ResultsMain() {
     subtitle: style({
       ...FontsRaw.BodyDefault,
       fontSize: '15px',
-      lineHeight: '1.5',
       borderLeft: '1px solid #5B5B66',
       paddingLeft: '9px',
     }),

--- a/src/components/CompareResults/ResultsMain.tsx
+++ b/src/components/CompareResults/ResultsMain.tsx
@@ -54,7 +54,7 @@ function ResultsMain() {
     subtitle: style({
       ...FontsRaw.BodyDefault,
       fontSize: '15px',
-      lineHeight: '20px',
+      lineHeight: '1.5',
       borderLeft: '1px solid #5B5B66',
       paddingLeft: '9px',
     }),

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -41,7 +41,7 @@ const typography = {
   fontStyle: 'normal',
   fontWeight: 400,
   fontSize: '13px',
-  lineHeight: '16px',
+  lineHeight: '1.5',
 };
 
 const stylesLight = {

--- a/src/components/CompareResults/SubtestsResults/SubtestsRevisionHeader.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsRevisionHeader.tsx
@@ -69,7 +69,7 @@ const styles = {
     fontStyle: 'normal',
     fontWeight: 590,
     fontSize: '15px',
-    lineHeight: '20px',
+    lineHeight: '1.5',
   }),
 };
 

--- a/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
@@ -29,7 +29,7 @@ const typography = style({
   fontStyle: 'normal',
   fontWeight: 400,
   fontSize: '13px',
-  lineHeight: '16px',
+  lineHeight: '1.5',
 });
 
 function getStyles(themeMode: string) {

--- a/src/components/CompareResults/TableHeader.tsx
+++ b/src/components/CompareResults/TableHeader.tsx
@@ -307,7 +307,7 @@ function TableHeader({
       fontStyle: 'normal',
       fontWeight: 590,
       fontSize: '13px',
-      lineHeight: '16px',
+      lineHeight: '1.5',
     }),
   };
 

--- a/src/components/CompareResults/TestHeader.tsx
+++ b/src/components/CompareResults/TestHeader.tsx
@@ -51,7 +51,7 @@ const styles = {
     fontStyle: 'normal',
     fontWeight: 590,
     fontSize: '15px',
-    lineHeight: '20px',
+    lineHeight: '1.5',
   }),
 };
 

--- a/src/styles/Fonts.ts
+++ b/src/styles/Fonts.ts
@@ -20,7 +20,6 @@ const sharedFontStyles = {
 export const FontsRaw = {
   HeadingDefault: {
     ...sharedFontStyles,
-    lineHeight: '1.5',
     fontWeight: '600',
     fontSize: '17px',
     fontFamily: 'SF Pro',
@@ -29,24 +28,14 @@ export const FontsRaw = {
 
   HeadingXS: {
     ...sharedFontStyles,
-    lineHeight: '1.5',
     fontSize: '24px',
     fontFamily: 'Metropolis',
   },
 
   BodyDefault: {
     ...sharedFontStyles,
-    lineHeight: '1.5',
     fontWeight: '400',
     fontSize: '14px',
-    fontFamily: 'SF Pro',
-  },
-
-  BodySmall: {
-    ...sharedFontStyles,
-    lineHeight: '1.5',
-    fontWeight: '400',
-    fontSize: '12px',
     fontFamily: 'SF Pro',
   },
 
@@ -54,7 +43,6 @@ export const FontsRaw = {
 
   HeadingDefaultDark: {
     ...sharedFontStyles,
-    lineHeight: '1.5',
     fontWeight: '600',
     fontSize: '17px',
     fontFamily: 'SF Pro',
@@ -62,24 +50,14 @@ export const FontsRaw = {
 
   HeadingXSDark: {
     ...sharedFontStyles,
-    lineHeight: '1.5',
     fontSize: '24px',
     fontFamily: 'Metropolis',
   },
 
   BodyDefaultDark: {
     ...sharedFontStyles,
-    lineHeight: '1.5',
     fontWeight: '400',
     fontSize: '14px',
-    fontFamily: 'SF Pro',
-  },
-
-  BodySmallDark: {
-    ...sharedFontStyles,
-    lineHeight: '1.5',
-    fontWeight: '400',
-    fontSize: '12px',
     fontFamily: 'SF Pro',
   },
 };
@@ -88,11 +66,9 @@ export const Fonts = {
   HeadingDefault: style(FontsRaw.HeadingDefault),
   HeadingXS: style(FontsRaw.HeadingXS),
   BodyDefault: style(FontsRaw.BodyDefault),
-  BodySmall: style(FontsRaw.BodySmall),
   HeadingDefaultDark: style(FontsRaw.HeadingDefaultDark),
   HeadingXSDark: style(FontsRaw.HeadingXSDark),
   BodyDefaultDark: style(FontsRaw.BodyDefaultDark),
-  BodySmallDark: style(FontsRaw.BodySmallDark),
 };
 
 export const FontSizeRaw = {

--- a/src/styles/Fonts.ts
+++ b/src/styles/Fonts.ts
@@ -20,7 +20,7 @@ const sharedFontStyles = {
 export const FontsRaw = {
   HeadingDefault: {
     ...sharedFontStyles,
-    lineHeight: '22px',
+    lineHeight: '1.5',
     fontWeight: '600',
     fontSize: '17px',
     fontFamily: 'SF Pro',
@@ -29,14 +29,14 @@ export const FontsRaw = {
 
   HeadingXS: {
     ...sharedFontStyles,
-    lineHeight: '28px',
+    lineHeight: '1.5',
     fontSize: '24px',
     fontFamily: 'Metropolis',
   },
 
   BodyDefault: {
     ...sharedFontStyles,
-    lineHeight: '16px',
+    lineHeight: '1.5',
     fontWeight: '400',
     fontSize: '14px',
     fontFamily: 'SF Pro',
@@ -44,7 +44,7 @@ export const FontsRaw = {
 
   BodySmall: {
     ...sharedFontStyles,
-    lineHeight: '14px',
+    lineHeight: '1.5',
     fontWeight: '400',
     fontSize: '12px',
     fontFamily: 'SF Pro',
@@ -54,7 +54,7 @@ export const FontsRaw = {
 
   HeadingDefaultDark: {
     ...sharedFontStyles,
-    lineHeight: '22px',
+    lineHeight: '1.5',
     fontWeight: '600',
     fontSize: '17px',
     fontFamily: 'SF Pro',
@@ -62,14 +62,14 @@ export const FontsRaw = {
 
   HeadingXSDark: {
     ...sharedFontStyles,
-    lineHeight: '28px',
+    lineHeight: '1.5',
     fontSize: '24px',
     fontFamily: 'Metropolis',
   },
 
   BodyDefaultDark: {
     ...sharedFontStyles,
-    lineHeight: '16px',
+    lineHeight: '1.5',
     fontWeight: '400',
     fontSize: '14px',
     fontFamily: 'SF Pro',
@@ -77,7 +77,7 @@ export const FontsRaw = {
 
   BodySmallDark: {
     ...sharedFontStyles,
-    lineHeight: '14px',
+    lineHeight: '1.5',
     fontWeight: '400',
     fontSize: '12px',
     fontFamily: 'SF Pro',

--- a/src/styles/SelectList.ts
+++ b/src/styles/SelectList.ts
@@ -1,5 +1,4 @@
 import { Colors } from './Colors';
-import { FontsRaw } from './Fonts';
 import { Spacing } from './Spacing';
 
 const sharedCaptionStyles = {
@@ -17,7 +16,6 @@ export const captionStylesLight = {
 
   $nest: {
     '.info-caption-item': {
-      ...FontsRaw.BodySmallDark,
       display: 'flex',
       alignItems: 'center',
       fontSize: '11px',
@@ -32,7 +30,6 @@ export const captionStylesDark = {
 
   $nest: {
     '.info-caption-item': {
-      ...FontsRaw.BodySmall,
       display: 'flex',
       alignItems: 'center',
       fontSize: '11px',

--- a/src/styles/SelectedRevsStyle.ts
+++ b/src/styles/SelectedRevsStyle.ts
@@ -78,7 +78,6 @@ export const SelectRevsStyles = (mode: string) => {
           ...(isTrueLight ? captionStylesLight : captionStylesDark),
           $nest: {
             '.info-caption-item': {
-              ...FontsRaw.BodySmallDark,
               display: 'flex',
               alignItems: 'center',
               fontSize: '11px',

--- a/src/theme/components.js
+++ b/src/theme/components.js
@@ -150,6 +150,7 @@ const components = {
     styleOverrides: {
       body1: {
         ...FontsRaw.BodyDefault,
+        lineHeight: '1.5',
       },
       root: {
         '&.perfcompare-header': {

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -10,10 +10,12 @@ const typography: TypographyOptions = {
   h1: {
     fontFamily: 'Zilla Slab',
     fontSize: h1Size,
+    lineHeight: '1.5',
   },
   h2: {
     ...FontsRaw.HeadingDefault,
     ...FontSizeRaw.xxLarge,
+    lineHeight: '1.5',
   },
   button: {
     textTransform: 'none',


### PR DESCRIPTION
## This PR updates `lineHeight` to 1.5 across the application  
### Bug [1946535](https://bugzilla.mozilla.org/show_bug.cgi?id=1946535)
### Description  
This PR updates the `lineHeight` to `1.5` everywhere, replacing pixel-based values in Fonts. Additionally, I have ensured the `h2` variant in `typography.ts` includes this update. 
- [x]  Verified that the retrigger sign-in modal displays correctly with the new lineHeight.
