### PR TITLE
Bug 1949264 - Add git migration compatibility for ./mach try perf

### DIFF
--- a/src/components/CompareResults/loader.ts
+++ b/src/components/CompareResults/loader.ts
@@ -4,6 +4,7 @@ import {
   fetchCompareResults,
   fetchFakeCompareResults,
   memoizedFetchRevisionForRepository,
+  fetchRevisionFromHash,
 } from '../../logic/treeherder';
 import { Changeset, CompareResultsItem, Repository } from '../../types/state';
 import { FakeCommitHash, Framework } from '../../types/types';
@@ -181,10 +182,21 @@ export async function loader({ request }: { request: Request }) {
   }
 
   const baseRevFromUrl = url.searchParams.get('baseRev');
+  const baseHashFromUrl = url.searchParams.get('originalHash');
+  if (baseRevFromUrl == null && baseHashFromUrl != null) {
+    const promises = await fetchRevisionFromHash(baseHashFromUrl, 'try');
+    console.log(promises)
+  }
+
   const baseRepoFromUrl = url.searchParams.get('baseRepo') as
     | Repository['name']
     | null;
   const newRevsFromUrl = url.searchParams.getAll('newRev');
+  const newHashFromUrl = url.searchParams.get('newHash');
+  if (newRevsFromUrl == null && newHashFromUrl != null) {
+    const promises = await fetchRevisionFromHash(newHashFromUrl, 'try');
+    console.log(promises)
+  }
   const newReposFromUrl = url.searchParams.getAll(
     'newRepo',
   ) as Repository['name'][];

--- a/src/logic/treeherder.ts
+++ b/src/logic/treeherder.ts
@@ -1,7 +1,7 @@
 import moize from 'moize';
 
 import { JobInformation } from '../types/api';
-import { CompareResultsItem, Repository, Changeset } from '../types/state';
+import { CompareResultsItem, Repository, Changeset, CommitToHash} from '../types/state';
 import { Framework, TimeRange } from '../types/types';
 
 // This file contains functions to request the Treeherder API
@@ -58,6 +58,22 @@ async function fetchFromTreeherder(url: string) {
     }
   }
   return response;
+}
+
+// This fetches the revision with the hash inside the ./mach try perf pushed job
+export async function fetchRevisionFromHash(
+  hash_to_commit: string,
+  repo: string) {
+  console.log("inside")
+  const searchParams = new URLSearchParams({
+    hash: String(hash_to_commit),
+  });
+  console.log(searchParams)
+  const url = `${treeherderBaseURL}/api/project/${repo}/push/commit_from_hash/?${searchParams.toString()}`;
+  console.log(url)
+  const response = await fetchFromTreeherder(url);
+
+  return response.json() as Promise<CommitToHash[]>;
 }
 
 // This fetches data from the Treeherder API /api/perfcompare/results.

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -109,6 +109,10 @@ export type CompareResultsItem = {
   has_subtests: boolean;
 };
 
+export type CommitToHash = {
+  revision: string;
+}
+
 export type InputType = 'base' | 'new';
 
 export type ThemeMode = 'light' | 'dark';


### PR DESCRIPTION
As we are moving away from hg to git ./mach try perf we will no longer be able to get the try url and will be unable to generate perfcompare links. This patch along with the 2 others on treeherder and mozilla central add a hash to the commit message and allows us to get a perfcompare url that finds the commits via that hash This patch is still a work in progress as to properly test I will need the treeherder one to merge first to test properly as currently I am blocked with cross origin requests being not being allowed