### PR TITLE
Fix alignment for long test name in subtest revision row

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -625,13 +625,12 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 />
               </div>
               <div
-                class="revisionRow f3czsqg f1vh4jdk MuiBox-root css-ux85ba"
+                class="revisionRow f1wrecgx f1vh4jdk MuiBox-root css-ux85ba"
                 role="row"
               >
                 <div
-                  class="subtests overflowing-text"
+                  class="subtests"
                   role="cell"
-                  style="overflow: hidden;"
                   title="dhtml.html"
                 >
                   dhtml.html
@@ -787,13 +786,12 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow f3czsqg f1vh4jdk MuiBox-root css-ux85ba"
+                class="revisionRow f1wrecgx f1vh4jdk MuiBox-root css-ux85ba"
                 role="row"
               >
                 <div
-                  class="subtests overflowing-text"
+                  class="subtests"
                   role="cell"
-                  style="overflow: hidden;"
                   title="improvement.html"
                 >
                   improvement.html
@@ -960,13 +958,12 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow f3czsqg f1vh4jdk MuiBox-root css-ux85ba"
+                class="revisionRow f1wrecgx f1vh4jdk MuiBox-root css-ux85ba"
                 role="row"
               >
                 <div
-                  class="subtests overflowing-text"
+                  class="subtests"
                   role="cell"
-                  style="overflow: hidden;"
                   title="regression.html"
                 >
                   regression.html
@@ -1133,13 +1130,12 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow f3czsqg f1vh4jdk MuiBox-root css-ux85ba"
+                class="revisionRow f1wrecgx f1vh4jdk MuiBox-root css-ux85ba"
                 role="row"
               >
                 <div
-                  class="subtests overflowing-text"
+                  class="subtests"
                   role="cell"
-                  style="overflow: hidden;"
                   title="tablemutation.html"
                 >
                   tablemutation.html
@@ -2269,13 +2265,12 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 />
               </div>
               <div
-                class="revisionRow f3czsqg f1vh4jdk MuiBox-root css-ux85ba"
+                class="revisionRow f1wrecgx f1vh4jdk MuiBox-root css-ux85ba"
                 role="row"
               >
                 <div
-                  class="subtests overflowing-text"
+                  class="subtests"
                   role="cell"
-                  style="overflow: hidden;"
                   title="dhtml.html"
                 >
                   dhtml.html
@@ -2431,13 +2426,12 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow f3czsqg f1vh4jdk MuiBox-root css-ux85ba"
+                class="revisionRow f1wrecgx f1vh4jdk MuiBox-root css-ux85ba"
                 role="row"
               >
                 <div
-                  class="subtests overflowing-text"
+                  class="subtests"
                   role="cell"
-                  style="overflow: hidden;"
                   title="improvement.html"
                 >
                   improvement.html
@@ -2604,13 +2598,12 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow f3czsqg f1vh4jdk MuiBox-root css-ux85ba"
+                class="revisionRow f1wrecgx f1vh4jdk MuiBox-root css-ux85ba"
                 role="row"
               >
                 <div
-                  class="subtests overflowing-text"
+                  class="subtests"
                   role="cell"
-                  style="overflow: hidden;"
                   title="regression.html"
                 >
                   regression.html
@@ -2777,13 +2770,12 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow f3czsqg f1vh4jdk MuiBox-root css-ux85ba"
+                class="revisionRow f1wrecgx f1vh4jdk MuiBox-root css-ux85ba"
                 role="row"
               >
                 <div
-                  class="subtests overflowing-text"
+                  class="subtests"
                   role="cell"
-                  style="overflow: hidden;"
                   title="tablemutation.html"
                 >
                   tablemutation.html

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -625,12 +625,14 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 />
               </div>
               <div
-                class="revisionRow f15pv6go f1vh4jdk MuiBox-root css-ux85ba"
+                class="revisionRow f3czsqg f1vh4jdk MuiBox-root css-ux85ba"
                 role="row"
               >
                 <div
