### PR TITLE
Follow up PCF-561 Add copy run values to extended row

### DIFF
--- a/src/__tests__/CompareResults/RevisionRow.test.tsx
+++ b/src/__tests__/CompareResults/RevisionRow.test.tsx
@@ -115,4 +115,29 @@ describe('Expanded row', () => {
 
     expect(showLessButton).toBeInTheDocument();
   });
+
+  it('should copy run values when "Copy values" is clicked', async () => {
+    const writeTextMock = jest
+      .spyOn(navigator.clipboard, 'writeText')
+      .mockResolvedValue();
+    const user = userEvent.setup({ delay: null });
+    const { testCompareData } = getTestData();
+    const baseRuns = testCompareData[0].base_runs.toString();
+
+    renderWithRoute(
+      <RevisionRow
+        result={testCompareData[0]}
+        view={compareView}
+        gridTemplateColumns='none'
+      />,
+    );
+
+    const expandRowButton = await screen.findByTestId(/ExpandMoreIcon/);
+    await user.click(expandRowButton);
+
+    const copyResultsButton = await screen.findAllByText('Copy results');
+    await user.click(copyResultsButton[0]);
+
+    expect(writeTextMock).toHaveBeenCalledWith(baseRuns);
+  });
 });

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -70,6 +70,16 @@ exports[`Results View Should display Base, New and Common graphs with 1 value an
             >
               602.04
             </div>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-1j7c0nu-MuiButtonBase-root-MuiButton-root"
+              tabindex="0"
+              type="button"
+            >
+              Copy results
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </button>
           </div>
           <div>
             <b>
@@ -145,6 +155,16 @@ exports[`Results View Should display Base, New and Common graphs with 1 value an
             >
               607.27
             </div>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-1j7c0nu-MuiButtonBase-root-MuiButton-root"
+              tabindex="0"
+              type="button"
+            >
+              Copy results
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </button>
           </div>
           <div>
             <b>
@@ -342,6 +362,16 @@ exports[`Results View Should display Base, New and Common graphs with replicates
             >
               602.04
             </div>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-1j7c0nu-MuiButtonBase-root-MuiButton-root"
+              tabindex="0"
+              type="button"
+            >
+              Copy results
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </button>
           </div>
           <div>
             <b>
@@ -417,6 +447,16 @@ exports[`Results View Should display Base, New and Common graphs with replicates
             >
               607.27
             </div>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-1j7c0nu-MuiButtonBase-root-MuiButton-root"
+              tabindex="0"
+              type="button"
+            >
+              Copy results
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </button>
           </div>
           <div>
             <b>
@@ -614,6 +654,16 @@ exports[`Results View Should display Base, New and Common graphs with tooltips 1
             >
               602.04
             </div>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-1j7c0nu-MuiButtonBase-root-MuiButton-root"
+              tabindex="0"
+              type="button"
+            >
+              Copy results
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </button>
           </div>
           <div>
             <b>
@@ -689,6 +739,16 @@ exports[`Results View Should display Base, New and Common graphs with tooltips 1
             >
               607.27
             </div>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-1j7c0nu-MuiButtonBase-root-MuiButton-root"
+              tabindex="0"
+              type="button"
+            >
+              Copy results
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </button>
           </div>
           <div>
             <b>

--- a/src/components/CompareResults/RunValues.tsx
+++ b/src/components/CompareResults/RunValues.tsx
@@ -50,6 +50,10 @@ function RunValues(props: RunValuesProps) {
     setExpanded(!expanded);
   };
 
+  const onCopyValues = () => {
+    void navigator.clipboard.writeText(values.toString());
+  };
+
   return (
     <div className={styles.container}>
       {application ? (
@@ -88,6 +92,11 @@ function RunValues(props: RunValuesProps) {
               {expanded ? 'Show less' : `Show ${lastValues.length} more`}
             </Button>
           ) : null}
+          {values.length && (
+            <Button variant='text' size='small' onClick={onCopyValues}>
+              Copy results
+            </Button>
+          )}
         </div>
         <div>
           <b>Mean</b>:{'\u00a0'}


### PR DESCRIPTION
This is a follow up PR for #844 
It adds the `Copy results` button inside the extended row.

[deploy test link](https://deploy-preview-859--mozilla-perfcompare.netlify.app/compare-over-time-results?baseRepo=try&selectedTimeRange=1209600&newRev=301fd7df21a146720ac180a15dbfd007b090dcaf&newRepo=try&framework=1) 

![Screenshot 2025-02-12 at 17 07 19](https://github.com/user-attachments/assets/41b6a72b-ec5d-4472-a2c8-eb392370cd59)
