### PR TITLE
Fix incorrectly rendered platform on results table

### DIFF
--- a/src/__tests__/CompareResults/ResultsTable.test.tsx
+++ b/src/__tests__/CompareResults/ResultsTable.test.tsx
@@ -164,9 +164,9 @@ describe('Results Table', () => {
     expect(summarizeVisibleRows()).toEqual([
       'a11yr dhtml.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - OS X 10.15, Improvement, 1.08 %, Low',
+      '  - macOS 10.15, Improvement, 1.08 %, Low',
       '  rev: devilrabbit',
-      '  - OS X 10.15, Improvement, 1.08 %, Low',
+      '  - macOS 10.15, Improvement, 1.08 %, Low',
     ]);
     expect(screen.getByRole('rowgroup')).toMatchSnapshot();
   });
@@ -184,7 +184,7 @@ describe('Results Table', () => {
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
       '  - Android, Improvement, 1.08 %, Low',
       '  - Linux 18.04, Regression, 1.85 %, Medium',
-      '  - OS X 10.15, Improvement, 1.08 %, Low',
+      '  - macOS 10.15, Improvement, 1.08 %, Low',
       '  - Windows 10, -, -24 %, -',
       '  - Windows 10, -, -2.4 %, High',
     ]);
@@ -197,7 +197,7 @@ describe('Results Table', () => {
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
       '  - Android, Improvement, 1.08 %, Low',
       '  - Linux 18.04, Regression, 1.85 %, Medium',
-      '  - OS X 10.15, Improvement, 1.08 %, Low',
+      '  - macOS 10.15, Improvement, 1.08 %, Low',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       platform: ['osx', 'linux', 'android'],
@@ -207,7 +207,7 @@ describe('Results Table', () => {
     expect(summarizeVisibleRows()).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
       '  - Android, Improvement, 1.08 %, Low',
-      '  - OS X 10.15, Improvement, 1.08 %, Low',
+      '  - macOS 10.15, Improvement, 1.08 %, Low',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       platform: ['osx', 'android'],
@@ -218,7 +218,7 @@ describe('Results Table', () => {
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
       '  - Android, Improvement, 1.08 %, Low',
       '  - Linux 18.04, Regression, 1.85 %, Medium',
-      '  - OS X 10.15, Improvement, 1.08 %, Low',
+      '  - macOS 10.15, Improvement, 1.08 %, Low',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       platform: ['osx', 'linux', 'android'],
@@ -229,7 +229,7 @@ describe('Results Table', () => {
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
       '  - Android, Improvement, 1.08 %, Low',
       '  - Linux 18.04, Regression, 1.85 %, Medium',
-      '  - OS X 10.15, Improvement, 1.08 %, Low',
+      '  - macOS 10.15, Improvement, 1.08 %, Low',
       '  - Windows 10, -, -24 %, -',
       '  - Windows 10, -, -2.4 %, High',
     ]);
@@ -276,7 +276,7 @@ describe('Results Table', () => {
     expect(summarizeVisibleRows()).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
       '  - Linux 18.04, Regression, 1.85 %, Medium',
-      '  - OS X 10.15, Improvement, 1.08 %, Low',
+      '  - macOS 10.15, Improvement, 1.08 %, Low',
       '  - Windows 10, -, -24 %, -',
       '  - Windows 10, -, -2.4 %, High',
     ]);
@@ -287,7 +287,7 @@ describe('Results Table', () => {
     expect(summarizeVisibleRows()).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
       '  - Linux 18.04, Regression, 1.85 %, Medium',
-      '  - OS X 10.15, Improvement, 1.08 %, Low',
+      '  - macOS 10.15, Improvement, 1.08 %, Low',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       status: ['improvement', 'regression'],
@@ -333,7 +333,7 @@ describe('Results Table', () => {
     expect(summarizeVisibleRows()).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
       '  - Linux 18.04, Regression, 1.85 %, Medium',
-      '  - OS X 10.15, Improvement, 1.08 %, Low',
+      '  - macOS 10.15, Improvement, 1.08 %, Low',
       '  - Windows 10, -, -24 %, -',
       '  - Windows 10, -, -2.4 %, High',
     ]);
@@ -374,7 +374,7 @@ describe('Results Table', () => {
     expect(summarizeVisibleRows()).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
       '  - Linux 18.04, Regression, 1.85 %, Medium',
-      '  - OS X 10.15, Improvement, 1.08 %, Low',
+      '  - macOS 10.15, Improvement, 1.08 %, Low',
       '  - Windows 10, -, -24 %, -',
       '  - Windows 10, -, -2.4 %, High',
     ]);
@@ -384,7 +384,7 @@ describe('Results Table', () => {
     expect(summarizeVisibleRows()).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
       '  - Linux 18.04, Regression, 1.85 %, Medium',
-      '  - OS X 10.15, Improvement, 1.08 %, Low',
+      '  - macOS 10.15, Improvement, 1.08 %, Low',
       '  - Windows 10, -, -2.4 %, High',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
@@ -414,23 +414,23 @@ describe('Results Table', () => {
       'a11yr aria.html opt e10s fission stylo webrender',
       '  rev: spam',
       '  - Linux 18.04, Regression, 1.97 %, Medium',
-      '  - OS X 10.15, Improvement, 1.2 %, Low',
+      '  - macOS 10.15, Improvement, 1.2 %, Low',
       '  - Windows 10, -, -23.88 %, -',
       '  - Windows 10, -, -2.28 %, High',
       '  rev: tictactoe',
       '  - Linux 18.04, Regression, 2.05 %, Medium',
-      '  - OS X 10.15, Improvement, 1.28 %, Low',
+      '  - macOS 10.15, Improvement, 1.28 %, Low',
       '  - Windows 10, -, -23.8 %, -',
       '  - Windows 10, -, -2.2 %, High',
       'a11yr dhtml.html opt e10s fission stylo webrender',
       '  rev: spam',
       '  - Linux 18.04, Regression, 1.85 %, Medium',
-      '  - OS X 10.15, Improvement, 1.08 %, Low',
+      '  - macOS 10.15, Improvement, 1.08 %, Low',
       '  - Windows 10, -, -24 %, -',
       '  - Windows 10, -, -2.4 %, High',
       '  rev: tictactoe',
       '  - Linux 18.04, Regression, 1.93 %, Medium',
-      '  - OS X 10.15, Improvement, 1.16 %, Low',
+      '  - macOS 10.15, Improvement, 1.16 %, Low',
       '  - Windows 10, -, -23.92 %, -',
       '  - Windows 10, -, -2.32 %, High',
     ]);
@@ -448,23 +448,23 @@ describe('Results Table', () => {
       '  - Windows 10, -, -24 %, -',
       '  - Windows 10, -, -2.4 %, High',
       '  - Linux 18.04, Regression, 1.85 %, Medium',
-      '  - OS X 10.15, Improvement, 1.08 %, Low',
+      '  - macOS 10.15, Improvement, 1.08 %, Low',
       '  rev: tictactoe',
       '  - Windows 10, -, -23.92 %, -',
       '  - Windows 10, -, -2.32 %, High',
       '  - Linux 18.04, Regression, 1.93 %, Medium',
-      '  - OS X 10.15, Improvement, 1.16 %, Low',
+      '  - macOS 10.15, Improvement, 1.16 %, Low',
       'a11yr aria.html opt e10s fission stylo webrender',
       '  rev: spam',
       '  - Windows 10, -, -23.88 %, -',
       '  - Windows 10, -, -2.28 %, High',
       '  - Linux 18.04, Regression, 1.97 %, Medium',
-      '  - OS X 10.15, Improvement, 1.2 %, Low',
+      '  - macOS 10.15, Improvement, 1.2 %, Low',
       '  rev: tictactoe',
       '  - Windows 10, -, -23.8 %, -',
       '  - Windows 10, -, -2.2 %, High',
       '  - Linux 18.04, Regression, 2.05 %, Medium',
-      '  - OS X 10.15, Improvement, 1.28 %, Low',
+      '  - macOS 10.15, Improvement, 1.28 %, Low',
     ]);
     // It should have the "descending" SVG.
     expect(deltaButton).toMatchSnapshot();
@@ -476,23 +476,23 @@ describe('Results Table', () => {
     expect(summarizeVisibleRows()).toEqual([
       'a11yr dhtml.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - OS X 10.15, Improvement, 1.08 %, Low',
+      '  - macOS 10.15, Improvement, 1.08 %, Low',
       '  - Linux 18.04, Regression, 1.85 %, Medium',
       '  - Windows 10, -, -2.4 %, High',
       '  - Windows 10, -, -24 %, -',
       '  rev: tictactoe',
-      '  - OS X 10.15, Improvement, 1.16 %, Low',
+      '  - macOS 10.15, Improvement, 1.16 %, Low',
       '  - Linux 18.04, Regression, 1.93 %, Medium',
       '  - Windows 10, -, -2.32 %, High',
       '  - Windows 10, -, -23.92 %, -',
       'a11yr aria.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - OS X 10.15, Improvement, 1.2 %, Low',
+      '  - macOS 10.15, Improvement, 1.2 %, Low',
       '  - Linux 18.04, Regression, 1.97 %, Medium',
       '  - Windows 10, -, -2.28 %, High',
       '  - Windows 10, -, -23.88 %, -',
       '  rev: tictactoe',
-      '  - OS X 10.15, Improvement, 1.28 %, Low',
+      '  - macOS 10.15, Improvement, 1.28 %, Low',
       '  - Linux 18.04, Regression, 2.05 %, Medium',
       '  - Windows 10, -, -2.2 %, High',
       '  - Windows 10, -, -23.8 %, -',
@@ -512,23 +512,23 @@ describe('Results Table', () => {
       '  rev: tictactoe',
       '  - Windows 10, -, -2.2 %, High',
       '  - Linux 18.04, Regression, 2.05 %, Medium',
-      '  - OS X 10.15, Improvement, 1.28 %, Low',
+      '  - macOS 10.15, Improvement, 1.28 %, Low',
       '  - Windows 10, -, -23.8 %, -',
       '  rev: spam',
       '  - Windows 10, -, -2.28 %, High',
       '  - Linux 18.04, Regression, 1.97 %, Medium',
-      '  - OS X 10.15, Improvement, 1.2 %, Low',
+      '  - macOS 10.15, Improvement, 1.2 %, Low',
       '  - Windows 10, -, -23.88 %, -',
       'a11yr dhtml.html opt e10s fission stylo webrender',
       '  rev: tictactoe',
       '  - Windows 10, -, -2.32 %, High',
       '  - Linux 18.04, Regression, 1.93 %, Medium',
-      '  - OS X 10.15, Improvement, 1.16 %, Low',
+      '  - macOS 10.15, Improvement, 1.16 %, Low',
       '  - Windows 10, -, -23.92 %, -',
       '  rev: spam',
       '  - Windows 10, -, -2.4 %, High',
       '  - Linux 18.04, Regression, 1.85 %, Medium',
-      '  - OS X 10.15, Improvement, 1.08 %, Low',
+      '  - macOS 10.15, Improvement, 1.08 %, Low',
       '  - Windows 10, -, -24 %, -',
     ]);
     // It should have the "no sort" SVG.
@@ -550,7 +550,7 @@ describe('Results Table', () => {
 
     expect(summarizeVisibleRows()).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - OS X 10.15, Improvement, 1.08 %, Low',
+      '  - macOS 10.15, Improvement, 1.08 %, Low',
       '  - Linux 18.04, Regression, 1.85 %, Medium',
       '  - Windows 10, -, -2.4 %, High',
       '  - Windows 10, -, -24 %, -',
@@ -562,7 +562,7 @@ describe('Results Table', () => {
     expect(summarizeVisibleRows()).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
       '  - Linux 18.04, Regression, 1.85 %, Medium',
-      '  - OS X 10.15, Improvement, 1.08 %, Low',
+      '  - macOS 10.15, Improvement, 1.08 %, Low',
       '  - Windows 10, -, -24 %, -',
       '  - Windows 10, -, -2.4 %, High',
     ]);
@@ -583,7 +583,7 @@ describe('Results Table', () => {
       '  - Windows 10, -, -24 %, -',
       '  - Windows 10, -, -2.4 %, High',
       '  - Linux 18.04, Regression, 1.85 %, Medium',
-      '  - OS X 10.15, Improvement, 1.08 %, Low',
+      '  - macOS 10.15, Improvement, 1.08 %, Low',
     ]);
   });
 });

--- a/src/__tests__/CompareResults/RevisionRow.test.tsx
+++ b/src/__tests__/CompareResults/RevisionRow.test.tsx
@@ -37,7 +37,7 @@ describe('<RevisionRow>', () => {
     },
     {
       platform: 'macosx1014-64-shippable-qr',
-      shortName: 'OS X 10.14',
+      shortName: 'macOS 10.14',
       hasIcon: true,
     },
     {

--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -838,7 +838,7 @@ exports[`Results View The table should match snapshot and other elements should 
                       />
                     </svg>
                     <span>
-                      OS X 10.15
+                      macOS 10.15
                     </span>
                   </div>
                 </div>

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -1614,7 +1614,7 @@ exports[`Results Table Should match snapshot 1`] = `
                                   />
                                 </svg>
                                 <span>
-                                  OS X 10.15
+                                  macOS 10.15
                                 </span>
                               </div>
                             </div>
@@ -2692,7 +2692,7 @@ exports[`Results Table should render different blocks when rendering several rev
             />
           </svg>
           <span>
-            OS X 10.15
+            macOS 10.15
           </span>
         </div>
       </div>
@@ -2956,7 +2956,7 @@ exports[`Results Table should render different blocks when rendering several rev
             />
           </svg>
           <span>
-            OS X 10.15
+            macOS 10.15
           </span>
         </div>
       </div>

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -1654,7 +1654,7 @@ exports[`Results View The table should match snapshot and other elements should 
                       />
                     </svg>
                     <span>
-                      OS X 10.15
+                      macOS 10.15
                     </span>
                   </div>
                 </div>

--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -25,7 +25,7 @@ const columnsConfiguration: CompareResultsTableConfig = [
     key: 'platform',
     gridWidth: '2fr',
     possibleValues: [
-      { label: 'Windows', key: 'win' },
+      { label: 'Windows', key: 'windows' },
       { label: 'macOS', key: 'osx' },
       { label: 'Linux', key: 'linux' },
       { label: 'Android', key: 'android' },

--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -25,7 +25,7 @@ const columnsConfiguration: CompareResultsTableConfig = [
     key: 'platform',
     gridWidth: '2fr',
     possibleValues: [
-      { label: 'Windows', key: 'windows' },
+      { label: 'Windows', key: 'win' },
       { label: 'macOS', key: 'osx' },
       { label: 'Linux', key: 'linux' },
       { label: 'Android', key: 'android' },

--- a/src/components/CompareResults/TableContent.tsx
+++ b/src/components/CompareResults/TableContent.tsx
@@ -191,7 +191,6 @@ function TableContent({
   if (!filteredResults.length) {
     return <NoResultsFound />;
   }
-console.log(processedResults)
   return (
     <Virtuoso
       useWindowScroll

--- a/src/components/CompareResults/TableContent.tsx
+++ b/src/components/CompareResults/TableContent.tsx
@@ -191,7 +191,7 @@ function TableContent({
   if (!filteredResults.length) {
     return <NoResultsFound />;
   }
-
+console.log(processedResults)
   return (
     <Virtuoso
       useWindowScroll

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -9,7 +9,7 @@ export const getPlatformShortName = (
     platformName.toLowerCase().includes('os x')
   )
     return 'macOS';
-  if (platformName.toLowerCase().includes('windows')) return 'Windows';
+  if (platformName.toLowerCase().includes('win')) return 'Windows';
   if (platformName.toLowerCase().includes('android')) return 'Android';
   return 'Unspecified';
 };

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -9,7 +9,7 @@ export const getPlatformShortName = (
     platformName.toLowerCase().includes('os x')
   )
     return 'macOS';
-  if (platformName.toLowerCase().includes('win')) return 'Windows';
+  if (platformName.toLowerCase().startsWith('win')) return 'Windows';
   if (platformName.toLowerCase().includes('android')) return 'Android';
   return 'Unspecified';
 };
@@ -20,10 +20,10 @@ const osMapping = {
   linux64: 'Linux x64',
   linux1804: 'Linux 18.04',
   linux2204: 'Linux 22.04',
-  osx: 'OS X',
-  macosx1014: 'OS X 10.14',
-  macosx1015: 'OS X 10.15',
-  macosx1100: 'OS X 11',
+  osx: 'macOS',
+  macosx1014: 'macOS 10.14',
+  macosx1015: 'macOS 10.15',
+  macosx1100: 'macOS 11',
   macosx1300: 'macOS 13',
   macosx1400: 'macOS 14.00',
   macosx1470: 'macOS 14.70',


### PR DESCRIPTION
[Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1943334)
[Deploy link](http://localhost:3000/compare-results?baseRev=0874fcba521fcf935ace34a3507f284de9bc4d79&baseRepo=autoland&newRev=e4734cd9848c0b570af98a9708da8fe4a2263b10&newRepo=autoland&framework=2&search=installer&filter_platform=windows)

This PR fixes incorrectly rendered platform names on the results table

Before

When macOS is filtered, we can still see windows as part of the result. [Live link](https://perf.compare/compare-results?baseRev=0874fcba521fcf935ace34a3507f284de9bc4d79&baseRepo=autoland&newRev=e4734cd9848c0b570af98a9708da8fe4a2263b10&newRepo=autoland&framework=2&search=installer&filter_platform=osx)


![macos](https://github.com/user-attachments/assets/c5c93678-1bca-4d1c-9f5f-a4fb94aac11d)


After

The platform name for Windows is `windows` so this wasn't capturing some windows platform with platform name as `win64-nightlyasrelease` 

To fix this I updated the `getPlatformShortName` to return Windows if platform name starts with `win` This way we cover both `win` and `windows` platforms.

I also updated `OS X` to `macOS` on the results table. This was updated on the `osMapping` object.

![download (19)](https://github.com/user-attachments/assets/60a97c6c-d562-4918-99fc-18d92d218fc5)