-                  class="subtests cell"
+                  class="subtests overflowing-text"
                   role="cell"
+                  style="overflow: hidden;"
+                  title="dhtml.html"
                 >
                   dhtml.html
                 </div>
@@ -785,12 +787,14 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow f15pv6go f1vh4jdk MuiBox-root css-ux85ba"
+                class="revisionRow f3czsqg f1vh4jdk MuiBox-root css-ux85ba"
                 role="row"
               >
                 <div
-                  class="subtests cell"
+                  class="subtests overflowing-text"
                   role="cell"
+                  style="overflow: hidden;"
+                  title="improvement.html"
                 >
                   improvement.html
                 </div>
@@ -956,12 +960,14 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow f15pv6go f1vh4jdk MuiBox-root css-ux85ba"
+                class="revisionRow f3czsqg f1vh4jdk MuiBox-root css-ux85ba"
                 role="row"
               >
                 <div
-                  class="subtests cell"
+                  class="subtests overflowing-text"
                   role="cell"
+                  style="overflow: hidden;"
+                  title="regression.html"
                 >
                   regression.html
                 </div>
@@ -1127,12 +1133,14 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow f15pv6go f1vh4jdk MuiBox-root css-ux85ba"
+                class="revisionRow f3czsqg f1vh4jdk MuiBox-root css-ux85ba"
                 role="row"
               >
                 <div
-                  class="subtests cell"
+                  class="subtests overflowing-text"
                   role="cell"
+                  style="overflow: hidden;"
+                  title="tablemutation.html"
                 >
                   tablemutation.html
                 </div>
@@ -2261,12 +2269,14 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 />
               </div>
               <div
-                class="revisionRow f15pv6go f1vh4jdk MuiBox-root css-ux85ba"
+                class="revisionRow f3czsqg f1vh4jdk MuiBox-root css-ux85ba"
                 role="row"
               >
                 <div
-                  class="subtests cell"
+                  class="subtests overflowing-text"
                   role="cell"
+                  style="overflow: hidden;"
+                  title="dhtml.html"
                 >
                   dhtml.html
                 </div>
@@ -2421,12 +2431,14 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow f15pv6go f1vh4jdk MuiBox-root css-ux85ba"
+                class="revisionRow f3czsqg f1vh4jdk MuiBox-root css-ux85ba"
                 role="row"
               >
                 <div
-                  class="subtests cell"
+                  class="subtests overflowing-text"
                   role="cell"
+                  style="overflow: hidden;"
+                  title="improvement.html"
                 >
                   improvement.html
                 </div>
@@ -2592,12 +2604,14 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow f15pv6go f1vh4jdk MuiBox-root css-ux85ba"
+                class="revisionRow f3czsqg f1vh4jdk MuiBox-root css-ux85ba"
                 role="row"
               >
                 <div
-                  class="subtests cell"
+                  class="subtests overflowing-text"
                   role="cell"
+                  style="overflow: hidden;"
+                  title="regression.html"
                 >
                   regression.html
                 </div>
@@ -2763,12 +2777,14 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow f15pv6go f1vh4jdk MuiBox-root css-ux85ba"
+                class="revisionRow f3czsqg f1vh4jdk MuiBox-root css-ux85ba"
                 role="row"
               >
                 <div
-                  class="subtests cell"
+                  class="subtests overflowing-text"
                   role="cell"
+                  style="overflow: hidden;"
+                  title="tablemutation.html"
                 >
                   tablemutation.html
                 </div>

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsRevisionRow.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsRevisionRow.test.tsx.snap
@@ -4,12 +4,14 @@ exports[`SubtestsRevisionRow Component renders the component with correct data 1
 <body>
   <div>
     <div
-      class="revisionRow f15pv6go f1vh4jdk MuiBox-root css-1ykk23q"
+      class="revisionRow f3czsqg f1vh4jdk MuiBox-root css-1ykk23q"
       role="row"
     >
       <div
-        class="subtests cell"
+        class="subtests overflowing-text"
         role="cell"
+        style="overflow: hidden;"
+        title="dhtml.html"
       >
         dhtml.html
       </div>

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsRevisionRow.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsRevisionRow.test.tsx.snap
@@ -4,13 +4,12 @@ exports[`SubtestsRevisionRow Component renders the component with correct data 1
 <body>
   <div>
     <div
-      class="revisionRow f3czsqg f1vh4jdk MuiBox-root css-1ykk23q"
+      class="revisionRow f1wrecgx f1vh4jdk MuiBox-root css-1ykk23q"
       role="row"
     >
       <div
-        class="subtests overflowing-text"
+        class="subtests"
         role="cell"
-        style="overflow: hidden;"
         title="dhtml.html"
       >
         dhtml.html

--- a/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
@@ -22,6 +22,7 @@ const revisionsRow = {
   borderRadius: '4px 0px 0px 4px',
   display: 'grid',
   margin: `${Spacing.Small}px 0px 0px 0px`,
+  alignItems: 'center',
 };
 
 const typography = style({
@@ -86,6 +87,11 @@ function getStyles(themeMode: string) {
         '.status-hint-regression .MuiSvgIcon-root': {
           // We need to move the icon a bit lower so that it _looks_ centered.
           marginTop: '2px',
+        },
+        '.overflowing-text': {
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
         },
       },
     }),
@@ -155,7 +161,12 @@ function SubtestsRevisionRow(props: RevisionRowProps) {
         sx={{ gridTemplateColumns }}
         role='row'
       >
-        <div className='subtests cell' role='cell'>
+        <div
+          title={test}
+          style={{ overflow: 'hidden' }}
+          className='subtests overflowing-text'
+          role='cell'
+        >
           {test}
         </div>
         <div className='base-value cell' role='cell'>

--- a/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
@@ -58,6 +58,9 @@ function getStyles(themeMode: string) {
           borderRadius: '4px 0 0 4px',
           paddingLeft: Spacing.Medium, // Synchronize with its header
           justifyContent: 'left',
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
         },
         '.status': {
           justifyContent: 'center',
@@ -87,11 +90,6 @@ function getStyles(themeMode: string) {
         '.status-hint-regression .MuiSvgIcon-root': {
           // We need to move the icon a bit lower so that it _looks_ centered.
           marginTop: '2px',
-        },
-        '.overflowing-text': {
-          whiteSpace: 'nowrap',
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
         },
       },
     }),
@@ -161,12 +159,7 @@ function SubtestsRevisionRow(props: RevisionRowProps) {
         sx={{ gridTemplateColumns }}
         role='row'
       >
-        <div
-          title={test}
-          style={{ overflow: 'hidden' }}
-          className='subtests overflowing-text'
-          role='cell'
-        >
+        <div title={test} className='subtests' role='cell'>
           {test}
         </div>
         <div className='base-value cell' role='cell'>


### PR DESCRIPTION
[Bugzilla number](https://bugzilla.mozilla.org/show_bug.cgi?id=1943914)
[Deploy link](https://deploy-preview-863--mozilla-perfcompare.netlify.app/subtests-compare-results?baseRev=632d1b46eeba0e6950cb84fd950eceb086142d23&baseRepo=try&newRev=7c9e39d87387c3ed4c829ad5300ceb13705026e0&newRepo=try&framework=12&baseParentSignature=59287&newParentSignature=59287&sort=delta%7Cdesc&filter_status=improvement%2Cregression)

This PR fixes the alignment issue of long test names in the subtest revision row.

Before

![download (21)](https://github.com/user-attachments/assets/d9dc0aeb-79eb-47af-8bcd-6d186b2b9d96)

After
Added `ellipse` and `overflow-hidden` to contain long test name
I also removed the `cell` styling from the test name column because `ellipse` wasn't working with `display:flex`

![download (22)](https://github.com/user-attachments/assets/17f020ce-3bab-4e7e-a0cb-3a45b8cf01a3)
