### PR TITLE
Fix font UI bugs 

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -236,7 +236,7 @@ exports[`Results View The table should match snapshot and other elements should 
           class="f6hg2jo"
         >
           <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-iendvr-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-1y7fc34-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"
           >
@@ -260,7 +260,7 @@ exports[`Results View The table should match snapshot and other elements should 
         <button
           aria-haspopup="true"
           aria-label="Platform (Click to filter values)"
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-12sme9p-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-9vteyo-MuiButtonBase-root-MuiButton-root"
           data-mui-internal-clone-element="true"
           tabindex="0"
           type="button"
@@ -325,7 +325,7 @@ exports[`Results View The table should match snapshot and other elements should 
         <button
           aria-haspopup="true"
           aria-label="Status (Click to filter values)"
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-12sme9p-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-9vteyo-MuiButtonBase-root-MuiButton-root"
           data-mui-internal-clone-element="true"
           tabindex="0"
           type="button"
@@ -366,7 +366,7 @@ exports[`Results View The table should match snapshot and other elements should 
         >
           <button
             aria-label="Delta (Click to sort by this column)"
-            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-lq49bj-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-cdzw26-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"
           >
@@ -401,7 +401,7 @@ exports[`Results View The table should match snapshot and other elements should 
         >
           <button
             aria-label="Confidence (Click to sort by this column)"
-            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton css-1r5r0xg-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton css-dtssjq-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"
           >
@@ -426,7 +426,7 @@ exports[`Results View The table should match snapshot and other elements should 
           <button
             aria-haspopup="true"
             aria-label="Confidence (Click to filter values)"
-            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-12sme9p-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-9vteyo-MuiButtonBase-root-MuiButton-root"
             data-mui-internal-clone-element="true"
             tabindex="0"
             type="button"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Results Table Should match snapshot 1`] = `
         class="MuiGrid-root header-container container_f1ocj467 css-plh9qo-MuiGrid-root"
       >
         <div
-          class="toggle-dark-mode fgk3bh6 MuiBox-root css-0"
+          class="toggle-dark-mode f1y1dem6 MuiBox-root css-0"
         >
           <div
             class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -44,7 +44,7 @@ exports[`Results Table Should match snapshot 1`] = `
                 />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-5pr40k-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1k2yhz0-MuiTypography-root"
               >
                 Dark mode
               </span>
@@ -62,7 +62,7 @@ exports[`Results Table Should match snapshot 1`] = `
         </div>
       </div>
       <section
-        class="container_fdgf30v"
+        class="container_f1h7ern2"
       >
         <a
           aria-label="link to home"
@@ -132,7 +132,7 @@ exports[`Results Table Should match snapshot 1`] = `
                 class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -159,7 +159,7 @@ exports[`Results Table Should match snapshot 1`] = `
                   id="base-search-container"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
                     id="base_search-dropdown"
                   >
                     <div
@@ -200,14 +200,14 @@ exports[`Results Table Should match snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f7qwsv0 big  css-17gmabg-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
                     id="base_search-input"
                   >
                     <div
                       class="MuiBox-root css-0"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+                        class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
                       >
                         <div
                           class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -264,7 +264,7 @@ exports[`Results Table Should match snapshot 1`] = `
                   data-testid="base-selected-revision"
                 >
                   <div
-                    class="box_f1wdk99e base-box MuiBox-root css-0"
+                    class="box_f9k3p52 base-box MuiBox-root css-0"
                   >
                     <ul
                       class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -291,16 +291,16 @@ exports[`Results Table Should match snapshot 1`] = `
                           </div>
                         </div>
                         <div
-                          class="selectedRevision_f1h5nweo MuiBox-root css-0"
+                          class="selectedRevision_fubtarc MuiBox-root css-0"
                         >
                           <div
                             class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
                           >
                             <span
-                              class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                              class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                             >
                               <span
-                                class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                                class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                               >
                                 <a
                                   class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
@@ -337,13 +337,12 @@ exports[`Results Table Should match snapshot 1`] = `
                                   </button>
                                 </span>
                               </span>
-                              <div
-                                class="info-caption"
+                              <span
+                                class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                               >
-                                <div
+                                <span
                                   class="info-caption-item item-author"
                                 >
-                                   
                                   <svg
                                     aria-hidden="true"
                                     class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
@@ -355,11 +354,15 @@ exports[`Results Table Should match snapshot 1`] = `
                                       d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                                     />
                                   </svg>
-                                   
-                                  johncleese@python.com
-                                </div>
-                                <div
+                                  <span
+                                    style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                                  >
+                                    johncleese@python.com
+                                  </span>
+                                </span>
+                                <span
                                   class="info-caption-item item-time"
+                                  style="display: flex; align-items: center; margin-left: 8px;"
                                 >
                                   <svg
                                     aria-hidden="true"
@@ -379,11 +382,11 @@ exports[`Results Table Should match snapshot 1`] = `
                                   >
                                     Mar 29, 51, 00:00 UTC
                                   </div>
-                                </div>
-                              </div>
+                                </span>
+                              </span>
                             </span>
                             <span
-                              class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                              class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                             >
                               you've got no arms left! 
                             </span>
@@ -420,7 +423,7 @@ exports[`Results Table Should match snapshot 1`] = `
                 class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -447,7 +450,7 @@ exports[`Results Table Should match snapshot 1`] = `
                   id="new-search-container"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
                     id="new_search-dropdown"
                   >
                     <div
@@ -488,14 +491,14 @@ exports[`Results Table Should match snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f7qwsv0 big  css-17gmabg-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
                     id="new_search-input"
                   >
                     <div
                       class="MuiBox-root css-0"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+                        class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
                       >
                         <div
                           class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -552,7 +555,7 @@ exports[`Results Table Should match snapshot 1`] = `
                   data-testid="new-selected-revision"
                 >
                   <div
-                    class="box_f1wdk99e new-box MuiBox-root css-0"
+                    class="box_f9k3p52 new-box MuiBox-root css-0"
                   >
                     <ul
                       class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -579,16 +582,16 @@ exports[`Results Table Should match snapshot 1`] = `
                           </div>
                         </div>
                         <div
-                          class="selectedRevision_f1h5nweo MuiBox-root css-0"
+                          class="selectedRevision_fubtarc MuiBox-root css-0"
                         >
                           <div
                             class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
                           >
                             <span
-                              class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                              class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                             >
                               <span
-                                class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                                class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                               >
                                 <a
                                   class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
@@ -625,13 +628,12 @@ exports[`Results Table Should match snapshot 1`] = `
                                   </button>
                                 </span>
                               </span>
-                              <div
-                                class="info-caption"
+                              <span
+                                class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                               >
-                                <div
+                                <span
                                   class="info-caption-item item-author"
                                 >
-                                   
                                   <svg
                                     aria-hidden="true"
                                     class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
@@ -643,11 +645,15 @@ exports[`Results Table Should match snapshot 1`] = `
                                       d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                                     />
                                   </svg>
-                                   
-                                  johncleese@python.com
-                                </div>
-                                <div
+                                  <span
+                                    style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                                  >
+                                    johncleese@python.com
+                                  </span>
+                                </span>
+                                <span
                                   class="info-caption-item item-time"
+                                  style="display: flex; align-items: center; margin-left: 8px;"
                                 >
                                   <svg
                                     aria-hidden="true"
@@ -667,11 +673,11 @@ exports[`Results Table Should match snapshot 1`] = `
                                   >
                                     Mar 29, 51, 00:00 UTC
                                   </div>
-                                </div>
-                              </div>
+                                </span>
+                              </span>
                             </span>
                             <span
-                              class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                              class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                             >
                               you've got no arms left! 
                             </span>

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -200,7 +200,7 @@ exports[`Results Table Should match snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
                     id="base_search-input"
                   >
                     <div
@@ -284,7 +284,7 @@ exports[`Results Table Should match snapshot 1`] = `
                           value="try"
                         />
                         <div
-                          class="repo_fkd3ycy"
+                          class="repo_f1akv6s4"
                         >
                           <div>
                             try
@@ -337,10 +337,10 @@ exports[`Results Table Should match snapshot 1`] = `
                                   </button>
                                 </span>
                               </span>
-                              <span
+                              <div
                                 class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                               >
-                                <span
+                                <div
                                   class="info-caption-item item-author"
                                 >
                                   <svg
@@ -354,15 +354,14 @@ exports[`Results Table Should match snapshot 1`] = `
                                       d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                                     />
                                   </svg>
-                                  <span
-                                    style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                                  <div
+                                    class="MuiBox-root css-1obfhg7"
                                   >
                                     johncleese@python.com
-                                  </span>
-                                </span>
-                                <span
-                                  class="info-caption-item item-time"
-                                  style="display: flex; align-items: center; margin-left: 8px;"
+                                  </div>
+                                </div>
+                                <div
+                                  class="info-caption-item item-time MuiBox-root css-9mul5i"
                                 >
                                   <svg
                                     aria-hidden="true"
@@ -382,8 +381,8 @@ exports[`Results Table Should match snapshot 1`] = `
                                   >
                                     Mar 29, 51, 00:00 UTC
                                   </div>
-                                </span>
-                              </span>
+                                </div>
+                              </div>
                             </span>
                             <span
                               class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
@@ -491,7 +490,7 @@ exports[`Results Table Should match snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
                     id="new_search-input"
                   >
                     <div
@@ -575,7 +574,7 @@ exports[`Results Table Should match snapshot 1`] = `
                           value="try"
                         />
                         <div
-                          class="repo_fkd3ycy"
+                          class="repo_f1akv6s4"
                         >
                           <div>
                             try
@@ -628,10 +627,10 @@ exports[`Results Table Should match snapshot 1`] = `
                                   </button>
                                 </span>
                               </span>
-                              <span
+                              <div
                                 class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                               >
-                                <span
+                                <div
                                   class="info-caption-item item-author"
                                 >
                                   <svg
@@ -645,15 +644,14 @@ exports[`Results Table Should match snapshot 1`] = `
                                       d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                                     />
                                   </svg>
-                                  <span
-                                    style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                                  <div
+                                    class="MuiBox-root css-1obfhg7"
                                   >
                                     johncleese@python.com
-                                  </span>
-                                </span>
-                                <span
-                                  class="info-caption-item item-time"
-                                  style="display: flex; align-items: center; margin-left: 8px;"
+                                  </div>
+                                </div>
+                                <div
+                                  class="info-caption-item item-time MuiBox-root css-9mul5i"
                                 >
                                   <svg
                                     aria-hidden="true"
@@ -673,8 +671,8 @@ exports[`Results Table Should match snapshot 1`] = `
                                   >
                                     Mar 29, 51, 00:00 UTC
                                   </div>
-                                </span>
-                              </span>
+                                </div>
+                              </div>
                             </span>
                             <span
                               class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`Results Table Should match snapshot 1`] = `
               >
                 <button
                   aria-label="edit revision"
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation global-edit-button edit-revision-button css-1rvsmwy-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation global-edit-button edit-revision-button css-nrxrys-MuiButtonBase-root-MuiButton-root"
                   name="edit-button"
                   tabindex="0"
                   type="button"
@@ -200,7 +200,7 @@ exports[`Results Table Should match snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
                     id="base_search-input"
                   >
                     <div
@@ -491,7 +491,7 @@ exports[`Results Table Should match snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
                     id="new_search-input"
                   >
                     <div
@@ -739,7 +739,7 @@ exports[`Results Table Should match snapshot 1`] = `
                   Results
                 </h2>
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation css-757951-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation css-17e12lq-MuiButtonBase-root-MuiButton-root"
                   tabindex="0"
                   type="button"
                 >
@@ -1036,7 +1036,7 @@ exports[`Results Table Should match snapshot 1`] = `
                       class="f6hg2jo"
                     >
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-iendvr-MuiButtonBase-root-MuiButton-root"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-1y7fc34-MuiButtonBase-root-MuiButton-root"
                         tabindex="0"
                         type="button"
                       >
@@ -1060,7 +1060,7 @@ exports[`Results Table Should match snapshot 1`] = `
                     <button
                       aria-haspopup="true"
                       aria-label="Platform (Click to filter values)"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-12sme9p-MuiButtonBase-root-MuiButton-root"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-9vteyo-MuiButtonBase-root-MuiButton-root"
                       data-mui-internal-clone-element="true"
                       tabindex="0"
                       type="button"
@@ -1125,7 +1125,7 @@ exports[`Results Table Should match snapshot 1`] = `
                     <button
                       aria-haspopup="true"
                       aria-label="Status (Click to filter values)"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-12sme9p-MuiButtonBase-root-MuiButton-root"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-9vteyo-MuiButtonBase-root-MuiButton-root"
                       data-mui-internal-clone-element="true"
                       tabindex="0"
                       type="button"
@@ -1166,7 +1166,7 @@ exports[`Results Table Should match snapshot 1`] = `
                     >
                       <button
                         aria-label="Delta (Click to sort by this column)"
-                        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-lq49bj-MuiButtonBase-root-MuiButton-root"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-cdzw26-MuiButtonBase-root-MuiButton-root"
                         tabindex="0"
                         type="button"
                       >
@@ -1201,7 +1201,7 @@ exports[`Results Table Should match snapshot 1`] = `
                     >
                       <button
                         aria-label="Confidence (Click to sort by this column)"
-                        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton css-1r5r0xg-MuiButtonBase-root-MuiButton-root"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton css-dtssjq-MuiButtonBase-root-MuiButton-root"
                         tabindex="0"
                         type="button"
                       >
@@ -1226,7 +1226,7 @@ exports[`Results Table Should match snapshot 1`] = `
                       <button
                         aria-haspopup="true"
                         aria-label="Confidence (Click to filter values)"
-                        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-12sme9p-MuiButtonBase-root-MuiButton-root"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-9vteyo-MuiButtonBase-root-MuiButton-root"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
@@ -2348,7 +2348,7 @@ exports[`Results Table Should match snapshot 1`] = `
 exports[`Results Table can load the sort parameters from the URL for a descending sort 1`] = `
 <button
   aria-label="Delta (Currently sorted by this column. Click to change)"
-  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-lq49bj-MuiButtonBase-root-MuiButton-root"
+  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-cdzw26-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
 >
@@ -2376,7 +2376,7 @@ exports[`Results Table can load the sort parameters from the URL for a descendin
 exports[`Results Table can load the sort parameters from the URL for an ascending sort 1`] = `
 <button
   aria-label="Delta (Currently sorted by this column. Click to change)"
-  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-lq49bj-MuiButtonBase-root-MuiButton-root"
+  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-cdzw26-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
 >
@@ -2404,7 +2404,7 @@ exports[`Results Table can load the sort parameters from the URL for an ascendin
 exports[`Results Table can sort the table and persist the sort parameters to the URL 1`] = `
 <button
   aria-label="Delta (Click to sort by this column)"
-  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-lq49bj-MuiButtonBase-root-MuiButton-root"
+  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-cdzw26-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
 >
@@ -2432,7 +2432,7 @@ exports[`Results Table can sort the table and persist the sort parameters to the
 exports[`Results Table can sort the table and persist the sort parameters to the URL 2`] = `
 <button
   aria-label="Delta (Currently sorted by this column. Click to change)"
-  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-lq49bj-MuiButtonBase-root-MuiButton-root"
+  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-cdzw26-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
 >
@@ -2469,7 +2469,7 @@ exports[`Results Table can sort the table and persist the sort parameters to the
 exports[`Results Table can sort the table and persist the sort parameters to the URL 3`] = `
 <button
   aria-label="Delta (Currently sorted by this column. Click to change)"
-  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-lq49bj-MuiButtonBase-root-MuiButton-root"
+  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-cdzw26-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
 >
@@ -2514,7 +2514,7 @@ exports[`Results Table can sort the table and persist the sort parameters to the
 exports[`Results Table can sort the table and persist the sort parameters to the URL 4`] = `
 <button
   aria-label="Delta (Click to sort by this column)"
-  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-lq49bj-MuiButtonBase-root-MuiButton-root"
+  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-cdzw26-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
 >
@@ -2559,7 +2559,7 @@ exports[`Results Table can sort the table and persist the sort parameters to the
 exports[`Results Table can sort the table and persist the sort parameters to the URL 5`] = `
 <button
   aria-label="Confidence (Currently sorted by this column. Click to change)"
-  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton css-1r5r0xg-MuiButtonBase-root-MuiButton-root"
+  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton css-dtssjq-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
 >

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -71,7 +71,7 @@ exports[`Results View Should display Base, New and Common graphs with 1 value an
               602.04
             </div>
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-1j7c0nu-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-121m766-MuiButtonBase-root-MuiButton-root"
               tabindex="0"
               type="button"
             >
@@ -156,7 +156,7 @@ exports[`Results View Should display Base, New and Common graphs with 1 value an
               607.27
             </div>
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-1j7c0nu-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-121m766-MuiButtonBase-root-MuiButton-root"
               tabindex="0"
               type="button"
             >
@@ -363,7 +363,7 @@ exports[`Results View Should display Base, New and Common graphs with replicates
               602.04
             </div>
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-1j7c0nu-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-121m766-MuiButtonBase-root-MuiButton-root"
               tabindex="0"
               type="button"
             >
@@ -448,7 +448,7 @@ exports[`Results View Should display Base, New and Common graphs with replicates
               607.27
             </div>
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-1j7c0nu-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-121m766-MuiButtonBase-root-MuiButton-root"
               tabindex="0"
               type="button"
             >
@@ -655,7 +655,7 @@ exports[`Results View Should display Base, New and Common graphs with tooltips 1
               602.04
             </div>
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-1j7c0nu-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-121m766-MuiButtonBase-root-MuiButton-root"
               tabindex="0"
               type="button"
             >
@@ -740,7 +740,7 @@ exports[`Results View Should display Base, New and Common graphs with tooltips 1
               607.27
             </div>
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-1j7c0nu-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-disableElevation css-121m766-MuiButtonBase-root-MuiButton-root"
               tabindex="0"
               type="button"
             >
@@ -919,7 +919,7 @@ exports[`Results View Should update url with new title and the table with the ne
       class="edit-title-btns MuiBox-root css-58oy1n"
     >
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation css-1rvsmwy-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation css-nrxrys-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         type="button"
       >
@@ -929,7 +929,7 @@ exports[`Results View Should update url with new title and the table with the ne
         />
       </button>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation css-1rvsmwy-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation css-nrxrys-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         type="submit"
       >
@@ -1188,7 +1188,7 @@ exports[`Results View The table should match snapshot and other elements should 
           class="f6hg2jo"
         >
           <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-iendvr-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-1y7fc34-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"
           >
@@ -1212,7 +1212,7 @@ exports[`Results View The table should match snapshot and other elements should 
         <button
           aria-haspopup="true"
           aria-label="Platform (Click to filter values)"
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-12sme9p-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-9vteyo-MuiButtonBase-root-MuiButton-root"
           data-mui-internal-clone-element="true"
           tabindex="0"
           type="button"
@@ -1277,7 +1277,7 @@ exports[`Results View The table should match snapshot and other elements should 
         <button
           aria-haspopup="true"
           aria-label="Status (Click to filter values)"
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-12sme9p-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-9vteyo-MuiButtonBase-root-MuiButton-root"
           data-mui-internal-clone-element="true"
           tabindex="0"
           type="button"
@@ -1318,7 +1318,7 @@ exports[`Results View The table should match snapshot and other elements should 
         >
           <button
             aria-label="Delta (Click to sort by this column)"
-            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-lq49bj-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-cdzw26-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"
           >
@@ -1353,7 +1353,7 @@ exports[`Results View The table should match snapshot and other elements should 
         >
           <button
             aria-label="Confidence (Click to sort by this column)"
-            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton css-1r5r0xg-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton css-dtssjq-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"
           >
@@ -1378,7 +1378,7 @@ exports[`Results View The table should match snapshot and other elements should 
           <button
             aria-haspopup="true"
             aria-label="Confidence (Click to filter values)"
-            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-12sme9p-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-9vteyo-MuiButtonBase-root-MuiButton-root"
             data-mui-internal-clone-element="true"
             tabindex="0"
             type="button"

--- a/src/__tests__/CompareResults/__snapshots__/Retrigger.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/Retrigger.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`Retrigger should retrigger one job for base revision and one job for ne
     class="SnackbarItem-action"
   >
     <a
-      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-cm1dua-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-aa1ild-MuiButtonBase-root-MuiButton-root"
       href="https://treeherder.mozilla.org/jobs?repo=mozilla-central&revision=coconut"
       rel="noreferrer"
       tabindex="0"
@@ -95,7 +95,7 @@ exports[`Retrigger should retrigger one job for base revision and one job for ne
     class="SnackbarItem-action"
   >
     <a
-      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-cm1dua-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-aa1ild-MuiButtonBase-root-MuiButton-root"
       href="https://treeherder.mozilla.org/jobs?repo=mozilla-central&revision=spam"
       rel="noreferrer"
       tabindex="0"

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -359,7 +359,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                     class="f6hg2jo"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-iendvr-MuiButtonBase-root-MuiButton-root"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-1y7fc34-MuiButtonBase-root-MuiButton-root"
                       tabindex="0"
                       type="button"
                     >
@@ -374,7 +374,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-auto css-t2kpsv-MuiGrid-root"
                 >
                   <button
-                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation css-1rvsmwy-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation css-nrxrys-MuiButtonBase-root-MuiButton-root"
                     tabindex="0"
                     title="retrigger jobs"
                     type="button"
@@ -418,7 +418,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 >
                   <button
                     aria-label="Subtests (Click to sort by this column)"
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-lq49bj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-cdzw26-MuiButtonBase-root-MuiButton-root"
                     tabindex="0"
                     type="button"
                   >
@@ -477,7 +477,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   <button
                     aria-haspopup="true"
                     aria-label="Status (Click to filter values)"
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-12sme9p-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-9vteyo-MuiButtonBase-root-MuiButton-root"
                     data-mui-internal-clone-element="true"
                     tabindex="0"
                     type="button"
@@ -518,7 +518,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   >
                     <button
                       aria-label="Delta (Click to sort by this column)"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-lq49bj-MuiButtonBase-root-MuiButton-root"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-cdzw26-MuiButtonBase-root-MuiButton-root"
                       tabindex="0"
                       type="button"
                     >
@@ -553,7 +553,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   >
                     <button
                       aria-label="Confidence (Click to sort by this column)"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton css-1r5r0xg-MuiButtonBase-root-MuiButton-root"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton css-dtssjq-MuiButtonBase-root-MuiButton-root"
                       tabindex="0"
                       type="button"
                     >
@@ -578,7 +578,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                     <button
                       aria-haspopup="true"
                       aria-label="Confidence (Click to filter values)"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-12sme9p-MuiButtonBase-root-MuiButton-root"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-9vteyo-MuiButtonBase-root-MuiButton-root"
                       data-mui-internal-clone-element="true"
                       tabindex="0"
                       type="button"
@@ -1479,7 +1479,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
 exports[`SubtestsResultsView Component Tests table sorting can sort the table and persist the information to the URL 1`] = `
 <button
   aria-label="Delta (Click to sort by this column)"
-  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-lq49bj-MuiButtonBase-root-MuiButton-root"
+  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-cdzw26-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
 >
@@ -1507,7 +1507,7 @@ exports[`SubtestsResultsView Component Tests table sorting can sort the table an
 exports[`SubtestsResultsView Component Tests table sorting can sort the table and persist the information to the URL 2`] = `
 <button
   aria-label="Delta (Currently sorted by this column. Click to change)"
-  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-lq49bj-MuiButtonBase-root-MuiButton-root"
+  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-cdzw26-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
 >
@@ -1544,7 +1544,7 @@ exports[`SubtestsResultsView Component Tests table sorting can sort the table an
 exports[`SubtestsResultsView Component Tests table sorting can sort the table and persist the information to the URL 3`] = `
 <button
   aria-label="Delta (Currently sorted by this column. Click to change)"
-  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-lq49bj-MuiButtonBase-root-MuiButton-root"
+  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-cdzw26-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
 >
@@ -1589,7 +1589,7 @@ exports[`SubtestsResultsView Component Tests table sorting can sort the table an
 exports[`SubtestsResultsView Component Tests table sorting can sort the table and persist the information to the URL 4`] = `
 <button
   aria-label="Delta (Click to sort by this column)"
-  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-lq49bj-MuiButtonBase-root-MuiButton-root"
+  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-cdzw26-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
 >
@@ -1634,7 +1634,7 @@ exports[`SubtestsResultsView Component Tests table sorting can sort the table an
 exports[`SubtestsResultsView Component Tests table sorting can sort the table and persist the information to the URL 5`] = `
 <button
   aria-label="Confidence (Currently sorted by this column. Click to change)"
-  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton css-1r5r0xg-MuiButtonBase-root-MuiButton-root"
+  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton css-dtssjq-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
 >
@@ -1670,7 +1670,7 @@ exports[`SubtestsResultsView Component Tests table sorting can sort the table an
 exports[`SubtestsResultsView Component Tests table sorting can sort the table and persist the information to the URL 6`] = `
 <button
   aria-label="Confidence (Click to sort by this column)"
-  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton css-1r5r0xg-MuiButtonBase-root-MuiButton-root"
+  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton css-dtssjq-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
 >
@@ -1706,7 +1706,7 @@ exports[`SubtestsResultsView Component Tests table sorting can sort the table an
 exports[`SubtestsResultsView Component Tests table sorting can sort the table and persist the information to the URL 7`] = `
 <button
   aria-label="Subtests (Currently sorted by this column. Click to change)"
-  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-lq49bj-MuiButtonBase-root-MuiButton-root"
+  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-cdzw26-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
 >
@@ -1743,7 +1743,7 @@ exports[`SubtestsResultsView Component Tests table sorting can sort the table an
 exports[`SubtestsResultsView Component Tests table sorting initializes the sort from the URL at load time for a descending sort 1`] = `
 <button
   aria-label="Delta (Currently sorted by this column. Click to change)"
-  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-lq49bj-MuiButtonBase-root-MuiButton-root"
+  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-cdzw26-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
 >
@@ -1771,7 +1771,7 @@ exports[`SubtestsResultsView Component Tests table sorting initializes the sort 
 exports[`SubtestsResultsView Component Tests table sorting initializes the sort from the URL at load time for an ascending sort 1`] = `
 <button
   aria-label="Delta (Currently sorted by this column. Click to change)"
-  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-lq49bj-MuiButtonBase-root-MuiButton-root"
+  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-cdzw26-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
 >
@@ -1799,7 +1799,7 @@ exports[`SubtestsResultsView Component Tests table sorting initializes the sort 
 exports[`SubtestsResultsView Component Tests table sorting initializes the sort from the URL at load time for an implicit descending sort 1`] = `
 <button
   aria-label="Delta (Currently sorted by this column. Click to change)"
-  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-lq49bj-MuiButtonBase-root-MuiButton-root"
+  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-cdzw26-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
 >
@@ -2176,7 +2176,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                     class="f6hg2jo"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-iendvr-MuiButtonBase-root-MuiButton-root"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-1y7fc34-MuiButtonBase-root-MuiButton-root"
                       tabindex="0"
                       type="button"
                     >
@@ -2191,7 +2191,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-auto css-t2kpsv-MuiGrid-root"
                 >
                   <button
-                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation css-1rvsmwy-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation css-nrxrys-MuiButtonBase-root-MuiButton-root"
                     tabindex="0"
                     title="retrigger jobs"
                     type="button"
@@ -2235,7 +2235,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 >
                   <button
                     aria-label="Subtests (Click to sort by this column)"
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-lq49bj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-cdzw26-MuiButtonBase-root-MuiButton-root"
                     tabindex="0"
                     type="button"
                   >
@@ -2294,7 +2294,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   <button
                     aria-haspopup="true"
                     aria-label="Status (Click to filter values)"
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-12sme9p-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-9vteyo-MuiButtonBase-root-MuiButton-root"
                     data-mui-internal-clone-element="true"
                     tabindex="0"
                     type="button"
@@ -2335,7 +2335,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   >
                     <button
                       aria-label="Delta (Click to sort by this column)"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-lq49bj-MuiButtonBase-root-MuiButton-root"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-cdzw26-MuiButtonBase-root-MuiButton-root"
                       tabindex="0"
                       type="button"
                     >
@@ -2370,7 +2370,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   >
                     <button
                       aria-label="Confidence (Click to sort by this column)"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton css-1r5r0xg-MuiButtonBase-root-MuiButton-root"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton css-dtssjq-MuiButtonBase-root-MuiButton-root"
                       tabindex="0"
                       type="button"
                     >
@@ -2395,7 +2395,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                     <button
                       aria-haspopup="true"
                       aria-label="Confidence (Click to filter values)"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-12sme9p-MuiButtonBase-root-MuiButton-root"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-disableElevation css-9vteyo-MuiButtonBase-root-MuiButton-root"
                       data-mui-internal-clone-element="true"
                       tabindex="0"
                       type="button"

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
         class="MuiGrid-root header-container container_f1ocj467 css-plh9qo-MuiGrid-root"
       >
         <div
-          class="toggle-dark-mode fgk3bh6 MuiBox-root css-0"
+          class="toggle-dark-mode f1y1dem6 MuiBox-root css-0"
         >
           <div
             class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -44,7 +44,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-5pr40k-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1k2yhz0-MuiTypography-root"
               >
                 Dark mode
               </span>
@@ -73,7 +73,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
           >
             <header>
               <nav
-                class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-1rypov2-MuiTypography-root-MuiBreadcrumbs-root"
+                class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-1jqzy3r-MuiTypography-root-MuiBreadcrumbs-root"
               >
                 <ol
                   class="MuiBreadcrumbs-ol css-4pdmu4-MuiBreadcrumbs-ol"
@@ -1836,7 +1836,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
         class="MuiGrid-root header-container container_f1ocj467 css-plh9qo-MuiGrid-root"
       >
         <div
-          class="toggle-dark-mode fgk3bh6 MuiBox-root css-0"
+          class="toggle-dark-mode f1y1dem6 MuiBox-root css-0"
         >
           <div
             class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -1869,7 +1869,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-5pr40k-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1k2yhz0-MuiTypography-root"
               >
                 Dark mode
               </span>
@@ -1898,7 +1898,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
           >
             <header>
               <nav
-                class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-1rypov2-MuiTypography-root-MuiBreadcrumbs-root"
+                class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-1jqzy3r-MuiTypography-root-MuiBreadcrumbs-root"
               >
                 <ol
                   class="MuiBreadcrumbs-ol css-4pdmu4-MuiBreadcrumbs-ol"

--- a/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1sh1skx css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_frp1utb css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -108,7 +108,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1sh1skx   css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_frp1utb   css-1t7ybvx-MuiGrid-root"
         id="time-range"
         style="max-width: 365px;"
       >
@@ -162,7 +162,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -190,7 +190,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx  -new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb  -new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -231,14 +231,14 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f7qwsv0   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
         id="new_search-input--time"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -294,7 +294,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_f1wdk99e new-box MuiBox-root css-0"
+        class="box_f9k3p52 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -303,7 +303,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1sh1skx css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_frp1utb css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -423,7 +423,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1sh1skx css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_frp1utb css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -477,11 +477,11 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
       id="time-search-container--readonly"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_f1sh1skx  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_frp1utb  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
         style="max-width: 415px;"
       >
         <span
-          class="MuiTypography-root MuiTypography-body2 css-19qsqbp-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body2 css-163bcq3-MuiTypography-root"
         >
           try
         </span>
@@ -494,7 +494,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
           style="display: flex; justify-content: space-between;"
         >
           <span
-            class="MuiTypography-root MuiTypography-body2 css-19qsqbp-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body2 css-163bcq3-MuiTypography-root"
           >
             Last day
           </span>
@@ -507,7 +507,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -533,7 +533,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_f1wdk99e new-box MuiBox-root css-0"
+        class="box_f9k3p52 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -560,16 +560,16 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
               </div>
             </div>
             <div
-              class="selectedRevision_f1h5nweo MuiBox-root css-0"
+              class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                 >
                   <span
-                    class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
@@ -606,13 +606,12 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
                       </button>
                     </span>
                   </span>
-                  <div
-                    class="info-caption"
+                  <span
+                    class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <div
+                    <span
                       class="info-caption-item item-author"
                     >
-                       
                       <svg
                         aria-hidden="true"
                         class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
@@ -624,11 +623,15 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                       
-                      johncleese@python.com
-                    </div>
-                    <div
+                      <span
+                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      >
+                        johncleese@python.com
+                      </span>
+                    </span>
+                    <span
                       class="info-caption-item item-time"
+                      style="display: flex; align-items: center; margin-left: 8px;"
                     >
                       <svg
                         aria-hidden="true"
@@ -648,11 +651,11 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </div>
-                  </div>
+                    </span>
+                  </span>
                 </span>
                 <span
-                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                 >
                   you've got no arms left! 
                 </span>
@@ -916,7 +919,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1sh1skx css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_frp1utb css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -1014,7 +1017,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown small dropDown_f1sh1skx   css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown small dropDown_frp1utb   css-1t7ybvx-MuiGrid-root"
         id="time-range"
         style="max-width: 415px;"
       >
@@ -1068,7 +1071,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1096,7 +1099,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx small compare-over-time-results-new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb small compare-over-time-results-new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -1137,14 +1140,14 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f7qwsv0 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
         id="new_search-input--time"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -1200,7 +1203,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_f1wdk99e new-box MuiBox-root css-0"
+        class="box_f9k3p52 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1227,16 +1230,16 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
               </div>
             </div>
             <div
-              class="selectedRevision_f1h5nweo MuiBox-root css-0"
+              class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                 >
                   <span
-                    class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
@@ -1273,13 +1276,12 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
                       </button>
                     </span>
                   </span>
-                  <div
-                    class="info-caption"
+                  <span
+                    class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <div
+                    <span
                       class="info-caption-item item-author"
                     >
-                       
                       <svg
                         aria-hidden="true"
                         class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
@@ -1291,11 +1293,15 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                       
-                      johncleese@python.com
-                    </div>
-                    <div
+                      <span
+                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      >
+                        johncleese@python.com
+                      </span>
+                    </span>
+                    <span
                       class="info-caption-item item-time"
+                      style="display: flex; align-items: center; margin-left: 8px;"
                     >
                       <svg
                         aria-hidden="true"
@@ -1315,11 +1321,11 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </div>
-                  </div>
+                    </span>
+                  </span>
                 </span>
                 <span
-                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                 >
                   you've got no arms left! 
                 </span>
@@ -1353,7 +1359,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1sh1skx css-13jteey-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_frp1utb css-13jteey-MuiGrid-root"
   >
     <div
       class="fs9pw6x cancel-compare"
@@ -1426,7 +1432,7 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1sh1skx css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_frp1utb css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -1480,11 +1486,11 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
       id="time-search-container--readonly"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_f1sh1skx  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_frp1utb  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
         style="max-width: 415px;"
       >
         <span
-          class="MuiTypography-root MuiTypography-body2 css-19qsqbp-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body2 css-163bcq3-MuiTypography-root"
         >
           try
         </span>
@@ -1497,7 +1503,7 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
           style="display: flex; justify-content: space-between;"
         >
           <span
-            class="MuiTypography-root MuiTypography-body2 css-19qsqbp-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body2 css-163bcq3-MuiTypography-root"
           >
             Last day
           </span>
@@ -1510,7 +1516,7 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1536,7 +1542,7 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_f1wdk99e new-box MuiBox-root css-0"
+        class="box_f9k3p52 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1563,16 +1569,16 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
               </div>
             </div>
             <div
-              class="selectedRevision_f1h5nweo MuiBox-root css-0"
+              class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                 >
                   <span
-                    class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
@@ -1609,13 +1615,12 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
                       </button>
                     </span>
                   </span>
-                  <div
-                    class="info-caption"
+                  <span
+                    class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <div
+                    <span
                       class="info-caption-item item-author"
                     >
-                       
                       <svg
                         aria-hidden="true"
                         class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
@@ -1627,11 +1632,15 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                       
-                      johncleese@python.com
-                    </div>
-                    <div
+                      <span
+                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      >
+                        johncleese@python.com
+                      </span>
+                    </span>
+                    <span
                       class="info-caption-item item-time"
+                      style="display: flex; align-items: center; margin-left: 8px;"
                     >
                       <svg
                         aria-hidden="true"
@@ -1651,11 +1660,11 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </div>
-                  </div>
+                    </span>
+                  </span>
                 </span>
                 <span
-                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                 >
                   you've got no arms left! 
                 </span>
@@ -1706,7 +1715,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1sh1skx css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_frp1utb css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -1804,7 +1813,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1sh1skx   css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_frp1utb   css-1t7ybvx-MuiGrid-root"
         id="time-range"
         style="max-width: 365px;"
       >
@@ -1858,7 +1867,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1886,7 +1895,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx  -new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb  -new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -1927,14 +1936,14 @@ exports[`Compare Over Time should remove the checked revision once X button is c
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f7qwsv0   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
         id="new_search-input--time"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -1990,7 +1999,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_f1wdk99e new-box MuiBox-root css-0"
+        class="box_f9k3p52 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1999,7 +2008,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1sh1skx css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_frp1utb css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -2128,7 +2137,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1sh1skx css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_frp1utb css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -2182,11 +2191,11 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       id="time-search-container--readonly"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_f1sh1skx  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_frp1utb  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
         style="max-width: 415px;"
       >
         <span
-          class="MuiTypography-root MuiTypography-body2 css-19qsqbp-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body2 css-163bcq3-MuiTypography-root"
         >
           autoland
         </span>
@@ -2199,7 +2208,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
           style="display: flex; justify-content: space-between;"
         >
           <span
-            class="MuiTypography-root MuiTypography-body2 css-19qsqbp-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body2 css-163bcq3-MuiTypography-root"
           >
             Last 2 days
           </span>
@@ -2212,7 +2221,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -2238,7 +2247,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_f1wdk99e new-box MuiBox-root css-0"
+        class="box_f9k3p52 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2265,16 +2274,16 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
               </div>
             </div>
             <div
-              class="selectedRevision_f1h5nweo MuiBox-root css-0"
+              class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                 >
                   <span
-                    class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
@@ -2311,13 +2320,12 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                       </button>
                     </span>
                   </span>
-                  <div
-                    class="info-caption"
+                  <span
+                    class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <div
+                    <span
                       class="info-caption-item item-author"
                     >
-                       
                       <svg
                         aria-hidden="true"
                         class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
@@ -2329,11 +2337,15 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                       
-                      johncleese@python.com
-                    </div>
-                    <div
+                      <span
+                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      >
+                        johncleese@python.com
+                      </span>
+                    </span>
+                    <span
                       class="info-caption-item item-time"
+                      style="display: flex; align-items: center; margin-left: 8px;"
                     >
                       <svg
                         aria-hidden="true"
@@ -2353,11 +2365,11 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </div>
-                  </div>
+                    </span>
+                  </span>
                 </span>
                 <span
-                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                 >
                   you've got no arms left! 
                 </span>
@@ -2408,16 +2420,16 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
               </div>
             </div>
             <div
-              class="selectedRevision_f1h5nweo MuiBox-root css-0"
+              class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                 >
                   <span
-                    class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
@@ -2454,13 +2466,12 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                       </button>
                     </span>
                   </span>
-                  <div
-                    class="info-caption"
+                  <span
+                    class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <div
+                    <span
                       class="info-caption-item item-author"
                     >
-                       
                       <svg
                         aria-hidden="true"
                         class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
@@ -2472,11 +2483,15 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                       
-                      michaelpalin@python.com
-                    </div>
-                    <div
+                      <span
+                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      >
+                        michaelpalin@python.com
+                      </span>
+                    </span>
+                    <span
                       class="info-caption-item item-time"
+                      style="display: flex; align-items: center; margin-left: 8px;"
                     >
                       <svg
                         aria-hidden="true"
@@ -2496,11 +2511,11 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                       >
                         Jul 4, 20, 00:00 UTC
                       </div>
-                    </div>
-                  </div>
+                    </span>
+                  </span>
                 </span>
                 <span
-                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                 >
                   You've got two empty 'alves of coconuts and you're bangin' 'em togetha 
                 </span>
@@ -2586,7 +2601,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1sh1skx css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_frp1utb css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -2684,7 +2699,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown small dropDown_f1sh1skx   css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown small dropDown_frp1utb   css-1t7ybvx-MuiGrid-root"
         id="time-range"
         style="max-width: 415px;"
       >
@@ -2738,7 +2753,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -2766,7 +2781,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx small compare-over-time-results-new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb small compare-over-time-results-new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -2807,14 +2822,14 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f7qwsv0 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
         id="new_search-input--time"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -2870,7 +2885,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_f1wdk99e new-box MuiBox-root css-0"
+        class="box_f9k3p52 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2897,16 +2912,16 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
               </div>
             </div>
             <div
-              class="selectedRevision_f1h5nweo MuiBox-root css-0"
+              class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                 >
                   <span
-                    class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
@@ -2943,13 +2958,12 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                       </button>
                     </span>
                   </span>
-                  <div
-                    class="info-caption"
+                  <span
+                    class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <div
+                    <span
                       class="info-caption-item item-author"
                     >
-                       
                       <svg
                         aria-hidden="true"
                         class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
@@ -2961,11 +2975,15 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                       
-                      johncleese@python.com
-                    </div>
-                    <div
+                      <span
+                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      >
+                        johncleese@python.com
+                      </span>
+                    </span>
+                    <span
                       class="info-caption-item item-time"
+                      style="display: flex; align-items: center; margin-left: 8px;"
                     >
                       <svg
                         aria-hidden="true"
@@ -2985,11 +3003,11 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </div>
-                  </div>
+                    </span>
+                  </span>
                 </span>
                 <span
-                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                 >
                   you've got no arms left! 
                 </span>
@@ -3023,7 +3041,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1sh1skx css-13jteey-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_frp1utb css-13jteey-MuiGrid-root"
   >
     <div
       class="fs9pw6x cancel-compare"
@@ -3096,7 +3114,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1sh1skx css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_frp1utb css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -3150,11 +3168,11 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       id="time-search-container--readonly"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_f1sh1skx  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_frp1utb  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
         style="max-width: 415px;"
       >
         <span
-          class="MuiTypography-root MuiTypography-body2 css-19qsqbp-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body2 css-163bcq3-MuiTypography-root"
         >
           try
         </span>
@@ -3167,7 +3185,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
           style="display: flex; justify-content: space-between;"
         >
           <span
-            class="MuiTypography-root MuiTypography-body2 css-19qsqbp-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body2 css-163bcq3-MuiTypography-root"
           >
             Last day
           </span>
@@ -3180,7 +3198,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -3206,7 +3224,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_f1wdk99e new-box MuiBox-root css-0"
+        class="box_f9k3p52 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -3233,16 +3251,16 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
               </div>
             </div>
             <div
-              class="selectedRevision_f1h5nweo MuiBox-root css-0"
+              class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                 >
                   <span
-                    class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
@@ -3279,13 +3297,12 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                       </button>
                     </span>
                   </span>
-                  <div
-                    class="info-caption"
+                  <span
+                    class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <div
+                    <span
                       class="info-caption-item item-author"
                     >
-                       
                       <svg
                         aria-hidden="true"
                         class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
@@ -3297,11 +3314,15 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                       
-                      johncleese@python.com
-                    </div>
-                    <div
+                      <span
+                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      >
+                        johncleese@python.com
+                      </span>
+                    </span>
+                    <span
                       class="info-caption-item item-time"
+                      style="display: flex; align-items: center; margin-left: 8px;"
                     >
                       <svg
                         aria-hidden="true"
@@ -3321,11 +3342,11 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </div>
-                  </div>
+                    </span>
+                  </span>
                 </span>
                 <span
-                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                 >
                   you've got no arms left! 
                 </span>

--- a/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
@@ -231,7 +231,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="new_search-input--time"
       >
         <div
@@ -553,7 +553,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
               value="try"
             />
             <div
-              class="repo_fkd3ycy"
+              class="repo_f1akv6s4"
             >
               <div>
                 try
@@ -606,10 +606,10 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
                       </button>
                     </span>
                   </span>
-                  <span
+                  <div
                     class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <span
+                    <div
                       class="info-caption-item item-author"
                     >
                       <svg
@@ -623,15 +623,14 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                      <span
-                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      <div
+                        class="MuiBox-root css-1obfhg7"
                       >
                         johncleese@python.com
-                      </span>
-                    </span>
-                    <span
-                      class="info-caption-item item-time"
-                      style="display: flex; align-items: center; margin-left: 8px;"
+                      </div>
+                    </div>
+                    <div
+                      class="info-caption-item item-time MuiBox-root css-9mul5i"
                     >
                       <svg
                         aria-hidden="true"
@@ -651,8 +650,8 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </span>
-                  </span>
+                    </div>
+                  </div>
                 </span>
                 <span
                   class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
@@ -1140,7 +1139,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="new_search-input--time"
       >
         <div
@@ -1223,7 +1222,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
               value="try"
             />
             <div
-              class="repo_fkd3ycy"
+              class="repo_f1akv6s4"
             >
               <div>
                 try
@@ -1276,10 +1275,10 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
                       </button>
                     </span>
                   </span>
-                  <span
+                  <div
                     class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <span
+                    <div
                       class="info-caption-item item-author"
                     >
                       <svg
@@ -1293,15 +1292,14 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                      <span
-                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      <div
+                        class="MuiBox-root css-1obfhg7"
                       >
                         johncleese@python.com
-                      </span>
-                    </span>
-                    <span
-                      class="info-caption-item item-time"
-                      style="display: flex; align-items: center; margin-left: 8px;"
+                      </div>
+                    </div>
+                    <div
+                      class="info-caption-item item-time MuiBox-root css-9mul5i"
                     >
                       <svg
                         aria-hidden="true"
@@ -1321,8 +1319,8 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </span>
-                  </span>
+                    </div>
+                  </div>
                 </span>
                 <span
                   class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
@@ -1562,7 +1560,7 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
               value="try"
             />
             <div
-              class="repo_fkd3ycy"
+              class="repo_f1akv6s4"
             >
               <div>
                 try
@@ -1615,10 +1613,10 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
                       </button>
                     </span>
                   </span>
-                  <span
+                  <div
                     class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <span
+                    <div
                       class="info-caption-item item-author"
                     >
                       <svg
@@ -1632,15 +1630,14 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                      <span
-                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      <div
+                        class="MuiBox-root css-1obfhg7"
                       >
                         johncleese@python.com
-                      </span>
-                    </span>
-                    <span
-                      class="info-caption-item item-time"
-                      style="display: flex; align-items: center; margin-left: 8px;"
+                      </div>
+                    </div>
+                    <div
+                      class="info-caption-item item-time MuiBox-root css-9mul5i"
                     >
                       <svg
                         aria-hidden="true"
@@ -1660,8 +1657,8 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </span>
-                  </span>
+                    </div>
+                  </div>
                 </span>
                 <span
                   class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
@@ -1936,7 +1933,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="new_search-input--time"
       >
         <div
@@ -2267,7 +2264,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
               value="try"
             />
             <div
-              class="repo_fkd3ycy"
+              class="repo_f1akv6s4"
             >
               <div>
                 try
@@ -2320,10 +2317,10 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                       </button>
                     </span>
                   </span>
-                  <span
+                  <div
                     class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <span
+                    <div
                       class="info-caption-item item-author"
                     >
                       <svg
@@ -2337,15 +2334,14 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                      <span
-                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      <div
+                        class="MuiBox-root css-1obfhg7"
                       >
                         johncleese@python.com
-                      </span>
-                    </span>
-                    <span
-                      class="info-caption-item item-time"
-                      style="display: flex; align-items: center; margin-left: 8px;"
+                      </div>
+                    </div>
+                    <div
+                      class="info-caption-item item-time MuiBox-root css-9mul5i"
                     >
                       <svg
                         aria-hidden="true"
@@ -2365,8 +2361,8 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </span>
-                  </span>
+                    </div>
+                  </div>
                 </span>
                 <span
                   class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
@@ -2413,7 +2409,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
               value="autoland"
             />
             <div
-              class="repo_fkd3ycy"
+              class="repo_f1akv6s4"
             >
               <div>
                 autoland
@@ -2466,10 +2462,10 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                       </button>
                     </span>
                   </span>
-                  <span
+                  <div
                     class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <span
+                    <div
                       class="info-caption-item item-author"
                     >
                       <svg
@@ -2483,15 +2479,14 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                      <span
-                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      <div
+                        class="MuiBox-root css-1obfhg7"
                       >
                         michaelpalin@python.com
-                      </span>
-                    </span>
-                    <span
-                      class="info-caption-item item-time"
-                      style="display: flex; align-items: center; margin-left: 8px;"
+                      </div>
+                    </div>
+                    <div
+                      class="info-caption-item item-time MuiBox-root css-9mul5i"
                     >
                       <svg
                         aria-hidden="true"
@@ -2511,8 +2506,8 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                       >
                         Jul 4, 20, 00:00 UTC
                       </div>
-                    </span>
-                  </span>
+                    </div>
+                  </div>
                 </span>
                 <span
                   class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
@@ -2822,7 +2817,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="new_search-input--time"
       >
         <div
@@ -2905,7 +2900,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
               value="try"
             />
             <div
-              class="repo_fkd3ycy"
+              class="repo_f1akv6s4"
             >
               <div>
                 try
@@ -2958,10 +2953,10 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                       </button>
                     </span>
                   </span>
-                  <span
+                  <div
                     class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <span
+                    <div
                       class="info-caption-item item-author"
                     >
                       <svg
@@ -2975,15 +2970,14 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                      <span
-                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      <div
+                        class="MuiBox-root css-1obfhg7"
                       >
                         johncleese@python.com
-                      </span>
-                    </span>
-                    <span
-                      class="info-caption-item item-time"
-                      style="display: flex; align-items: center; margin-left: 8px;"
+                      </div>
+                    </div>
+                    <div
+                      class="info-caption-item item-time MuiBox-root css-9mul5i"
                     >
                       <svg
                         aria-hidden="true"
@@ -3003,8 +2997,8 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </span>
-                  </span>
+                    </div>
+                  </div>
                 </span>
                 <span
                   class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
@@ -3244,7 +3238,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
               value="try"
             />
             <div
-              class="repo_fkd3ycy"
+              class="repo_f1akv6s4"
             >
               <div>
                 try
@@ -3297,10 +3291,10 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                       </button>
                     </span>
                   </span>
-                  <span
+                  <div
                     class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <span
+                    <div
                       class="info-caption-item item-author"
                     >
                       <svg
@@ -3314,15 +3308,14 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                      <span
-                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      <div
+                        class="MuiBox-root css-1obfhg7"
                       >
                         johncleese@python.com
-                      </span>
-                    </span>
-                    <span
-                      class="info-caption-item item-time"
-                      style="display: flex; align-items: center; margin-left: 8px;"
+                      </div>
+                    </div>
+                    <div
+                      class="info-caption-item item-time MuiBox-root css-9mul5i"
                     >
                       <svg
                         aria-hidden="true"
@@ -3342,8 +3335,8 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </span>
-                  </span>
+                    </div>
+                  </div>
                 </span>
                 <span
                   class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"

--- a/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_frp1utb   css-1t7ybvx-MuiGrid-root"
         id="time-range"
-        style="max-width: 365px;"
+        style="max-width: 430px;"
       >
         <div
           class="MuiFormControl-root timerange-dropdown f1o9jg5h css-1nrlq1o-MuiFormControl-root"
@@ -231,7 +231,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
         id="new_search-input--time"
       >
         <div
@@ -372,7 +372,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
       class="fs9pw6x cancel-compare"
     >
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-pp3xxr-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-6hc3gy-MuiButtonBase-root-MuiButton-root"
         id="compare-button"
         tabindex="0"
         type="submit"
@@ -398,7 +398,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
   >
     <button
       aria-label="edit revision"
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation global-edit-button edit-revision-button css-1rvsmwy-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation global-edit-button edit-revision-button css-nrxrys-MuiButtonBase-root-MuiButton-root"
       name="edit-button"
       tabindex="0"
       type="button"
@@ -478,7 +478,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_frp1utb  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
-        style="max-width: 415px;"
+        style="max-width: 430px;"
       >
         <span
           class="MuiTypography-root MuiTypography-body2 css-163bcq3-MuiTypography-root"
@@ -488,7 +488,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
       </div>
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  flie9py css-1t7ybvx-MuiGrid-root"
-        style="max-width: 415px;"
+        style="max-width: 430px;"
       >
         <div
           style="display: flex; justify-content: space-between;"
@@ -885,7 +885,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
   >
     <button
       aria-label="edit revision"
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation global-edit-button edit-revision-button css-1rvsmwy-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation global-edit-button edit-revision-button css-nrxrys-MuiButtonBase-root-MuiButton-root"
       name="edit-button"
       tabindex="0"
       type="button"
@@ -975,7 +975,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown css-1t7ybvx-MuiGrid-root"
         id="base_search-dropdown--time"
-        style="max-width: 415px;"
+        style="max-width: 430px;"
       >
         <div
           class="MuiFormControl-root search-dropdown f1o9jg5h css-1nrlq1o-MuiFormControl-root"
@@ -1019,7 +1019,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown small dropDown_frp1utb   css-1t7ybvx-MuiGrid-root"
         id="time-range"
-        style="max-width: 415px;"
+        style="max-width: 430px;"
       >
         <div
           class="MuiFormControl-root timerange-dropdown f1o9jg5h css-1nrlq1o-MuiFormControl-root"
@@ -1140,7 +1140,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
         id="new_search-input--time"
       >
         <div
@@ -1365,7 +1365,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
       class="fs9pw6x cancel-compare"
     >
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-button css-iendvr-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-button css-1y7fc34-MuiButtonBase-root-MuiButton-root"
         name="cancel-button"
         tabindex="0"
         type="button"
@@ -1376,7 +1376,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
         />
       </button>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-pp3xxr-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-6hc3gy-MuiButtonBase-root-MuiButton-root"
         id="compare-button"
         tabindex="0"
         type="submit"
@@ -1407,7 +1407,7 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
   >
     <button
       aria-label="edit revision"
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation global-edit-button edit-revision-button css-1rvsmwy-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation global-edit-button edit-revision-button css-nrxrys-MuiButtonBase-root-MuiButton-root"
       name="edit-button"
       tabindex="0"
       type="button"
@@ -1487,7 +1487,7 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_frp1utb  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
-        style="max-width: 415px;"
+        style="max-width: 430px;"
       >
         <span
           class="MuiTypography-root MuiTypography-body2 css-163bcq3-MuiTypography-root"
@@ -1497,7 +1497,7 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
       </div>
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  flie9py css-1t7ybvx-MuiGrid-root"
-        style="max-width: 415px;"
+        style="max-width: 430px;"
       >
         <div
           style="display: flex; justify-content: space-between;"
@@ -1815,7 +1815,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_frp1utb   css-1t7ybvx-MuiGrid-root"
         id="time-range"
-        style="max-width: 365px;"
+        style="max-width: 430px;"
       >
         <div
           class="MuiFormControl-root timerange-dropdown f1o9jg5h css-1nrlq1o-MuiFormControl-root"
@@ -1936,7 +1936,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
         id="new_search-input--time"
       >
         <div
@@ -2077,7 +2077,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
       class="fs9pw6x cancel-compare"
     >
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-pp3xxr-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-6hc3gy-MuiButtonBase-root-MuiButton-root"
         id="compare-button"
         tabindex="0"
         type="submit"
@@ -2103,7 +2103,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
   >
     <button
       aria-label="edit revision"
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation global-edit-button edit-revision-button css-1rvsmwy-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation global-edit-button edit-revision-button css-nrxrys-MuiButtonBase-root-MuiButton-root"
       name="edit-button"
       tabindex="0"
       type="button"
@@ -2192,7 +2192,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_frp1utb  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
-        style="max-width: 415px;"
+        style="max-width: 430px;"
       >
         <span
           class="MuiTypography-root MuiTypography-body2 css-163bcq3-MuiTypography-root"
@@ -2202,7 +2202,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       </div>
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  flie9py css-1t7ybvx-MuiGrid-root"
-        style="max-width: 415px;"
+        style="max-width: 430px;"
       >
         <div
           style="display: flex; justify-content: space-between;"
@@ -2567,7 +2567,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
   >
     <button
       aria-label="edit revision"
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation global-edit-button edit-revision-button css-1rvsmwy-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation global-edit-button edit-revision-button css-nrxrys-MuiButtonBase-root-MuiButton-root"
       name="edit-button"
       tabindex="0"
       type="button"
@@ -2657,7 +2657,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown css-1t7ybvx-MuiGrid-root"
         id="base_search-dropdown--time"
-        style="max-width: 415px;"
+        style="max-width: 430px;"
       >
         <div
           class="MuiFormControl-root search-dropdown f1o9jg5h css-1nrlq1o-MuiFormControl-root"
@@ -2701,7 +2701,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown small dropDown_frp1utb   css-1t7ybvx-MuiGrid-root"
         id="time-range"
-        style="max-width: 415px;"
+        style="max-width: 430px;"
       >
         <div
           class="MuiFormControl-root timerange-dropdown f1o9jg5h css-1nrlq1o-MuiFormControl-root"
@@ -2822,7 +2822,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
         id="new_search-input--time"
       >
         <div
@@ -3047,7 +3047,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       class="fs9pw6x cancel-compare"
     >
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-button css-iendvr-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-button css-1y7fc34-MuiButtonBase-root-MuiButton-root"
         name="cancel-button"
         tabindex="0"
         type="button"
@@ -3058,7 +3058,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
         />
       </button>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-pp3xxr-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-6hc3gy-MuiButtonBase-root-MuiButton-root"
         id="compare-button"
         tabindex="0"
         type="submit"
@@ -3089,7 +3089,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
   >
     <button
       aria-label="edit revision"
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation global-edit-button edit-revision-button css-1rvsmwy-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation global-edit-button edit-revision-button css-nrxrys-MuiButtonBase-root-MuiButton-root"
       name="edit-button"
       tabindex="0"
       type="button"
@@ -3169,7 +3169,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true base-search-dropdown flie9py dropDown_frp1utb  compare-over-time-results-base-dropdown css-1t7ybvx-MuiGrid-root"
-        style="max-width: 415px;"
+        style="max-width: 430px;"
       >
         <span
           class="MuiTypography-root MuiTypography-body2 css-163bcq3-MuiTypography-root"
@@ -3179,7 +3179,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
       </div>
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  flie9py css-1t7ybvx-MuiGrid-root"
-        style="max-width: 415px;"
+        style="max-width: 430px;"
       >
         <div
           style="display: flex; justify-content: space-between;"

--- a/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
@@ -104,7 +104,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
@@ -188,7 +188,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
               value="try"
             />
             <div
-              class="repo_fkd3ycy"
+              class="repo_f1akv6s4"
             >
               <div>
                 try
@@ -261,10 +261,10 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
                       </button>
                     </span>
                   </span>
-                  <span
+                  <div
                     class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <span
+                    <div
                       class="info-caption-item item-author"
                     >
                       <svg
@@ -278,15 +278,14 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                      <span
-                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      <div
+                        class="MuiBox-root css-1obfhg7"
                       >
                         johncleese@python.com
-                      </span>
-                    </span>
-                    <span
-                      class="info-caption-item item-time"
-                      style="display: flex; align-items: center; margin-left: 8px;"
+                      </div>
+                    </div>
+                    <div
+                      class="info-caption-item item-time MuiBox-root css-9mul5i"
                     >
                       <svg
                         aria-hidden="true"
@@ -306,8 +305,8 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </span>
-                  </span>
+                    </div>
+                  </div>
                 </span>
                 <span
                   class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
@@ -415,7 +414,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
@@ -499,7 +498,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
               value="try"
             />
             <div
-              class="repo_fkd3ycy"
+              class="repo_f1akv6s4"
             >
               <div>
                 try
@@ -572,10 +571,10 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
                       </button>
                     </span>
                   </span>
-                  <span
+                  <div
                     class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <span
+                    <div
                       class="info-caption-item item-author"
                     >
                       <svg
@@ -589,15 +588,14 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                      <span
-                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      <div
+                        class="MuiBox-root css-1obfhg7"
                       >
                         johncleese@python.com
-                      </span>
-                    </span>
-                    <span
-                      class="info-caption-item item-time"
-                      style="display: flex; align-items: center; margin-left: 8px;"
+                      </div>
+                    </div>
+                    <div
+                      class="info-caption-item item-time MuiBox-root css-9mul5i"
                     >
                       <svg
                         aria-hidden="true"
@@ -617,8 +615,8 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </span>
-                  </span>
+                    </div>
+                  </div>
                 </span>
                 <span
                   class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
@@ -921,7 +919,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
@@ -1005,7 +1003,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
               value="try"
             />
             <div
-              class="repo_fkd3ycy"
+              class="repo_f1akv6s4"
             >
               <div>
                 try
@@ -1078,10 +1076,10 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                       </button>
                     </span>
                   </span>
-                  <span
+                  <div
                     class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <span
+                    <div
                       class="info-caption-item item-author"
                     >
                       <svg
@@ -1095,15 +1093,14 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                      <span
-                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      <div
+                        class="MuiBox-root css-1obfhg7"
                       >
                         johncleese@python.com
-                      </span>
-                    </span>
-                    <span
-                      class="info-caption-item item-time"
-                      style="display: flex; align-items: center; margin-left: 8px;"
+                      </div>
+                    </div>
+                    <div
+                      class="info-caption-item item-time MuiBox-root css-9mul5i"
                     >
                       <svg
                         aria-hidden="true"
@@ -1123,8 +1120,8 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </span>
-                  </span>
+                    </div>
+                  </div>
                 </span>
                 <span
                   class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
@@ -1232,7 +1229,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
@@ -1425,7 +1422,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
@@ -1509,7 +1506,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
               value="try"
             />
             <div
-              class="repo_fkd3ycy"
+              class="repo_f1akv6s4"
             >
               <div>
                 try
@@ -1582,10 +1579,10 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                       </button>
                     </span>
                   </span>
-                  <span
+                  <div
                     class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <span
+                    <div
                       class="info-caption-item item-author"
                     >
                       <svg
@@ -1599,15 +1596,14 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                      <span
-                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      <div
+                        class="MuiBox-root css-1obfhg7"
                       >
                         johncleese@python.com
-                      </span>
-                    </span>
-                    <span
-                      class="info-caption-item item-time"
-                      style="display: flex; align-items: center; margin-left: 8px;"
+                      </div>
+                    </div>
+                    <div
+                      class="info-caption-item item-time MuiBox-root css-9mul5i"
                     >
                       <svg
                         aria-hidden="true"
@@ -1627,8 +1623,8 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </span>
-                  </span>
+                    </div>
+                  </div>
                 </span>
                 <span
                   class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
@@ -1736,7 +1732,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
@@ -1820,7 +1816,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
               value="try"
             />
             <div
-              class="repo_fkd3ycy"
+              class="repo_f1akv6s4"
             >
               <div>
                 try
@@ -1893,10 +1889,10 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                       </button>
                     </span>
                   </span>
-                  <span
+                  <div
                     class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <span
+                    <div
                       class="info-caption-item item-author"
                     >
                       <svg
@@ -1910,15 +1906,14 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                      <span
-                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      <div
+                        class="MuiBox-root css-1obfhg7"
                       >
                         johncleese@python.com
-                      </span>
-                    </span>
-                    <span
-                      class="info-caption-item item-time"
-                      style="display: flex; align-items: center; margin-left: 8px;"
+                      </div>
+                    </div>
+                    <div
+                      class="info-caption-item item-time MuiBox-root css-9mul5i"
                     >
                       <svg
                         aria-hidden="true"
@@ -1938,8 +1933,8 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </span>
-                  </span>
+                    </div>
+                  </div>
                 </span>
                 <span
                   class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
@@ -2117,7 +2112,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
@@ -2201,7 +2196,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
               value="try"
             />
             <div
-              class="repo_fkd3ycy"
+              class="repo_f1akv6s4"
             >
               <div>
                 try
@@ -2274,10 +2269,10 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
                       </button>
                     </span>
                   </span>
-                  <span
+                  <div
                     class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <span
+                    <div
                       class="info-caption-item item-author"
                     >
                       <svg
@@ -2291,15 +2286,14 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                      <span
-                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      <div
+                        class="MuiBox-root css-1obfhg7"
                       >
                         johncleese@python.com
-                      </span>
-                    </span>
-                    <span
-                      class="info-caption-item item-time"
-                      style="display: flex; align-items: center; margin-left: 8px;"
+                      </div>
+                    </div>
+                    <div
+                      class="info-caption-item item-time MuiBox-root css-9mul5i"
                     >
                       <svg
                         aria-hidden="true"
@@ -2319,8 +2313,8 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </span>
-                  </span>
+                    </div>
+                  </div>
                 </span>
                 <span
                   class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
@@ -2428,7 +2422,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
@@ -2512,7 +2506,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
               value="try"
             />
             <div
-              class="repo_fkd3ycy"
+              class="repo_f1akv6s4"
             >
               <div>
                 try
@@ -2585,10 +2579,10 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
                       </button>
                     </span>
                   </span>
-                  <span
+                  <div
                     class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <span
+                    <div
                       class="info-caption-item item-author"
                     >
                       <svg
@@ -2602,15 +2596,14 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                      <span
-                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      <div
+                        class="MuiBox-root css-1obfhg7"
                       >
                         johncleese@python.com
-                      </span>
-                    </span>
-                    <span
-                      class="info-caption-item item-time"
-                      style="display: flex; align-items: center; margin-left: 8px;"
+                      </div>
+                    </div>
+                    <div
+                      class="info-caption-item item-time MuiBox-root css-9mul5i"
                     >
                       <svg
                         aria-hidden="true"
@@ -2630,8 +2623,8 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </span>
-                  </span>
+                    </div>
+                  </div>
                 </span>
                 <span
                   class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
@@ -2796,7 +2789,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
@@ -2940,7 +2933,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
@@ -3024,7 +3017,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
               value="try"
             />
             <div
-              class="repo_fkd3ycy"
+              class="repo_f1akv6s4"
             >
               <div>
                 try
@@ -3097,10 +3090,10 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
                       </button>
                     </span>
                   </span>
-                  <span
+                  <div
                     class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <span
+                    <div
                       class="info-caption-item item-author"
                     >
                       <svg
@@ -3114,15 +3107,14 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                      <span
-                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      <div
+                        class="MuiBox-root css-1obfhg7"
                       >
                         johncleese@python.com
-                      </span>
-                    </span>
-                    <span
-                      class="info-caption-item item-time"
-                      style="display: flex; align-items: center; margin-left: 8px;"
+                      </div>
+                    </div>
+                    <div
+                      class="info-caption-item item-time MuiBox-root css-9mul5i"
                     >
                       <svg
                         aria-hidden="true"
@@ -3142,8 +3134,8 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </span>
-                  </span>
+                    </div>
+                  </div>
                 </span>
                 <span
                   class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
@@ -3346,7 +3338,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
@@ -3430,7 +3422,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
               value="try"
             />
             <div
-              class="repo_fkd3ycy"
+              class="repo_f1akv6s4"
             >
               <div>
                 try
@@ -3503,10 +3495,10 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
                       </button>
                     </span>
                   </span>
-                  <span
+                  <div
                     class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <span
+                    <div
                       class="info-caption-item item-author"
                     >
                       <svg
@@ -3520,15 +3512,14 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                      <span
-                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      <div
+                        class="MuiBox-root css-1obfhg7"
                       >
                         johncleese@python.com
-                      </span>
-                    </span>
-                    <span
-                      class="info-caption-item item-time"
-                      style="display: flex; align-items: center; margin-left: 8px;"
+                      </div>
+                    </div>
+                    <div
+                      class="info-caption-item item-time MuiBox-root css-9mul5i"
                     >
                       <svg
                         aria-hidden="true"
@@ -3548,8 +3539,8 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </span>
-                  </span>
+                    </div>
+                  </div>
                 </span>
                 <span
                   class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
@@ -3657,7 +3648,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
@@ -3970,7 +3961,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
                       id="base_search-input"
                     >
                       <div
@@ -4114,7 +4105,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
                       id="new_search-input"
                     >
                       <div
@@ -4535,7 +4526,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
                       id="new_search-input--time"
                     >
                       <div

--- a/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
   >
     <button
       aria-label="edit revision"
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation global-edit-button edit-revision-button css-1rvsmwy-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation global-edit-button edit-revision-button css-nrxrys-MuiButtonBase-root-MuiButton-root"
       name="edit-button"
       tabindex="0"
       type="button"
@@ -104,7 +104,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
@@ -415,7 +415,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
@@ -803,7 +803,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
   >
     <button
       aria-label="edit revision"
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation global-edit-button edit-revision-button css-1rvsmwy-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation global-edit-button edit-revision-button css-nrxrys-MuiButtonBase-root-MuiButton-root"
       name="edit-button"
       tabindex="0"
       type="button"
@@ -921,7 +921,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
@@ -1232,7 +1232,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
@@ -1323,7 +1323,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
   >
     <button
       aria-label="edit revision"
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation global-edit-button edit-revision-button css-1rvsmwy-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation global-edit-button edit-revision-button css-nrxrys-MuiButtonBase-root-MuiButton-root"
       name="edit-button"
       tabindex="0"
       type="button"
@@ -1425,7 +1425,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
@@ -1736,7 +1736,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
@@ -1982,7 +1982,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
       class="fs9pw6x cancel-compare"
     >
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-button css-iendvr-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-button css-1y7fc34-MuiButtonBase-root-MuiButton-root"
         name="cancel-button"
         tabindex="0"
         type="button"
@@ -1993,7 +1993,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
         />
       </button>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-pp3xxr-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-6hc3gy-MuiButtonBase-root-MuiButton-root"
         id="compare-button"
         tabindex="0"
         type="submit"
@@ -2024,7 +2024,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
   >
     <button
       aria-label="edit revision"
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation global-edit-button edit-revision-button css-1rvsmwy-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation global-edit-button edit-revision-button css-nrxrys-MuiButtonBase-root-MuiButton-root"
       name="edit-button"
       tabindex="0"
       type="button"
@@ -2117,7 +2117,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
@@ -2428,7 +2428,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
@@ -2686,7 +2686,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
   >
     <button
       aria-label="edit revision"
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation global-edit-button edit-revision-button css-1rvsmwy-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation global-edit-button edit-revision-button css-nrxrys-MuiButtonBase-root-MuiButton-root"
       name="edit-button"
       tabindex="0"
       type="button"
@@ -2796,7 +2796,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
@@ -2940,7 +2940,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
@@ -3186,7 +3186,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
       class="fs9pw6x cancel-compare"
     >
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-button css-iendvr-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-button css-1y7fc34-MuiButtonBase-root-MuiButton-root"
         name="cancel-button"
         tabindex="0"
         type="button"
@@ -3197,7 +3197,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
         />
       </button>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-pp3xxr-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-6hc3gy-MuiButtonBase-root-MuiButton-root"
         id="compare-button"
         tabindex="0"
         type="submit"
@@ -3228,7 +3228,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
   >
     <button
       aria-label="edit revision"
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation global-edit-button edit-revision-button css-1rvsmwy-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-disableElevation global-edit-button edit-revision-button css-nrxrys-MuiButtonBase-root-MuiButton-root"
       name="edit-button"
       tabindex="0"
       type="button"
@@ -3346,7 +3346,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
@@ -3657,7 +3657,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07 big  css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
@@ -3736,7 +3736,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
       class="fs9pw6x cancel-compare"
     >
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-button css-iendvr-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation cancel-button css-1y7fc34-MuiButtonBase-root-MuiButton-root"
         name="cancel-button"
         tabindex="0"
         type="button"
@@ -3747,7 +3747,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
         />
       </button>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-pp3xxr-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-6hc3gy-MuiButtonBase-root-MuiButton-root"
         id="compare-button"
         tabindex="0"
         type="submit"
@@ -3840,7 +3840,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
             Analyze results of performance tests to detect regressions and identify opportunities for improvement.
           </div>
           <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation learn-more-btn css-pp3xxr-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation learn-more-btn css-6hc3gy-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"
           >
@@ -3970,7 +3970,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
                       id="base_search-input"
                     >
                       <div
@@ -4114,7 +4114,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
                       id="new_search-input"
                     >
                       <div
@@ -4256,7 +4256,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                     class="fs9pw6x cancel-compare"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-pp3xxr-MuiButtonBase-root-MuiButton-root"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-6hc3gy-MuiButtonBase-root-MuiButton-root"
                       id="compare-button"
                       tabindex="0"
                       type="submit"
@@ -4414,7 +4414,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                     <div
                       class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_frp1utb   css-1t7ybvx-MuiGrid-root"
                       id="time-range"
-                      style="max-width: 365px;"
+                      style="max-width: 430px;"
                     >
                       <div
                         class="MuiFormControl-root timerange-dropdown f1o9jg5h css-1nrlq1o-MuiFormControl-root"
@@ -4535,7 +4535,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
                       id="new_search-input--time"
                     >
                       <div
@@ -4676,7 +4676,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                     class="fs9pw6x cancel-compare"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-pp3xxr-MuiButtonBase-root-MuiButton-root"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-6hc3gy-MuiButtonBase-root-MuiButton-root"
                       id="compare-button"
                       tabindex="0"
                       type="submit"

--- a/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -63,7 +63,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -104,14 +104,14 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f7qwsv0 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -168,7 +168,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
       data-testid="base-selected-revision"
     >
       <div
-        class="box_f1wdk99e base-box MuiBox-root css-0"
+        class="box_f9k3p52 base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -215,16 +215,16 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
               </div>
             </div>
             <div
-              class="selectedRevision_f1h5nweo MuiBox-root css-0"
+              class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                 >
                   <span
-                    class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
@@ -261,13 +261,12 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
                       </button>
                     </span>
                   </span>
-                  <div
-                    class="info-caption"
+                  <span
+                    class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <div
+                    <span
                       class="info-caption-item item-author"
                     >
-                       
                       <svg
                         aria-hidden="true"
                         class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
@@ -279,11 +278,15 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                       
-                      johncleese@python.com
-                    </div>
-                    <div
+                      <span
+                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      >
+                        johncleese@python.com
+                      </span>
+                    </span>
+                    <span
                       class="info-caption-item item-time"
+                      style="display: flex; align-items: center; margin-left: 8px;"
                     >
                       <svg
                         aria-hidden="true"
@@ -303,11 +306,11 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </div>
-                  </div>
+                    </span>
+                  </span>
                 </span>
                 <span
-                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                 >
                   you've got no arms left! 
                 </span>
@@ -344,7 +347,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -371,7 +374,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -412,14 +415,14 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f7qwsv0 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -476,7 +479,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
       data-testid="new-selected-revision"
     >
       <div
-        class="box_f1wdk99e new-box MuiBox-root css-0"
+        class="box_f9k3p52 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -523,16 +526,16 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
               </div>
             </div>
             <div
-              class="selectedRevision_f1h5nweo MuiBox-root css-0"
+              class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                 >
                   <span
-                    class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
@@ -569,13 +572,12 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
                       </button>
                     </span>
                   </span>
-                  <div
-                    class="info-caption"
+                  <span
+                    class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <div
+                    <span
                       class="info-caption-item item-author"
                     >
-                       
                       <svg
                         aria-hidden="true"
                         class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
@@ -587,11 +589,15 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                       
-                      johncleese@python.com
-                    </div>
-                    <div
+                      <span
+                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      >
+                        johncleese@python.com
+                      </span>
+                    </span>
+                    <span
                       class="info-caption-item item-time"
+                      style="display: flex; align-items: center; margin-left: 8px;"
                     >
                       <svg
                         aria-hidden="true"
@@ -611,11 +617,11 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </div>
-                  </div>
+                    </span>
+                  </span>
                 </span>
                 <span
-                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                 >
                   you've got no arms left! 
                 </span>
@@ -847,7 +853,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -874,7 +880,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -915,14 +921,14 @@ exports[`Compare With Base should have an edit mode in Results View: After click
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f7qwsv0 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -979,7 +985,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
       data-testid="base-selected-revision"
     >
       <div
-        class="box_f1wdk99e base-box MuiBox-root css-0"
+        class="box_f9k3p52 base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1026,16 +1032,16 @@ exports[`Compare With Base should have an edit mode in Results View: After click
               </div>
             </div>
             <div
-              class="selectedRevision_f1h5nweo MuiBox-root css-0"
+              class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                 >
                   <span
-                    class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
@@ -1072,13 +1078,12 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                       </button>
                     </span>
                   </span>
-                  <div
-                    class="info-caption"
+                  <span
+                    class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <div
+                    <span
                       class="info-caption-item item-author"
                     >
-                       
                       <svg
                         aria-hidden="true"
                         class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
@@ -1090,11 +1095,15 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                       
-                      johncleese@python.com
-                    </div>
-                    <div
+                      <span
+                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      >
+                        johncleese@python.com
+                      </span>
+                    </span>
+                    <span
                       class="info-caption-item item-time"
+                      style="display: flex; align-items: center; margin-left: 8px;"
                     >
                       <svg
                         aria-hidden="true"
@@ -1114,11 +1123,11 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </div>
-                  </div>
+                    </span>
+                  </span>
                 </span>
                 <span
-                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                 >
                   you've got no arms left! 
                 </span>
@@ -1155,7 +1164,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1182,7 +1191,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -1223,14 +1232,14 @@ exports[`Compare With Base should have an edit mode in Results View: After click
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f7qwsv0 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -1287,7 +1296,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
       data-testid="new-selected-revision"
     >
       <div
-        class="box_f1wdk99e new-box MuiBox-root css-0"
+        class="box_f9k3p52 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1348,7 +1357,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1375,7 +1384,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -1416,14 +1425,14 @@ exports[`Compare With Base should have an edit mode in Results View: After click
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f7qwsv0 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -1480,7 +1489,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
       data-testid="base-selected-revision"
     >
       <div
-        class="box_f1wdk99e base-box MuiBox-root css-0"
+        class="box_f9k3p52 base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1527,16 +1536,16 @@ exports[`Compare With Base should have an edit mode in Results View: After click
               </div>
             </div>
             <div
-              class="selectedRevision_f1h5nweo MuiBox-root css-0"
+              class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                 >
                   <span
-                    class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
@@ -1573,13 +1582,12 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                       </button>
                     </span>
                   </span>
-                  <div
-                    class="info-caption"
+                  <span
+                    class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <div
+                    <span
                       class="info-caption-item item-author"
                     >
-                       
                       <svg
                         aria-hidden="true"
                         class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
@@ -1591,11 +1599,15 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                       
-                      johncleese@python.com
-                    </div>
-                    <div
+                      <span
+                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      >
+                        johncleese@python.com
+                      </span>
+                    </span>
+                    <span
                       class="info-caption-item item-time"
+                      style="display: flex; align-items: center; margin-left: 8px;"
                     >
                       <svg
                         aria-hidden="true"
@@ -1615,11 +1627,11 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </div>
-                  </div>
+                    </span>
+                  </span>
                 </span>
                 <span
-                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                 >
                   you've got no arms left! 
                 </span>
@@ -1656,7 +1668,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1683,7 +1695,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -1724,14 +1736,14 @@ exports[`Compare With Base should have an edit mode in Results View: After click
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f7qwsv0 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -1788,7 +1800,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
       data-testid="new-selected-revision"
     >
       <div
-        class="box_f1wdk99e new-box MuiBox-root css-0"
+        class="box_f9k3p52 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1835,16 +1847,16 @@ exports[`Compare With Base should have an edit mode in Results View: After click
               </div>
             </div>
             <div
-              class="selectedRevision_f1h5nweo MuiBox-root css-0"
+              class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                 >
                   <span
-                    class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
@@ -1881,13 +1893,12 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                       </button>
                     </span>
                   </span>
-                  <div
-                    class="info-caption"
+                  <span
+                    class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <div
+                    <span
                       class="info-caption-item item-author"
                     >
-                       
                       <svg
                         aria-hidden="true"
                         class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
@@ -1899,11 +1910,15 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                       
-                      johncleese@python.com
-                    </div>
-                    <div
+                      <span
+                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      >
+                        johncleese@python.com
+                      </span>
+                    </span>
+                    <span
                       class="info-caption-item item-time"
+                      style="display: flex; align-items: center; margin-left: 8px;"
                     >
                       <svg
                         aria-hidden="true"
@@ -1923,11 +1938,11 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </div>
-                  </div>
+                    </span>
+                  </span>
                 </span>
                 <span
-                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                 >
                   you've got no arms left! 
                 </span>
@@ -1961,7 +1976,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1sh1skx css-13jteey-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_frp1utb css-13jteey-MuiGrid-root"
   >
     <div
       class="fs9pw6x cancel-compare"
@@ -2034,7 +2049,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -2061,7 +2076,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -2102,14 +2117,14 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f7qwsv0 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -2166,7 +2181,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
       data-testid="base-selected-revision"
     >
       <div
-        class="box_f1wdk99e base-box MuiBox-root css-0"
+        class="box_f9k3p52 base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2213,16 +2228,16 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
               </div>
             </div>
             <div
-              class="selectedRevision_f1h5nweo MuiBox-root css-0"
+              class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                 >
                   <span
-                    class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
@@ -2259,13 +2274,12 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
                       </button>
                     </span>
                   </span>
-                  <div
-                    class="info-caption"
+                  <span
+                    class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <div
+                    <span
                       class="info-caption-item item-author"
                     >
-                       
                       <svg
                         aria-hidden="true"
                         class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
@@ -2277,11 +2291,15 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                       
-                      johncleese@python.com
-                    </div>
-                    <div
+                      <span
+                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      >
+                        johncleese@python.com
+                      </span>
+                    </span>
+                    <span
                       class="info-caption-item item-time"
+                      style="display: flex; align-items: center; margin-left: 8px;"
                     >
                       <svg
                         aria-hidden="true"
@@ -2301,11 +2319,11 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </div>
-                  </div>
+                    </span>
+                  </span>
                 </span>
                 <span
-                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                 >
                   you've got no arms left! 
                 </span>
@@ -2342,7 +2360,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -2369,7 +2387,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -2410,14 +2428,14 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f7qwsv0 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -2474,7 +2492,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
       data-testid="new-selected-revision"
     >
       <div
-        class="box_f1wdk99e new-box MuiBox-root css-0"
+        class="box_f9k3p52 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2521,16 +2539,16 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
               </div>
             </div>
             <div
-              class="selectedRevision_f1h5nweo MuiBox-root css-0"
+              class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                 >
                   <span
-                    class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
@@ -2567,13 +2585,12 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
                       </button>
                     </span>
                   </span>
-                  <div
-                    class="info-caption"
+                  <span
+                    class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <div
+                    <span
                       class="info-caption-item item-author"
                     >
-                       
                       <svg
                         aria-hidden="true"
                         class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
@@ -2585,11 +2602,15 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                       
-                      johncleese@python.com
-                    </div>
-                    <div
+                      <span
+                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      >
+                        johncleese@python.com
+                      </span>
+                    </span>
+                    <span
                       class="info-caption-item item-time"
+                      style="display: flex; align-items: center; margin-left: 8px;"
                     >
                       <svg
                         aria-hidden="true"
@@ -2609,11 +2630,11 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </div>
-                  </div>
+                    </span>
+                  </span>
                 </span>
                 <span
-                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                 >
                   you've got no arms left! 
                 </span>
@@ -2707,7 +2728,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -2734,7 +2755,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -2775,14 +2796,14 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f7qwsv0 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -2839,7 +2860,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
       data-testid="base-selected-revision"
     >
       <div
-        class="box_f1wdk99e base-box MuiBox-root css-0"
+        class="box_f9k3p52 base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2851,7 +2872,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -2878,7 +2899,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -2919,14 +2940,14 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f7qwsv0 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -2983,7 +3004,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
       data-testid="new-selected-revision"
     >
       <div
-        class="box_f1wdk99e new-box MuiBox-root css-0"
+        class="box_f9k3p52 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -3030,16 +3051,16 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
               </div>
             </div>
             <div
-              class="selectedRevision_f1h5nweo MuiBox-root css-0"
+              class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                 >
                   <span
-                    class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
@@ -3076,13 +3097,12 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
                       </button>
                     </span>
                   </span>
-                  <div
-                    class="info-caption"
+                  <span
+                    class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <div
+                    <span
                       class="info-caption-item item-author"
                     >
-                       
                       <svg
                         aria-hidden="true"
                         class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
@@ -3094,11 +3114,15 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                       
-                      johncleese@python.com
-                    </div>
-                    <div
+                      <span
+                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      >
+                        johncleese@python.com
+                      </span>
+                    </span>
+                    <span
                       class="info-caption-item item-time"
+                      style="display: flex; align-items: center; margin-left: 8px;"
                     >
                       <svg
                         aria-hidden="true"
@@ -3118,11 +3142,11 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </div>
-                  </div>
+                    </span>
+                  </span>
                 </span>
                 <span
-                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                 >
                   you've got no arms left! 
                 </span>
@@ -3156,7 +3180,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1sh1skx css-13jteey-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_frp1utb css-13jteey-MuiGrid-root"
   >
     <div
       class="fs9pw6x cancel-compare"
@@ -3254,7 +3278,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -3281,7 +3305,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -3322,14 +3346,14 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f7qwsv0 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -3386,7 +3410,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
       data-testid="base-selected-revision"
     >
       <div
-        class="box_f1wdk99e base-box MuiBox-root css-0"
+        class="box_f9k3p52 base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -3433,16 +3457,16 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
               </div>
             </div>
             <div
-              class="selectedRevision_f1h5nweo MuiBox-root css-0"
+              class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                 >
                   <span
-                    class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
@@ -3479,13 +3503,12 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
                       </button>
                     </span>
                   </span>
-                  <div
-                    class="info-caption"
+                  <span
+                    class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <div
+                    <span
                       class="info-caption-item item-author"
                     >
-                       
                       <svg
                         aria-hidden="true"
                         class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
@@ -3497,11 +3520,15 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                       
-                      johncleese@python.com
-                    </div>
-                    <div
+                      <span
+                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      >
+                        johncleese@python.com
+                      </span>
+                    </span>
+                    <span
                       class="info-caption-item item-time"
+                      style="display: flex; align-items: center; margin-left: 8px;"
                     >
                       <svg
                         aria-hidden="true"
@@ -3521,11 +3548,11 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
                       >
                         Mar 29, 51, 00:00 UTC
                       </div>
-                    </div>
-                  </div>
+                    </span>
+                  </span>
                 </span>
                 <span
-                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                 >
                   you've got no arms left! 
                 </span>
@@ -3562,7 +3589,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -3589,7 +3616,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb small compare-results-base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -3630,14 +3657,14 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f7qwsv0 big  css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x big  css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -3694,7 +3721,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
       data-testid="new-selected-revision"
     >
       <div
-        class="box_f1wdk99e new-box MuiBox-root css-0"
+        class="box_f9k3p52 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -3703,7 +3730,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1sh1skx css-13jteey-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_frp1utb css-13jteey-MuiGrid-root"
   >
     <div
       class="fs9pw6x cancel-compare"
@@ -3759,7 +3786,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
         class="MuiGrid-root header-container container_fllbiki css-plh9qo-MuiGrid-root"
       >
         <div
-          class="toggle-dark-mode fgk3bh6 MuiBox-root css-0"
+          class="toggle-dark-mode f1y1dem6 MuiBox-root css-0"
         >
           <div
             class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -3792,7 +3819,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                 />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-5pr40k-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1k2yhz0-MuiTypography-root"
               >
                 Dark mode
               </span>
@@ -3808,7 +3835,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
             PerfCompare
           </h1>
           <div
-            class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-tagline css-hqwb90-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-tagline css-1nsmgxl-MuiTypography-root"
           >
             Analyze results of performance tests to detect regressions and identify opportunities for improvement.
           </div>
@@ -3825,11 +3852,11 @@ exports[`Compare With Base should remove the checked revision once X button is c
         </div>
       </div>
       <section
-        class="container_fyuz3mb"
+        class="container_fwc27mb"
         data-testid="search-section"
       >
         <span
-          class="MuiTypography-root MuiTypography-body1 search-default-title css-5pr40k-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 search-default-title css-1k2yhz0-MuiTypography-root"
         >
           Compare with a base or over time
         </span>
@@ -3839,7 +3866,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
             data-testid="base-state"
           >
             <div
-              class="compare-card-text cardText_fqwx59w"
+              class="compare-card-text cardText_fsmdlf1"
             >
               <h2
                 class="MuiTypography-root MuiTypography-h2 compare-card-title css-gja6vo-MuiTypography-root"
@@ -3875,7 +3902,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                   class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -3902,7 +3929,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                     id="base-search-container"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx  -base-dropdown css-1awobkc-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb  -base-dropdown css-1awobkc-MuiGrid-root"
                       id="base_search-dropdown"
                     >
                       <div
@@ -3943,14 +3970,14 @@ exports[`Compare With Base should remove the checked revision once X button is c
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f7qwsv0   css-17gmabg-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
                       id="base_search-input"
                     >
                       <div
                         class="MuiBox-root css-0"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+                          class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
                         >
                           <div
                             class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -4007,7 +4034,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                     data-testid="base-selected-revision"
                   >
                     <div
-                      class="box_f1wdk99e base-box MuiBox-root css-0"
+                      class="box_f9k3p52 base-box MuiBox-root css-0"
                     >
                       <ul
                         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -4019,7 +4046,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                   class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -4046,7 +4073,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                     id="new-search-container"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx  -base-dropdown css-1awobkc-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb  -base-dropdown css-1awobkc-MuiGrid-root"
                       id="new_search-dropdown"
                     >
                       <div
@@ -4087,14 +4114,14 @@ exports[`Compare With Base should remove the checked revision once X button is c
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f7qwsv0   css-17gmabg-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
                       id="new_search-input"
                     >
                       <div
                         class="MuiBox-root css-0"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+                          class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
                         >
                           <div
                             class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -4151,7 +4178,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                     data-testid="new-selected-revision"
                   >
                     <div
-                      class="box_f1wdk99e new-box MuiBox-root css-0"
+                      class="box_f9k3p52 new-box MuiBox-root css-0"
                     >
                       <ul
                         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -4160,7 +4187,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                   </div>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1sh1skx css-bwiycy-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_frp1utb css-bwiycy-MuiGrid-root"
                 >
                   <div
                     class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -4251,7 +4278,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
             data-testid="time-state"
           >
             <div
-              class="compare-card-text cardText_fqwx59w"
+              class="compare-card-text cardText_fsmdlf1"
             >
               <h2
                 class="MuiTypography-root MuiTypography-h2 compare-card-title css-gja6vo-MuiTypography-root"
@@ -4287,7 +4314,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                   class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1sh1skx css-1e9xsub-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_frp1utb css-1e9xsub-MuiGrid-root"
                   >
                     <div
                       class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -4385,7 +4412,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1sh1skx   css-1t7ybvx-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_frp1utb   css-1t7ybvx-MuiGrid-root"
                       id="time-range"
                       style="max-width: 365px;"
                     >
@@ -4439,7 +4466,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx css-13eijkh-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb css-13eijkh-MuiGrid-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -4467,7 +4494,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                     id="new-search-container--time"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx  -new-dropdown css-1awobkc-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb  -new-dropdown css-1awobkc-MuiGrid-root"
                       id="new_search-dropdown--time"
                     >
                       <div
@@ -4508,14 +4535,14 @@ exports[`Compare With Base should remove the checked revision once X button is c
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f7qwsv0   css-17gmabg-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
                       id="new_search-input--time"
                     >
                       <div
                         class="MuiBox-root css-0"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+                          class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
                         >
                           <div
                             class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -4571,7 +4598,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                     class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
                   >
                     <div
-                      class="box_f1wdk99e new-box MuiBox-root css-0"
+                      class="box_f9k3p52 new-box MuiBox-root css-0"
                     >
                       <ul
                         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -4580,7 +4607,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                   </div>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1sh1skx css-bwiycy-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_frp1utb css-bwiycy-MuiGrid-root"
                 >
                   <div
                     class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"

--- a/src/__tests__/Search/__snapshots__/SearchContainer.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchContainer.test.tsx.snap
@@ -122,7 +122,7 @@ exports[`Search Containter should match snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
                     id="base_search-input"
                   >
                     <div
@@ -266,7 +266,7 @@ exports[`Search Containter should match snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
                     id="new_search-input"
                   >
                     <div
@@ -687,7 +687,7 @@ exports[`Search Containter should match snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
                     id="new_search-input--time"
                   >
                     <div

--- a/src/__tests__/Search/__snapshots__/SearchContainer.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchContainer.test.tsx.snap
@@ -4,11 +4,11 @@ exports[`Search Containter should match snapshot 1`] = `
 <body>
   <div>
     <section
-      class="container_fyuz3mb"
+      class="container_fwc27mb"
       data-testid="search-section"
     >
       <span
-        class="MuiTypography-root MuiTypography-body1 search-default-title css-5pr40k-MuiTypography-root"
+        class="MuiTypography-root MuiTypography-body1 search-default-title css-1k2yhz0-MuiTypography-root"
       >
         Compare with a base or over time
       </span>
@@ -18,7 +18,7 @@ exports[`Search Containter should match snapshot 1`] = `
           data-testid="base-state"
         >
           <div
-            class="compare-card-text cardText_fqwx59w"
+            class="compare-card-text cardText_fsmdlf1"
           >
             <h2
               class="MuiTypography-root MuiTypography-h2 compare-card-title css-gja6vo-MuiTypography-root"
@@ -54,7 +54,7 @@ exports[`Search Containter should match snapshot 1`] = `
                 class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -81,7 +81,7 @@ exports[`Search Containter should match snapshot 1`] = `
                   id="base-search-container"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx  -base-dropdown css-1awobkc-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb  -base-dropdown css-1awobkc-MuiGrid-root"
                     id="base_search-dropdown"
                   >
                     <div
@@ -122,14 +122,14 @@ exports[`Search Containter should match snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f7qwsv0   css-17gmabg-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
                     id="base_search-input"
                   >
                     <div
                       class="MuiBox-root css-0"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+                        class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
                       >
                         <div
                           class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -186,7 +186,7 @@ exports[`Search Containter should match snapshot 1`] = `
                   data-testid="base-selected-revision"
                 >
                   <div
-                    class="box_f1wdk99e base-box MuiBox-root css-0"
+                    class="box_f9k3p52 base-box MuiBox-root css-0"
                   >
                     <ul
                       class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -198,7 +198,7 @@ exports[`Search Containter should match snapshot 1`] = `
                 class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -225,7 +225,7 @@ exports[`Search Containter should match snapshot 1`] = `
                   id="new-search-container"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx  -base-dropdown css-1awobkc-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb  -base-dropdown css-1awobkc-MuiGrid-root"
                     id="new_search-dropdown"
                   >
                     <div
@@ -266,14 +266,14 @@ exports[`Search Containter should match snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f7qwsv0   css-17gmabg-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
                     id="new_search-input"
                   >
                     <div
                       class="MuiBox-root css-0"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+                        class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
                       >
                         <div
                           class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -330,7 +330,7 @@ exports[`Search Containter should match snapshot 1`] = `
                   data-testid="new-selected-revision"
                 >
                   <div
-                    class="box_f1wdk99e new-box MuiBox-root css-0"
+                    class="box_f9k3p52 new-box MuiBox-root css-0"
                   >
                     <ul
                       class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -339,7 +339,7 @@ exports[`Search Containter should match snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1sh1skx css-bwiycy-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_frp1utb css-bwiycy-MuiGrid-root"
               >
                 <div
                   class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -430,7 +430,7 @@ exports[`Search Containter should match snapshot 1`] = `
           data-testid="time-state"
         >
           <div
-            class="compare-card-text cardText_fqwx59w"
+            class="compare-card-text cardText_fsmdlf1"
           >
             <h2
               class="MuiTypography-root MuiTypography-h2 compare-card-title css-gja6vo-MuiTypography-root"
@@ -466,7 +466,7 @@ exports[`Search Containter should match snapshot 1`] = `
                 class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1sh1skx css-1e9xsub-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_frp1utb css-1e9xsub-MuiGrid-root"
                 >
                   <div
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -564,7 +564,7 @@ exports[`Search Containter should match snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1sh1skx   css-1t7ybvx-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_frp1utb   css-1t7ybvx-MuiGrid-root"
                     id="time-range"
                     style="max-width: 365px;"
                   >
@@ -618,7 +618,7 @@ exports[`Search Containter should match snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx css-13eijkh-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb css-13eijkh-MuiGrid-root"
                 >
                   <label
                     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -646,7 +646,7 @@ exports[`Search Containter should match snapshot 1`] = `
                   id="new-search-container--time"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx  -new-dropdown css-1awobkc-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb  -new-dropdown css-1awobkc-MuiGrid-root"
                     id="new_search-dropdown--time"
                   >
                     <div
@@ -687,14 +687,14 @@ exports[`Search Containter should match snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f7qwsv0   css-17gmabg-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
                     id="new_search-input--time"
                   >
                     <div
                       class="MuiBox-root css-0"
                     >
                       <div
-                        class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+                        class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
                       >
                         <div
                           class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -750,7 +750,7 @@ exports[`Search Containter should match snapshot 1`] = `
                   class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="box_f1wdk99e new-box MuiBox-root css-0"
+                    class="box_f9k3p52 new-box MuiBox-root css-0"
                   >
                     <ul
                       class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -759,7 +759,7 @@ exports[`Search Containter should match snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1sh1skx css-bwiycy-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_frp1utb css-bwiycy-MuiGrid-root"
               >
                 <div
                   class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"

--- a/src/__tests__/Search/__snapshots__/SearchContainer.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchContainer.test.tsx.snap
@@ -122,7 +122,7 @@ exports[`Search Containter should match snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
                     id="base_search-input"
                   >
                     <div
@@ -266,7 +266,7 @@ exports[`Search Containter should match snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
                     id="new_search-input"
                   >
                     <div
@@ -408,7 +408,7 @@ exports[`Search Containter should match snapshot 1`] = `
                   class="fs9pw6x cancel-compare"
                 >
                   <button
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-pp3xxr-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-6hc3gy-MuiButtonBase-root-MuiButton-root"
                     id="compare-button"
                     tabindex="0"
                     type="submit"
@@ -566,7 +566,7 @@ exports[`Search Containter should match snapshot 1`] = `
                   <div
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_frp1utb   css-1t7ybvx-MuiGrid-root"
                     id="time-range"
-                    style="max-width: 365px;"
+                    style="max-width: 430px;"
                   >
                     <div
                       class="MuiFormControl-root timerange-dropdown f1o9jg5h css-1nrlq1o-MuiFormControl-root"
@@ -687,7 +687,7 @@ exports[`Search Containter should match snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
                     id="new_search-input--time"
                   >
                     <div
@@ -828,7 +828,7 @@ exports[`Search Containter should match snapshot 1`] = `
                   class="fs9pw6x cancel-compare"
                 >
                   <button
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-pp3xxr-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-6hc3gy-MuiButtonBase-root-MuiButton-root"
                     id="compare-button"
                     tabindex="0"
                     type="submit"

--- a/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
@@ -794,7 +794,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
                       id="base_search-input"
                     >
                       <div
@@ -1528,7 +1528,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
                       id="new_search-input"
                     >
                       <div
@@ -1949,7 +1949,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
                       id="new_search-input--time"
                     >
                       <div

--- a/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`SearchResultsList Should apply dark and light mode styles when theme button is toggled: after toggling dark mode 1`] = `
 <div
-  class="fl85orx results-list-dark MuiBox-root css-y1kcm0"
+  class="ffbezx results-list-dark MuiBox-root css-y1kcm0"
   data-testid="list-mode"
   id="search-results-list"
 >
@@ -62,10 +62,10 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
           class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
         >
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
           >
             <span
-              class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
             >
               coconut
             </span>
@@ -115,7 +115,7 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
             </div>
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
           >
             you've got no arms left! 
           </span>
@@ -178,10 +178,10 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
           class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
         >
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
           >
             <span
-              class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
             >
               spam
             </span>
@@ -231,7 +231,7 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
             </div>
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
           >
             it's just a flesh wound 
           </span>
@@ -294,10 +294,10 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
           class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
         >
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
           >
             <span
-              class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
             >
               spamspam
             </span>
@@ -347,7 +347,7 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
             </div>
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
           >
             What, ridden on a horse? 
           </span>
@@ -410,10 +410,10 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
           class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
         >
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
           >
             <span
-              class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
             >
               spamspamspam
             </span>
@@ -463,7 +463,7 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
             </div>
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
           >
             You've got two empty 'alves of coconuts and you're bangin' 'em togetha 
           </span>
@@ -526,10 +526,10 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
           class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
         >
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
           >
             <span
-              class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
             >
               spamspamspam
             </span>
@@ -579,7 +579,7 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
             </div>
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
           >
             She turned me into a newt! 
           </span>
@@ -610,7 +610,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
         class="MuiGrid-root header-container container_fllbiki css-plh9qo-MuiGrid-root"
       >
         <div
-          class="toggle-dark-mode fgk3bh6 MuiBox-root css-0"
+          class="toggle-dark-mode f1y1dem6 MuiBox-root css-0"
         >
           <div
             class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -643,7 +643,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                 />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-5pr40k-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1k2yhz0-MuiTypography-root"
               >
                 Dark mode
               </span>
@@ -659,7 +659,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
             PerfCompare
           </h1>
           <div
-            class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-tagline css-hqwb90-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-tagline css-1nsmgxl-MuiTypography-root"
           >
             Analyze results of performance tests to detect regressions and identify opportunities for improvement.
           </div>
@@ -676,11 +676,11 @@ exports[`SearchResultsList should match snapshot 1`] = `
         </div>
       </div>
       <section
-        class="container_fyuz3mb"
+        class="container_fwc27mb"
         data-testid="search-section"
       >
         <span
-          class="MuiTypography-root MuiTypography-body1 search-default-title css-5pr40k-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 search-default-title css-1k2yhz0-MuiTypography-root"
         >
           Compare with a base or over time
         </span>
@@ -690,7 +690,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
             data-testid="base-state"
           >
             <div
-              class="compare-card-text cardText_fqwx59w"
+              class="compare-card-text cardText_fsmdlf1"
             >
               <h2
                 class="MuiTypography-root MuiTypography-h2 compare-card-title css-gja6vo-MuiTypography-root"
@@ -726,7 +726,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                   class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -753,7 +753,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                     id="base-search-container"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx  -base-dropdown css-1awobkc-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb  -base-dropdown css-1awobkc-MuiGrid-root"
                       id="base_search-dropdown"
                     >
                       <div
@@ -794,14 +794,14 @@ exports[`SearchResultsList should match snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f7qwsv0   css-17gmabg-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
                       id="base_search-input"
                     >
                       <div
                         class="MuiBox-root css-0"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+                          class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
                         >
                           <div
                             class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -851,7 +851,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                           </div>
                         </div>
                         <div
-                          class="f34bwq7 results-list-light MuiBox-root css-y1kcm0"
+                          class="f1v7p2nj results-list-light MuiBox-root css-y1kcm0"
                           data-testid="list-mode"
                           id="search-results-list"
                         >
@@ -911,10 +911,10 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                   class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
                                 >
                                   <span
-                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                                   >
                                     <span
-                                      class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                                      class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                                     >
                                       coconut
                                     </span>
@@ -964,7 +964,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                     </div>
                                   </span>
                                   <span
-                                    class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                                    class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                                   >
                                     you've got no arms left! 
                                   </span>
@@ -1027,10 +1027,10 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                   class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
                                 >
                                   <span
-                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                                   >
                                     <span
-                                      class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                                      class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                                     >
                                       spam
                                     </span>
@@ -1080,7 +1080,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                     </div>
                                   </span>
                                   <span
-                                    class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                                    class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                                   >
                                     it's just a flesh wound 
                                   </span>
@@ -1143,10 +1143,10 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                   class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
                                 >
                                   <span
-                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                                   >
                                     <span
-                                      class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                                      class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                                     >
                                       spamspam
                                     </span>
@@ -1196,7 +1196,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                     </div>
                                   </span>
                                   <span
-                                    class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                                    class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                                   >
                                     What, ridden on a horse? 
                                   </span>
@@ -1259,10 +1259,10 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                   class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
                                 >
                                   <span
-                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                                   >
                                     <span
-                                      class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                                      class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                                     >
                                       spamspamspam
                                     </span>
@@ -1312,7 +1312,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                     </div>
                                   </span>
                                   <span
-                                    class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                                    class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                                   >
                                     You've got two empty 'alves of coconuts and you're bangin' 'em togetha 
                                   </span>
@@ -1375,10 +1375,10 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                   class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
                                 >
                                   <span
-                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                                   >
                                     <span
-                                      class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                                      class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                                     >
                                       spamspamspam
                                     </span>
@@ -1428,7 +1428,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                     </div>
                                   </span>
                                   <span
-                                    class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                                    class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                                   >
                                     She turned me into a newt! 
                                   </span>
@@ -1448,7 +1448,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                     data-testid="base-selected-revision"
                   >
                     <div
-                      class="box_f1wdk99e base-box MuiBox-root css-0"
+                      class="box_f9k3p52 base-box MuiBox-root css-0"
                     >
                       <ul
                         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1460,7 +1460,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                   class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1487,7 +1487,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                     id="new-search-container"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx  -base-dropdown css-1awobkc-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb  -base-dropdown css-1awobkc-MuiGrid-root"
                       id="new_search-dropdown"
                     >
                       <div
@@ -1528,14 +1528,14 @@ exports[`SearchResultsList should match snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f7qwsv0   css-17gmabg-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
                       id="new_search-input"
                     >
                       <div
                         class="MuiBox-root css-0"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+                          class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
                         >
                           <div
                             class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -1592,7 +1592,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                     data-testid="new-selected-revision"
                   >
                     <div
-                      class="box_f1wdk99e new-box MuiBox-root css-0"
+                      class="box_f9k3p52 new-box MuiBox-root css-0"
                     >
                       <ul
                         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1601,7 +1601,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1sh1skx css-bwiycy-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_frp1utb css-bwiycy-MuiGrid-root"
                 >
                   <div
                     class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -1692,7 +1692,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
             data-testid="time-state"
           >
             <div
-              class="compare-card-text cardText_fqwx59w"
+              class="compare-card-text cardText_fsmdlf1"
             >
               <h2
                 class="MuiTypography-root MuiTypography-h2 compare-card-title css-gja6vo-MuiTypography-root"
@@ -1728,7 +1728,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                   class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1sh1skx css-1e9xsub-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_frp1utb css-1e9xsub-MuiGrid-root"
                   >
                     <div
                       class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -1826,7 +1826,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1sh1skx   css-1t7ybvx-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_frp1utb   css-1t7ybvx-MuiGrid-root"
                       id="time-range"
                       style="max-width: 365px;"
                     >
@@ -1880,7 +1880,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx css-13eijkh-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb css-13eijkh-MuiGrid-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1908,7 +1908,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                     id="new-search-container--time"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx  -new-dropdown css-1awobkc-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb  -new-dropdown css-1awobkc-MuiGrid-root"
                       id="new_search-dropdown--time"
                     >
                       <div
@@ -1949,14 +1949,14 @@ exports[`SearchResultsList should match snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f7qwsv0   css-17gmabg-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
                       id="new_search-input--time"
                     >
                       <div
                         class="MuiBox-root css-0"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+                          class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
                         >
                           <div
                             class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -2012,7 +2012,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                     class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
                   >
                     <div
-                      class="box_f1wdk99e new-box MuiBox-root css-0"
+                      class="box_f9k3p52 new-box MuiBox-root css-0"
                     >
                       <ul
                         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2021,7 +2021,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1sh1skx css-bwiycy-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_frp1utb css-bwiycy-MuiGrid-root"
                 >
                   <div
                     class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"

--- a/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
@@ -664,7 +664,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
             Analyze results of performance tests to detect regressions and identify opportunities for improvement.
           </div>
           <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation learn-more-btn css-pp3xxr-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation learn-more-btn css-6hc3gy-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"
           >
@@ -794,7 +794,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
                       id="base_search-input"
                     >
                       <div
@@ -1528,7 +1528,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
                       id="new_search-input"
                     >
                       <div
@@ -1670,7 +1670,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                     class="fs9pw6x cancel-compare"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-pp3xxr-MuiButtonBase-root-MuiButton-root"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-6hc3gy-MuiButtonBase-root-MuiButton-root"
                       id="compare-button"
                       tabindex="0"
                       type="submit"
@@ -1828,7 +1828,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                     <div
                       class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_frp1utb   css-1t7ybvx-MuiGrid-root"
                       id="time-range"
-                      style="max-width: 365px;"
+                      style="max-width: 430px;"
                     >
                       <div
                         class="MuiFormControl-root timerange-dropdown f1o9jg5h css-1nrlq1o-MuiFormControl-root"
@@ -1949,7 +1949,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
                       id="new_search-input--time"
                     >
                       <div
@@ -2090,7 +2090,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                     class="fs9pw6x cancel-compare"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-pp3xxr-MuiButtonBase-root-MuiButton-root"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-6hc3gy-MuiButtonBase-root-MuiButton-root"
                       id="compare-button"
                       tabindex="0"
                       type="submit"

--- a/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
@@ -201,7 +201,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
                       id="base_search-input"
                     >
                       <div
@@ -345,7 +345,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
                       id="new_search-input"
                     >
                       <div
@@ -766,7 +766,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
                       id="new_search-input--time"
                     >
                       <div
@@ -1160,7 +1160,7 @@ exports[`With search parameters both search components are populated as expected
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="new_search-input--time"
       >
         <div
@@ -1243,7 +1243,7 @@ exports[`With search parameters both search components are populated as expected
               value="try"
             />
             <div
-              class="repo_fkd3ycy"
+              class="repo_f1akv6s4"
             >
               <div>
                 try
@@ -1296,10 +1296,10 @@ exports[`With search parameters both search components are populated as expected
                       </button>
                     </span>
                   </span>
-                  <span
+                  <div
                     class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <span
+                    <div
                       class="info-caption-item item-author"
                     >
                       <svg
@@ -1313,15 +1313,14 @@ exports[`With search parameters both search components are populated as expected
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                      <span
-                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      <div
+                        class="MuiBox-root css-1obfhg7"
                       >
                         terrygilliam@python.com
-                      </span>
-                    </span>
-                    <span
-                      class="info-caption-item item-time"
-                      style="display: flex; align-items: center; margin-left: 8px;"
+                      </div>
+                    </div>
+                    <div
+                      class="info-caption-item item-time MuiBox-root css-9mul5i"
                     >
                       <svg
                         aria-hidden="true"
@@ -1341,8 +1340,8 @@ exports[`With search parameters both search components are populated as expected
                       >
                         Jul 29, 87, 00:00 UTC
                       </div>
-                    </span>
-                  </span>
+                    </div>
+                  </div>
                 </span>
                 <span
                   class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
@@ -1541,7 +1540,7 @@ exports[`With search parameters both search components are populated as expected
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
@@ -1685,7 +1684,7 @@ exports[`With search parameters both search components are populated as expected
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
@@ -1769,7 +1768,7 @@ exports[`With search parameters both search components are populated as expected
               value="try"
             />
             <div
-              class="repo_fkd3ycy"
+              class="repo_f1akv6s4"
             >
               <div>
                 try
@@ -1822,10 +1821,10 @@ exports[`With search parameters both search components are populated as expected
                       </button>
                     </span>
                   </span>
-                  <span
+                  <div
                     class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <span
+                    <div
                       class="info-caption-item item-author"
                     >
                       <svg
@@ -1839,15 +1838,14 @@ exports[`With search parameters both search components are populated as expected
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                      <span
-                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      <div
+                        class="MuiBox-root css-1obfhg7"
                       >
                         terrygilliam@python.com
-                      </span>
-                    </span>
-                    <span
-                      class="info-caption-item item-time"
-                      style="display: flex; align-items: center; margin-left: 8px;"
+                      </div>
+                    </div>
+                    <div
+                      class="info-caption-item item-time MuiBox-root css-9mul5i"
                     >
                       <svg
                         aria-hidden="true"
@@ -1867,8 +1865,8 @@ exports[`With search parameters both search components are populated as expected
                       >
                         Jul 29, 87, 00:00 UTC
                       </div>
-                    </span>
-                  </span>
+                    </div>
+                  </div>
                 </span>
                 <span
                   class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
@@ -2220,7 +2218,7 @@ exports[`With search parameters both search components are populated as expected
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="new_search-input--time"
       >
         <div
@@ -2303,7 +2301,7 @@ exports[`With search parameters both search components are populated as expected
               value="autoland"
             />
             <div
-              class="repo_fkd3ycy"
+              class="repo_f1akv6s4"
             >
               <div>
                 autoland
@@ -2356,10 +2354,10 @@ exports[`With search parameters both search components are populated as expected
                       </button>
                     </span>
                   </span>
-                  <span
+                  <div
                     class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <span
+                    <div
                       class="info-caption-item item-author"
                     >
                       <svg
@@ -2373,15 +2371,14 @@ exports[`With search parameters both search components are populated as expected
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                      <span
-                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      <div
+                        class="MuiBox-root css-1obfhg7"
                       >
                         michaelpalin@python.com
-                      </span>
-                    </span>
-                    <span
-                      class="info-caption-item item-time"
-                      style="display: flex; align-items: center; margin-left: 8px;"
+                      </div>
+                    </div>
+                    <div
+                      class="info-caption-item item-time MuiBox-root css-9mul5i"
                     >
                       <svg
                         aria-hidden="true"
@@ -2401,8 +2398,8 @@ exports[`With search parameters both search components are populated as expected
                       >
                         Jul 4, 20, 00:00 UTC
                       </div>
-                    </span>
-                  </span>
+                    </div>
+                  </div>
                 </span>
                 <span
                   class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
@@ -2601,7 +2598,7 @@ exports[`With search parameters both search components are populated as expected
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
@@ -2745,7 +2742,7 @@ exports[`With search parameters both search components are populated as expected
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
@@ -2829,7 +2826,7 @@ exports[`With search parameters both search components are populated as expected
               value="autoland"
             />
             <div
-              class="repo_fkd3ycy"
+              class="repo_f1akv6s4"
             >
               <div>
                 autoland
@@ -2882,10 +2879,10 @@ exports[`With search parameters both search components are populated as expected
                       </button>
                     </span>
                   </span>
-                  <span
+                  <div
                     class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <span
+                    <div
                       class="info-caption-item item-author"
                     >
                       <svg
@@ -2899,15 +2896,14 @@ exports[`With search parameters both search components are populated as expected
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                      <span
-                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      <div
+                        class="MuiBox-root css-1obfhg7"
                       >
                         michaelpalin@python.com
-                      </span>
-                    </span>
-                    <span
-                      class="info-caption-item item-time"
-                      style="display: flex; align-items: center; margin-left: 8px;"
+                      </div>
+                    </div>
+                    <div
+                      class="info-caption-item item-time MuiBox-root css-9mul5i"
                     >
                       <svg
                         aria-hidden="true"
@@ -2927,8 +2923,8 @@ exports[`With search parameters both search components are populated as expected
                       >
                         Jul 4, 20, 00:00 UTC
                       </div>
-                    </span>
-                  </span>
+                    </div>
+                  </div>
                 </span>
                 <span
                   class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
@@ -3280,7 +3276,7 @@ exports[`With search parameters displays the default value for framework if the 
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="new_search-input--time"
       >
         <div
@@ -3363,7 +3359,7 @@ exports[`With search parameters displays the default value for framework if the 
               value="try"
             />
             <div
-              class="repo_fkd3ycy"
+              class="repo_f1akv6s4"
             >
               <div>
                 try
@@ -3416,10 +3412,10 @@ exports[`With search parameters displays the default value for framework if the 
                       </button>
                     </span>
                   </span>
-                  <span
+                  <div
                     class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <span
+                    <div
                       class="info-caption-item item-author"
                     >
                       <svg
@@ -3433,15 +3429,14 @@ exports[`With search parameters displays the default value for framework if the 
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                      <span
-                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      <div
+                        class="MuiBox-root css-1obfhg7"
                       >
                         terrygilliam@python.com
-                      </span>
-                    </span>
-                    <span
-                      class="info-caption-item item-time"
-                      style="display: flex; align-items: center; margin-left: 8px;"
+                      </div>
+                    </div>
+                    <div
+                      class="info-caption-item item-time MuiBox-root css-9mul5i"
                     >
                       <svg
                         aria-hidden="true"
@@ -3461,8 +3456,8 @@ exports[`With search parameters displays the default value for framework if the 
                       >
                         Jul 29, 87, 00:00 UTC
                       </div>
-                    </span>
-                  </span>
+                    </div>
+                  </div>
                 </span>
                 <span
                   class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
@@ -3661,7 +3656,7 @@ exports[`With search parameters displays the default value for framework if the 
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
@@ -3805,7 +3800,7 @@ exports[`With search parameters displays the default value for framework if the 
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
@@ -3889,7 +3884,7 @@ exports[`With search parameters displays the default value for framework if the 
               value="try"
             />
             <div
-              class="repo_fkd3ycy"
+              class="repo_f1akv6s4"
             >
               <div>
                 try
@@ -3942,10 +3937,10 @@ exports[`With search parameters displays the default value for framework if the 
                       </button>
                     </span>
                   </span>
-                  <span
+                  <div
                     class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <span
+                    <div
                       class="info-caption-item item-author"
                     >
                       <svg
@@ -3959,15 +3954,14 @@ exports[`With search parameters displays the default value for framework if the 
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                      <span
-                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      <div
+                        class="MuiBox-root css-1obfhg7"
                       >
                         terrygilliam@python.com
-                      </span>
-                    </span>
-                    <span
-                      class="info-caption-item item-time"
-                      style="display: flex; align-items: center; margin-left: 8px;"
+                      </div>
+                    </div>
+                    <div
+                      class="info-caption-item item-time MuiBox-root css-9mul5i"
                     >
                       <svg
                         aria-hidden="true"
@@ -3987,8 +3981,8 @@ exports[`With search parameters displays the default value for framework if the 
                       >
                         Jul 29, 87, 00:00 UTC
                       </div>
-                    </span>
-                  </span>
+                    </div>
+                  </div>
                 </span>
                 <span
                   class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
@@ -4340,7 +4334,7 @@ exports[`With search parameters displays the default values if some values are b
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="new_search-input--time"
       >
         <div
@@ -4574,7 +4568,7 @@ exports[`With search parameters displays the default values if some values are b
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
@@ -4718,7 +4712,7 @@ exports[`With search parameters displays the default values if some values are b
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_foodp4k css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div

--- a/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
         class="MuiGrid-root header-container container_fllbiki css-plh9qo-MuiGrid-root"
       >
         <div
-          class="toggle-dark-mode fgk3bh6 MuiBox-root css-0"
+          class="toggle-dark-mode f1y1dem6 MuiBox-root css-0"
         >
           <div
             class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -50,7 +50,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                 />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-5pr40k-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1k2yhz0-MuiTypography-root"
               >
                 Dark mode
               </span>
@@ -66,7 +66,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
             PerfCompare
           </h1>
           <div
-            class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-tagline css-hqwb90-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-tagline css-1nsmgxl-MuiTypography-root"
           >
             Analyze results of performance tests to detect regressions and identify opportunities for improvement.
           </div>
@@ -83,11 +83,11 @@ exports[`Search View renders correctly when there are no results 1`] = `
         </div>
       </div>
       <section
-        class="container_fyuz3mb"
+        class="container_fwc27mb"
         data-testid="search-section"
       >
         <span
-          class="MuiTypography-root MuiTypography-body1 search-default-title css-5pr40k-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 search-default-title css-1k2yhz0-MuiTypography-root"
         >
           Compare with a base or over time
         </span>
@@ -97,7 +97,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
             data-testid="base-state"
           >
             <div
-              class="compare-card-text cardText_fqwx59w"
+              class="compare-card-text cardText_fsmdlf1"
             >
               <h2
                 class="MuiTypography-root MuiTypography-h2 compare-card-title css-gja6vo-MuiTypography-root"
@@ -133,7 +133,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                   class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -160,7 +160,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                     id="base-search-container"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx  -base-dropdown css-1awobkc-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb  -base-dropdown css-1awobkc-MuiGrid-root"
                       id="base_search-dropdown"
                     >
                       <div
@@ -201,14 +201,14 @@ exports[`Search View renders correctly when there are no results 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f7qwsv0   css-17gmabg-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
                       id="base_search-input"
                     >
                       <div
                         class="MuiBox-root css-0"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+                          class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
                         >
                           <div
                             class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -265,7 +265,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                     data-testid="base-selected-revision"
                   >
                     <div
-                      class="box_f1wdk99e base-box MuiBox-root css-0"
+                      class="box_f9k3p52 base-box MuiBox-root css-0"
                     >
                       <ul
                         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -277,7 +277,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                   class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -304,7 +304,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                     id="new-search-container"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx  -base-dropdown css-1awobkc-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb  -base-dropdown css-1awobkc-MuiGrid-root"
                       id="new_search-dropdown"
                     >
                       <div
@@ -345,14 +345,14 @@ exports[`Search View renders correctly when there are no results 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f7qwsv0   css-17gmabg-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
                       id="new_search-input"
                     >
                       <div
                         class="MuiBox-root css-0"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+                          class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
                         >
                           <div
                             class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -409,7 +409,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                     data-testid="new-selected-revision"
                   >
                     <div
-                      class="box_f1wdk99e new-box MuiBox-root css-0"
+                      class="box_f9k3p52 new-box MuiBox-root css-0"
                     >
                       <ul
                         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -418,7 +418,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                   </div>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1sh1skx css-bwiycy-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_frp1utb css-bwiycy-MuiGrid-root"
                 >
                   <div
                     class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -509,7 +509,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
             data-testid="time-state"
           >
             <div
-              class="compare-card-text cardText_fqwx59w"
+              class="compare-card-text cardText_fsmdlf1"
             >
               <h2
                 class="MuiTypography-root MuiTypography-h2 compare-card-title css-gja6vo-MuiTypography-root"
@@ -545,7 +545,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                   class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1sh1skx css-1e9xsub-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_frp1utb css-1e9xsub-MuiGrid-root"
                   >
                     <div
                       class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -643,7 +643,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1sh1skx   css-1t7ybvx-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_frp1utb   css-1t7ybvx-MuiGrid-root"
                       id="time-range"
                       style="max-width: 365px;"
                     >
@@ -697,7 +697,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx css-13eijkh-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb css-13eijkh-MuiGrid-root"
                   >
                     <label
                       class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -725,7 +725,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                     id="new-search-container--time"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx  -new-dropdown css-1awobkc-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb  -new-dropdown css-1awobkc-MuiGrid-root"
                       id="new_search-dropdown--time"
                     >
                       <div
@@ -766,14 +766,14 @@ exports[`Search View renders correctly when there are no results 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f7qwsv0   css-17gmabg-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
                       id="new_search-input--time"
                     >
                       <div
                         class="MuiBox-root css-0"
                       >
                         <div
-                          class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+                          class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
                         >
                           <div
                             class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -829,7 +829,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                     class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
                   >
                     <div
-                      class="box_f1wdk99e new-box MuiBox-root css-0"
+                      class="box_f9k3p52 new-box MuiBox-root css-0"
                     >
                       <ul
                         class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -838,7 +838,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                   </div>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1sh1skx css-bwiycy-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_frp1utb css-bwiycy-MuiGrid-root"
                 >
                   <div
                     class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -939,7 +939,7 @@ exports[`With search parameters both search components are populated as expected
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1sh1skx css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_frp1utb css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -1037,7 +1037,7 @@ exports[`With search parameters both search components are populated as expected
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1sh1skx   css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_frp1utb   css-1t7ybvx-MuiGrid-root"
         id="time-range"
         style="max-width: 365px;"
       >
@@ -1091,7 +1091,7 @@ exports[`With search parameters both search components are populated as expected
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1119,7 +1119,7 @@ exports[`With search parameters both search components are populated as expected
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx  -new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb  -new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -1160,14 +1160,14 @@ exports[`With search parameters both search components are populated as expected
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f7qwsv0   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
         id="new_search-input--time"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -1223,7 +1223,7 @@ exports[`With search parameters both search components are populated as expected
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_f1wdk99e new-box MuiBox-root css-0"
+        class="box_f9k3p52 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1250,16 +1250,16 @@ exports[`With search parameters both search components are populated as expected
               </div>
             </div>
             <div
-              class="selectedRevision_f1h5nweo MuiBox-root css-0"
+              class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                 >
                   <span
-                    class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
@@ -1296,13 +1296,12 @@ exports[`With search parameters both search components are populated as expected
                       </button>
                     </span>
                   </span>
-                  <div
-                    class="info-caption"
+                  <span
+                    class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <div
+                    <span
                       class="info-caption-item item-author"
                     >
-                       
                       <svg
                         aria-hidden="true"
                         class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
@@ -1314,11 +1313,15 @@ exports[`With search parameters both search components are populated as expected
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                       
-                      terrygilliam@python.com
-                    </div>
-                    <div
+                      <span
+                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      >
+                        terrygilliam@python.com
+                      </span>
+                    </span>
+                    <span
                       class="info-caption-item item-time"
+                      style="display: flex; align-items: center; margin-left: 8px;"
                     >
                       <svg
                         aria-hidden="true"
@@ -1338,11 +1341,11 @@ exports[`With search parameters both search components are populated as expected
                       >
                         Jul 29, 87, 00:00 UTC
                       </div>
-                    </div>
-                  </div>
+                    </span>
+                  </span>
                 </span>
                 <span
-                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                 >
                   What, ridden on a horse? 
                 </span>
@@ -1376,7 +1379,7 @@ exports[`With search parameters both search components are populated as expected
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1sh1skx css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_frp1utb css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -1470,7 +1473,7 @@ exports[`With search parameters both search components are populated as expected
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1497,7 +1500,7 @@ exports[`With search parameters both search components are populated as expected
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx  -base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb  -base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -1538,14 +1541,14 @@ exports[`With search parameters both search components are populated as expected
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f7qwsv0   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -1602,7 +1605,7 @@ exports[`With search parameters both search components are populated as expected
       data-testid="base-selected-revision"
     >
       <div
-        class="box_f1wdk99e base-box MuiBox-root css-0"
+        class="box_f9k3p52 base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1614,7 +1617,7 @@ exports[`With search parameters both search components are populated as expected
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -1641,7 +1644,7 @@ exports[`With search parameters both search components are populated as expected
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx  -base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb  -base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -1682,14 +1685,14 @@ exports[`With search parameters both search components are populated as expected
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f7qwsv0   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -1746,7 +1749,7 @@ exports[`With search parameters both search components are populated as expected
       data-testid="new-selected-revision"
     >
       <div
-        class="box_f1wdk99e new-box MuiBox-root css-0"
+        class="box_f9k3p52 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -1773,16 +1776,16 @@ exports[`With search parameters both search components are populated as expected
               </div>
             </div>
             <div
-              class="selectedRevision_f1h5nweo MuiBox-root css-0"
+              class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                 >
                   <span
-                    class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
@@ -1819,13 +1822,12 @@ exports[`With search parameters both search components are populated as expected
                       </button>
                     </span>
                   </span>
-                  <div
-                    class="info-caption"
+                  <span
+                    class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <div
+                    <span
                       class="info-caption-item item-author"
                     >
-                       
                       <svg
                         aria-hidden="true"
                         class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
@@ -1837,11 +1839,15 @@ exports[`With search parameters both search components are populated as expected
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                       
-                      terrygilliam@python.com
-                    </div>
-                    <div
+                      <span
+                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      >
+                        terrygilliam@python.com
+                      </span>
+                    </span>
+                    <span
                       class="info-caption-item item-time"
+                      style="display: flex; align-items: center; margin-left: 8px;"
                     >
                       <svg
                         aria-hidden="true"
@@ -1861,11 +1867,11 @@ exports[`With search parameters both search components are populated as expected
                       >
                         Jul 29, 87, 00:00 UTC
                       </div>
-                    </div>
-                  </div>
+                    </span>
+                  </span>
                 </span>
                 <span
-                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                 >
                   What, ridden on a horse? 
                 </span>
@@ -1899,7 +1905,7 @@ exports[`With search parameters both search components are populated as expected
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1sh1skx css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_frp1utb css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -1993,7 +1999,7 @@ exports[`With search parameters both search components are populated as expected
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1sh1skx css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_frp1utb css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -2091,7 +2097,7 @@ exports[`With search parameters both search components are populated as expected
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1sh1skx   css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_frp1utb   css-1t7ybvx-MuiGrid-root"
         id="time-range"
         style="max-width: 365px;"
       >
@@ -2145,7 +2151,7 @@ exports[`With search parameters both search components are populated as expected
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -2173,7 +2179,7 @@ exports[`With search parameters both search components are populated as expected
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx  -new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb  -new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -2214,14 +2220,14 @@ exports[`With search parameters both search components are populated as expected
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f7qwsv0   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
         id="new_search-input--time"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -2277,7 +2283,7 @@ exports[`With search parameters both search components are populated as expected
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_f1wdk99e new-box MuiBox-root css-0"
+        class="box_f9k3p52 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2304,16 +2310,16 @@ exports[`With search parameters both search components are populated as expected
               </div>
             </div>
             <div
-              class="selectedRevision_f1h5nweo MuiBox-root css-0"
+              class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                 >
                   <span
-                    class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
@@ -2350,13 +2356,12 @@ exports[`With search parameters both search components are populated as expected
                       </button>
                     </span>
                   </span>
-                  <div
-                    class="info-caption"
+                  <span
+                    class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <div
+                    <span
                       class="info-caption-item item-author"
                     >
-                       
                       <svg
                         aria-hidden="true"
                         class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
@@ -2368,11 +2373,15 @@ exports[`With search parameters both search components are populated as expected
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                       
-                      michaelpalin@python.com
-                    </div>
-                    <div
+                      <span
+                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      >
+                        michaelpalin@python.com
+                      </span>
+                    </span>
+                    <span
                       class="info-caption-item item-time"
+                      style="display: flex; align-items: center; margin-left: 8px;"
                     >
                       <svg
                         aria-hidden="true"
@@ -2392,11 +2401,11 @@ exports[`With search parameters both search components are populated as expected
                       >
                         Jul 4, 20, 00:00 UTC
                       </div>
-                    </div>
-                  </div>
+                    </span>
+                  </span>
                 </span>
                 <span
-                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                 >
                   You've got two empty 'alves of coconuts and you're bangin' 'em togetha 
                 </span>
@@ -2430,7 +2439,7 @@ exports[`With search parameters both search components are populated as expected
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1sh1skx css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_frp1utb css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -2524,7 +2533,7 @@ exports[`With search parameters both search components are populated as expected
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -2551,7 +2560,7 @@ exports[`With search parameters both search components are populated as expected
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx  -base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb  -base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -2592,14 +2601,14 @@ exports[`With search parameters both search components are populated as expected
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f7qwsv0   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -2656,7 +2665,7 @@ exports[`With search parameters both search components are populated as expected
       data-testid="base-selected-revision"
     >
       <div
-        class="box_f1wdk99e base-box MuiBox-root css-0"
+        class="box_f9k3p52 base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2668,7 +2677,7 @@ exports[`With search parameters both search components are populated as expected
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -2695,7 +2704,7 @@ exports[`With search parameters both search components are populated as expected
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx  -base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb  -base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -2736,14 +2745,14 @@ exports[`With search parameters both search components are populated as expected
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f7qwsv0   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -2800,7 +2809,7 @@ exports[`With search parameters both search components are populated as expected
       data-testid="new-selected-revision"
     >
       <div
-        class="box_f1wdk99e new-box MuiBox-root css-0"
+        class="box_f9k3p52 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -2827,16 +2836,16 @@ exports[`With search parameters both search components are populated as expected
               </div>
             </div>
             <div
-              class="selectedRevision_f1h5nweo MuiBox-root css-0"
+              class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                 >
                   <span
-                    class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
@@ -2873,13 +2882,12 @@ exports[`With search parameters both search components are populated as expected
                       </button>
                     </span>
                   </span>
-                  <div
-                    class="info-caption"
+                  <span
+                    class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <div
+                    <span
                       class="info-caption-item item-author"
                     >
-                       
                       <svg
                         aria-hidden="true"
                         class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
@@ -2891,11 +2899,15 @@ exports[`With search parameters both search components are populated as expected
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                       
-                      michaelpalin@python.com
-                    </div>
-                    <div
+                      <span
+                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      >
+                        michaelpalin@python.com
+                      </span>
+                    </span>
+                    <span
                       class="info-caption-item item-time"
+                      style="display: flex; align-items: center; margin-left: 8px;"
                     >
                       <svg
                         aria-hidden="true"
@@ -2915,11 +2927,11 @@ exports[`With search parameters both search components are populated as expected
                       >
                         Jul 4, 20, 00:00 UTC
                       </div>
-                    </div>
-                  </div>
+                    </span>
+                  </span>
                 </span>
                 <span
-                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                 >
                   You've got two empty 'alves of coconuts and you're bangin' 'em togetha 
                 </span>
@@ -2953,7 +2965,7 @@ exports[`With search parameters both search components are populated as expected
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1sh1skx css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_frp1utb css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -3047,7 +3059,7 @@ exports[`With search parameters displays the default value for framework if the 
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1sh1skx css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_frp1utb css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -3145,7 +3157,7 @@ exports[`With search parameters displays the default value for framework if the 
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1sh1skx   css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_frp1utb   css-1t7ybvx-MuiGrid-root"
         id="time-range"
         style="max-width: 365px;"
       >
@@ -3199,7 +3211,7 @@ exports[`With search parameters displays the default value for framework if the 
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -3227,7 +3239,7 @@ exports[`With search parameters displays the default value for framework if the 
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx  -new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb  -new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -3268,14 +3280,14 @@ exports[`With search parameters displays the default value for framework if the 
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f7qwsv0   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
         id="new_search-input--time"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -3331,7 +3343,7 @@ exports[`With search parameters displays the default value for framework if the 
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_f1wdk99e new-box MuiBox-root css-0"
+        class="box_f9k3p52 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -3358,16 +3370,16 @@ exports[`With search parameters displays the default value for framework if the 
               </div>
             </div>
             <div
-              class="selectedRevision_f1h5nweo MuiBox-root css-0"
+              class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                 >
                   <span
-                    class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
@@ -3404,13 +3416,12 @@ exports[`With search parameters displays the default value for framework if the 
                       </button>
                     </span>
                   </span>
-                  <div
-                    class="info-caption"
+                  <span
+                    class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <div
+                    <span
                       class="info-caption-item item-author"
                     >
-                       
                       <svg
                         aria-hidden="true"
                         class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
@@ -3422,11 +3433,15 @@ exports[`With search parameters displays the default value for framework if the 
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                       
-                      terrygilliam@python.com
-                    </div>
-                    <div
+                      <span
+                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      >
+                        terrygilliam@python.com
+                      </span>
+                    </span>
+                    <span
                       class="info-caption-item item-time"
+                      style="display: flex; align-items: center; margin-left: 8px;"
                     >
                       <svg
                         aria-hidden="true"
@@ -3446,11 +3461,11 @@ exports[`With search parameters displays the default value for framework if the 
                       >
                         Jul 29, 87, 00:00 UTC
                       </div>
-                    </div>
-                  </div>
+                    </span>
+                  </span>
                 </span>
                 <span
-                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                 >
                   What, ridden on a horse? 
                 </span>
@@ -3484,7 +3499,7 @@ exports[`With search parameters displays the default value for framework if the 
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1sh1skx css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_frp1utb css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -3578,7 +3593,7 @@ exports[`With search parameters displays the default value for framework if the 
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -3605,7 +3620,7 @@ exports[`With search parameters displays the default value for framework if the 
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx  -base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb  -base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -3646,14 +3661,14 @@ exports[`With search parameters displays the default value for framework if the 
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f7qwsv0   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -3710,7 +3725,7 @@ exports[`With search parameters displays the default value for framework if the 
       data-testid="base-selected-revision"
     >
       <div
-        class="box_f1wdk99e base-box MuiBox-root css-0"
+        class="box_f9k3p52 base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -3722,7 +3737,7 @@ exports[`With search parameters displays the default value for framework if the 
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -3749,7 +3764,7 @@ exports[`With search parameters displays the default value for framework if the 
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx  -base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb  -base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -3790,14 +3805,14 @@ exports[`With search parameters displays the default value for framework if the 
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f7qwsv0   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -3854,7 +3869,7 @@ exports[`With search parameters displays the default value for framework if the 
       data-testid="new-selected-revision"
     >
       <div
-        class="box_f1wdk99e new-box MuiBox-root css-0"
+        class="box_f9k3p52 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -3881,16 +3896,16 @@ exports[`With search parameters displays the default value for framework if the 
               </div>
             </div>
             <div
-              class="selectedRevision_f1h5nweo MuiBox-root css-0"
+              class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
                 class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
               >
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
                 >
                   <span
-                    class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+                    class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
@@ -3927,13 +3942,12 @@ exports[`With search parameters displays the default value for framework if the 
                       </button>
                     </span>
                   </span>
-                  <div
-                    class="info-caption"
+                  <span
+                    class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
                   >
-                    <div
+                    <span
                       class="info-caption-item item-author"
                     >
-                       
                       <svg
                         aria-hidden="true"
                         class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
@@ -3945,11 +3959,15 @@ exports[`With search parameters displays the default value for framework if the 
                           d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
                         />
                       </svg>
-                       
-                      terrygilliam@python.com
-                    </div>
-                    <div
+                      <span
+                        style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+                      >
+                        terrygilliam@python.com
+                      </span>
+                    </span>
+                    <span
                       class="info-caption-item item-time"
+                      style="display: flex; align-items: center; margin-left: 8px;"
                     >
                       <svg
                         aria-hidden="true"
@@ -3969,11 +3987,11 @@ exports[`With search parameters displays the default value for framework if the 
                       >
                         Jul 29, 87, 00:00 UTC
                       </div>
-                    </div>
-                  </div>
+                    </span>
+                  </span>
                 </span>
                 <span
-                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
                 >
                   What, ridden on a horse? 
                 </span>
@@ -4007,7 +4025,7 @@ exports[`With search parameters displays the default value for framework if the 
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1sh1skx css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_frp1utb css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -4101,7 +4119,7 @@ exports[`With search parameters displays the default values if some values are b
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_f1sh1skx css-1e9xsub-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 base-repo-dropdown dropDown_frp1utb css-1e9xsub-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1ikqdgy-MuiGrid-root"
@@ -4199,7 +4217,7 @@ exports[`With search parameters displays the default values if some values are b
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_f1sh1skx   css-1t7ybvx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_frp1utb   css-1t7ybvx-MuiGrid-root"
         id="time-range"
         style="max-width: 365px;"
       >
@@ -4253,7 +4271,7 @@ exports[`With search parameters displays the default values if some values are b
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx css-13eijkh-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb css-13eijkh-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -4281,7 +4299,7 @@ exports[`With search parameters displays the default values if some values are b
       id="new-search-container--time"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx  -new-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb  -new-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown--time"
       >
         <div
@@ -4322,14 +4340,14 @@ exports[`With search parameters displays the default values if some values are b
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f7qwsv0   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
         id="new_search-input--time"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -4385,7 +4403,7 @@ exports[`With search parameters displays the default values if some values are b
       class="MuiGrid-root d-flex css-plh9qo-MuiGrid-root"
     >
       <div
-        class="box_f1wdk99e new-box MuiBox-root css-0"
+        class="box_f9k3p52 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -4394,7 +4412,7 @@ exports[`With search parameters displays the default values if some values are b
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1sh1skx css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_frp1utb css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"
@@ -4488,7 +4506,7 @@ exports[`With search parameters displays the default values if some values are b
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -4515,7 +4533,7 @@ exports[`With search parameters displays the default values if some values are b
       id="base-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_f1sh1skx  -base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 base-search-dropdown dropDown_frp1utb  -base-dropdown css-1awobkc-MuiGrid-root"
         id="base_search-dropdown"
       >
         <div
@@ -4556,14 +4574,14 @@ exports[`With search parameters displays the default values if some values are b
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f7qwsv0   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field base css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -4620,7 +4638,7 @@ exports[`With search parameters displays the default values if some values are b
       data-testid="base-selected-revision"
     >
       <div
-        class="box_f1wdk99e base-box MuiBox-root css-0"
+        class="box_f9k3p52 base-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -4632,7 +4650,7 @@ exports[`With search parameters displays the default values if some values are b
     class="MuiGrid-root component_fr4vqnw css-plh9qo-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx label-edit-wrapper css-dhs41p-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb label-edit-wrapper css-dhs41p-MuiGrid-root"
     >
       <label
         class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated dropdown-select-label css-qru5ho-MuiFormLabel-root-MuiInputLabel-root"
@@ -4659,7 +4677,7 @@ exports[`With search parameters displays the default values if some values are b
       id="new-search-container"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_f1sh1skx  -base-dropdown css-1awobkc-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 new-search-dropdown dropDown_frp1utb  -base-dropdown css-1awobkc-MuiGrid-root"
         id="new_search-dropdown"
       >
         <div
@@ -4700,14 +4718,14 @@ exports[`With search parameters displays the default values if some values are b
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f7qwsv0   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
           class="MuiBox-root css-0"
         >
           <div
-            class="MuiFormControl-root MuiFormControl-fullWidth f6q7umf css-q8hpuo-MuiFormControl-root"
+            class="MuiFormControl-root MuiFormControl-fullWidth f7lnopv css-q8hpuo-MuiFormControl-root"
           >
             <div
               class="MuiFormControl-root MuiTextField-root search-text-field new css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
@@ -4764,7 +4782,7 @@ exports[`With search parameters displays the default values if some values are b
       data-testid="new-selected-revision"
     >
       <div
-        class="box_f1wdk99e new-box MuiBox-root css-0"
+        class="box_f9k3p52 new-box MuiBox-root css-0"
       >
         <ul
           class="MuiList-root MuiList-padding css-h4y409-MuiList-root"
@@ -4773,7 +4791,7 @@ exports[`With search parameters displays the default values if some values are b
     </div>
   </div>
   <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_f1sh1skx css-bwiycy-MuiGrid-root"
+    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-2 dropDown_frp1utb css-bwiycy-MuiGrid-root"
   >
     <div
       class="MuiFormControl-root framework-dropdown f1ttr4cl css-1nrlq1o-MuiFormControl-root"

--- a/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
@@ -71,7 +71,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
             Analyze results of performance tests to detect regressions and identify opportunities for improvement.
           </div>
           <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation learn-more-btn css-pp3xxr-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation learn-more-btn css-6hc3gy-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"
           >
@@ -201,7 +201,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
                       id="base_search-input"
                     >
                       <div
@@ -345,7 +345,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
                       id="new_search-input"
                     >
                       <div
@@ -487,7 +487,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                     class="fs9pw6x cancel-compare"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-pp3xxr-MuiButtonBase-root-MuiButton-root"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-6hc3gy-MuiButtonBase-root-MuiButton-root"
                       id="compare-button"
                       tabindex="0"
                       type="submit"
@@ -645,7 +645,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                     <div
                       class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_frp1utb   css-1t7ybvx-MuiGrid-root"
                       id="time-range"
-                      style="max-width: 365px;"
+                      style="max-width: 430px;"
                     >
                       <div
                         class="MuiFormControl-root timerange-dropdown f1o9jg5h css-1nrlq1o-MuiFormControl-root"
@@ -766,7 +766,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
                       id="new_search-input--time"
                     >
                       <div
@@ -907,7 +907,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                     class="fs9pw6x cancel-compare"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-pp3xxr-MuiButtonBase-root-MuiButton-root"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-6hc3gy-MuiButtonBase-root-MuiButton-root"
                       id="compare-button"
                       tabindex="0"
                       type="submit"
@@ -1039,7 +1039,7 @@ exports[`With search parameters both search components are populated as expected
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_frp1utb   css-1t7ybvx-MuiGrid-root"
         id="time-range"
-        style="max-width: 365px;"
+        style="max-width: 430px;"
       >
         <div
           class="MuiFormControl-root timerange-dropdown f1o9jg5h css-1nrlq1o-MuiFormControl-root"
@@ -1160,7 +1160,7 @@ exports[`With search parameters both search components are populated as expected
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
         id="new_search-input--time"
       >
         <div
@@ -1448,7 +1448,7 @@ exports[`With search parameters both search components are populated as expected
       class="fs9pw6x cancel-compare"
     >
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-pp3xxr-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-6hc3gy-MuiButtonBase-root-MuiButton-root"
         id="compare-button"
         tabindex="0"
         type="submit"
@@ -1541,7 +1541,7 @@ exports[`With search parameters both search components are populated as expected
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
@@ -1685,7 +1685,7 @@ exports[`With search parameters both search components are populated as expected
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
@@ -1974,7 +1974,7 @@ exports[`With search parameters both search components are populated as expected
       class="fs9pw6x cancel-compare"
     >
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-pp3xxr-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-6hc3gy-MuiButtonBase-root-MuiButton-root"
         id="compare-button"
         tabindex="0"
         type="submit"
@@ -2099,7 +2099,7 @@ exports[`With search parameters both search components are populated as expected
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_frp1utb   css-1t7ybvx-MuiGrid-root"
         id="time-range"
-        style="max-width: 365px;"
+        style="max-width: 430px;"
       >
         <div
           class="MuiFormControl-root timerange-dropdown f1o9jg5h css-1nrlq1o-MuiFormControl-root"
@@ -2220,7 +2220,7 @@ exports[`With search parameters both search components are populated as expected
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
         id="new_search-input--time"
       >
         <div
@@ -2508,7 +2508,7 @@ exports[`With search parameters both search components are populated as expected
       class="fs9pw6x cancel-compare"
     >
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-pp3xxr-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-6hc3gy-MuiButtonBase-root-MuiButton-root"
         id="compare-button"
         tabindex="0"
         type="submit"
@@ -2601,7 +2601,7 @@ exports[`With search parameters both search components are populated as expected
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
@@ -2745,7 +2745,7 @@ exports[`With search parameters both search components are populated as expected
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
@@ -3034,7 +3034,7 @@ exports[`With search parameters both search components are populated as expected
       class="fs9pw6x cancel-compare"
     >
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-pp3xxr-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-6hc3gy-MuiButtonBase-root-MuiButton-root"
         id="compare-button"
         tabindex="0"
         type="submit"
@@ -3159,7 +3159,7 @@ exports[`With search parameters displays the default value for framework if the 
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_frp1utb   css-1t7ybvx-MuiGrid-root"
         id="time-range"
-        style="max-width: 365px;"
+        style="max-width: 430px;"
       >
         <div
           class="MuiFormControl-root timerange-dropdown f1o9jg5h css-1nrlq1o-MuiFormControl-root"
@@ -3280,7 +3280,7 @@ exports[`With search parameters displays the default value for framework if the 
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
         id="new_search-input--time"
       >
         <div
@@ -3568,7 +3568,7 @@ exports[`With search parameters displays the default value for framework if the 
       class="fs9pw6x cancel-compare"
     >
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-pp3xxr-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-6hc3gy-MuiButtonBase-root-MuiButton-root"
         id="compare-button"
         tabindex="0"
         type="submit"
@@ -3661,7 +3661,7 @@ exports[`With search parameters displays the default value for framework if the 
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
@@ -3805,7 +3805,7 @@ exports[`With search parameters displays the default value for framework if the 
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
@@ -4094,7 +4094,7 @@ exports[`With search parameters displays the default value for framework if the 
       class="fs9pw6x cancel-compare"
     >
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-pp3xxr-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-6hc3gy-MuiButtonBase-root-MuiButton-root"
         id="compare-button"
         tabindex="0"
         type="submit"
@@ -4219,7 +4219,7 @@ exports[`With search parameters displays the default values if some values are b
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true new-search-dropdown  dropDown_frp1utb   css-1t7ybvx-MuiGrid-root"
         id="time-range"
-        style="max-width: 365px;"
+        style="max-width: 430px;"
       >
         <div
           class="MuiFormControl-root timerange-dropdown f1o9jg5h css-1nrlq1o-MuiFormControl-root"
@@ -4340,7 +4340,7 @@ exports[`With search parameters displays the default values if some values are b
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input--time  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
         id="new_search-input--time"
       >
         <div
@@ -4481,7 +4481,7 @@ exports[`With search parameters displays the default values if some values are b
       class="fs9pw6x cancel-compare"
     >
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-pp3xxr-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-6hc3gy-MuiButtonBase-root-MuiButton-root"
         id="compare-button"
         tabindex="0"
         type="submit"
@@ -4574,7 +4574,7 @@ exports[`With search parameters displays the default values if some values are b
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 base-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
         id="base_search-input"
       >
         <div
@@ -4718,7 +4718,7 @@ exports[`With search parameters displays the default values if some values are b
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f18mez9x   css-17gmabg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-7 new-search-input  baseSearchInput_f1yel07   css-17gmabg-MuiGrid-root"
         id="new_search-input"
       >
         <div
@@ -4860,7 +4860,7 @@ exports[`With search parameters displays the default values if some values are b
       class="fs9pw6x cancel-compare"
     >
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-pp3xxr-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-disableElevation css-6hc3gy-MuiButtonBase-root-MuiButton-root"
         id="compare-button"
         tabindex="0"
         type="submit"

--- a/src/__tests__/Search/__snapshots__/SelectedRevision.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SelectedRevision.test.tsx.snap
@@ -23,16 +23,16 @@ exports[`SelectedRevision should show the selected checked revisions once a resu
     </div>
   </div>
   <div
-    class="selectedRevision_f1h5nweo MuiBox-root css-0"
+    class="selectedRevision_fubtarc MuiBox-root css-0"
   >
     <div
       class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-konndc-MuiListItemText-root"
     >
       <span
-        class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-4q8oy7-MuiTypography-root"
+        class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-7p9rhm-MuiTypography-root"
       >
         <span
-          class="MuiTypography-root MuiTypography-body2 revision-hash css-eqisi8-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body2 revision-hash css-1kaxyiw-MuiTypography-root"
         >
           <a
             class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1qhous5-MuiTypography-root-MuiLink-root"
@@ -69,13 +69,12 @@ exports[`SelectedRevision should show the selected checked revisions once a resu
             </button>
           </span>
         </span>
-        <div
-          class="info-caption"
+        <span
+          class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
         >
-          <div
+          <span
             class="info-caption-item item-author"
           >
-             
             <svg
               aria-hidden="true"
               class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-1mecf1h-MuiSvgIcon-root"
@@ -87,11 +86,15 @@ exports[`SelectedRevision should show the selected checked revisions once a resu
                 d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
               />
             </svg>
-             
-            johncleese@python.com
-          </div>
-          <div
+            <span
+              style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+            >
+              johncleese@python.com
+            </span>
+          </span>
+          <span
             class="info-caption-item item-time"
+            style="display: flex; align-items: center; margin-left: 8px;"
           >
             <svg
               aria-hidden="true"
@@ -111,11 +114,11 @@ exports[`SelectedRevision should show the selected checked revisions once a resu
             >
               Mar 29, 51, 00:00 UTC
             </div>
-          </div>
-        </div>
+          </span>
+        </span>
       </span>
       <span
-        class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-jxfi63-MuiTypography-root"
+        class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"
       >
         you've got no arms left! 
       </span>

--- a/src/__tests__/Search/__snapshots__/SelectedRevision.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SelectedRevision.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`SelectedRevision should show the selected checked revisions once a resu
     value="try"
   />
   <div
-    class="repo_fkd3ycy"
+    class="repo_f1akv6s4"
   >
     <div>
       try
@@ -69,10 +69,10 @@ exports[`SelectedRevision should show the selected checked revisions once a resu
             </button>
           </span>
         </span>
-        <span
+        <div
           class="MuiTypography-root MuiTypography-body2 info-caption css-1e2mg7s-MuiTypography-root"
         >
-          <span
+          <div
             class="info-caption-item item-author"
           >
             <svg
@@ -86,15 +86,14 @@ exports[`SelectedRevision should show the selected checked revisions once a resu
                 d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"
               />
             </svg>
-            <span
-              style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden; display: inline-block; max-width: 100%;"
+            <div
+              class="MuiBox-root css-1obfhg7"
             >
               johncleese@python.com
-            </span>
-          </span>
-          <span
-            class="info-caption-item item-time"
-            style="display: flex; align-items: center; margin-left: 8px;"
+            </div>
+          </div>
+          <div
+            class="info-caption-item item-time MuiBox-root css-9mul5i"
           >
             <svg
               aria-hidden="true"
@@ -114,8 +113,8 @@ exports[`SelectedRevision should show the selected checked revisions once a resu
             >
               Mar 29, 51, 00:00 UTC
             </div>
-          </span>
-        </span>
+          </div>
+        </div>
       </span>
       <span
         class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-16ejnil-MuiTypography-root"

--- a/src/__tests__/__snapshots__/App.test.tsx.snap
+++ b/src/__tests__/__snapshots__/App.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
         class="MuiGrid-root header-container container_f1ocj467 css-plh9qo-MuiGrid-root"
       >
         <div
-          class="toggle-dark-mode fgk3bh6 MuiBox-root css-0"
+          class="toggle-dark-mode f1y1dem6 MuiBox-root css-0"
         >
           <div
             class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -96,7 +96,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
                 />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-5pr40k-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1k2yhz0-MuiTypography-root"
               >
                 Dark mode
               </span>
@@ -114,7 +114,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
         </div>
       </div>
       <section
-        class="container_fdgf30v"
+        class="container_f1h7ern2"
       >
         <a
           aria-label="link to home"
@@ -321,7 +321,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
         class="MuiGrid-root header-container container_f1ocj467 css-plh9qo-MuiGrid-root"
       >
         <div
-          class="toggle-dark-mode fgk3bh6 MuiBox-root css-0"
+          class="toggle-dark-mode f1y1dem6 MuiBox-root css-0"
         >
           <div
             class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -354,7 +354,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
                 />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-5pr40k-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1k2yhz0-MuiTypography-root"
               >
                 Dark mode
               </span>
@@ -372,7 +372,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
         </div>
       </div>
       <section
-        class="container_fdgf30v"
+        class="container_f1h7ern2"
       >
         <a
           aria-label="link to home"
@@ -474,7 +474,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
         class="MuiGrid-root header-container container_f1ocj467 css-plh9qo-MuiGrid-root"
       >
         <div
-          class="toggle-dark-mode fgk3bh6 MuiBox-root css-0"
+          class="toggle-dark-mode f1y1dem6 MuiBox-root css-0"
         >
           <div
             class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -507,7 +507,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
                 />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-5pr40k-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1k2yhz0-MuiTypography-root"
               >
                 Dark mode
               </span>
@@ -525,7 +525,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
         </div>
       </div>
       <section
-        class="container_fdgf30v"
+        class="container_f1h7ern2"
       >
         <a
           aria-label="link to home"

--- a/src/components/Search/SearchComponent.tsx
+++ b/src/components/Search/SearchComponent.tsx
@@ -103,9 +103,7 @@ function SearchComponent({
           item
           xs={7}
           id={`${searchType}_search-input`}
-          className={`${searchType}-search-input  ${styles.baseSearchInput} ${
-            hasEditButton ? 'big' : ''
-          } `}
+          className={`${searchType}-search-input  ${styles.baseSearchInput}`}
         >
           <SearchInputAndResults
             compact={hasEditButton}

--- a/src/components/Search/SearchOverTime.tsx
+++ b/src/components/Search/SearchOverTime.tsx
@@ -274,9 +274,7 @@ export default function SearchOverTime({
             item
             xs={7}
             id='new_search-input--time'
-            className={`new-search-input--time  ${styles.baseSearchInput} ${
-              hasEditButton ? 'big' : ''
-            } `}
+            className={`new-search-input--time  ${styles.baseSearchInput}`}
           >
             <SearchInputAndResults
               compact={hasEditButton}

--- a/src/components/Search/SearchOverTime.tsx
+++ b/src/components/Search/SearchOverTime.tsx
@@ -71,6 +71,9 @@ export default function SearchOverTime({
     padding: '6px 12px 6px 16px',
   });
 
+  const maxWidthTimeRangeL = '430px';
+  const maxWidthTimeRangeS = '365px';
+
   return (
     <Grid className={styles.component}>
       {/**** Base - Time-Range Labels ****/}
@@ -130,7 +133,9 @@ export default function SearchOverTime({
           <Grid
             item
             xs
-            style={{ maxWidth: hasEditButton ? '415px' : '365px' }}
+            style={{
+              maxWidth: hasEditButton ? maxWidthTimeRangeL : maxWidthTimeRangeS,
+            }}
             className={`base-search-dropdown ${readOnlyStyles} ${
               styles.dropDown
             }  ${hasEditButton ? compareOverTimeView : ''}-base-dropdown`}
@@ -148,7 +153,9 @@ export default function SearchOverTime({
           <Grid
             item
             xs
-            style={{ maxWidth: hasEditButton ? '415px' : '365px' }}
+            style={{
+              maxWidth: hasEditButton ? maxWidthTimeRangeL : maxWidthTimeRangeS,
+            }}
             className={`new-search-dropdown  ${readOnlyStyles}`}
           >
             <div style={{ display: 'flex', justifyContent: 'space-between' }}>
@@ -185,7 +192,9 @@ export default function SearchOverTime({
           <Grid
             item
             xs
-            style={{ maxWidth: hasEditButton ? '415px' : '365px' }}
+            style={{
+              maxWidth: hasEditButton ? maxWidthTimeRangeL : maxWidthTimeRangeS,
+            }}
             id='base_search-dropdown--time'
             className='base-search-dropdown'
           >
@@ -204,7 +213,7 @@ export default function SearchOverTime({
             item
             xs
             id='time-range'
-            style={{ maxWidth: hasEditButton ? '415px' : '365px' }}
+            style={{ maxWidth: maxWidthTimeRangeL }}
             className={`new-search-dropdown ${hasEditButton ? 'small' : ''} ${
               styles.dropDown
             }  `}

--- a/src/components/Search/SelectedRevisionItem.tsx
+++ b/src/components/Search/SelectedRevisionItem.tsx
@@ -99,23 +99,43 @@ function SelectedRevisionItem({
                 />
               </Typography>
 
-              <div className='info-caption'>
-                <div className='info-caption-item item-author'>
-                  {' '}
+              <Typography
+                component='span'
+                variant='body2'
+                className='info-caption'
+              >
+                <span className='info-caption-item item-author'>
                   <MailOutlineOutlinedIcon
                     className='mail-icon'
                     fontSize='small'
-                  />{' '}
-                  {item.author}
-                </div>
-                <div className='info-caption-item item-time'>
+                  />
+                  <span
+                    style={{
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      overflow: 'hidden',
+                      display: 'inline-block',
+                      maxWidth: '100%',
+                    }}
+                  >
+                    {item.author}
+                  </span>
+                </span>
+                <span
+                  className='info-caption-item item-time'
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    marginLeft: '8px',
+                  }}
+                >
                   <AccessTimeOutlinedIcon
                     className='time-icon'
                     fontSize='small'
                   />
                   <DateTimeDisplay itemDate={itemDate} />
-                </div>
-              </div>
+                </span>
+              </Typography>
             </React.Fragment>
           }
           secondary={`${commitMessage} `}

--- a/src/components/Search/SelectedRevisionItem.tsx
+++ b/src/components/Search/SelectedRevisionItem.tsx
@@ -100,17 +100,17 @@ function SelectedRevisionItem({
               </Typography>
 
               <Typography
-                component='span'
+                component='div'
                 variant='body2'
                 className='info-caption'
               >
-                <span className='info-caption-item item-author'>
+                <div className='info-caption-item item-author'>
                   <MailOutlineOutlinedIcon
                     className='mail-icon'
                     fontSize='small'
                   />
-                  <span
-                    style={{
+                  <Box
+                    sx={{
                       textOverflow: 'ellipsis',
                       whiteSpace: 'nowrap',
                       overflow: 'hidden',
@@ -119,11 +119,11 @@ function SelectedRevisionItem({
                     }}
                   >
                     {item.author}
-                  </span>
-                </span>
-                <span
+                  </Box>
+                </div>
+                <Box
                   className='info-caption-item item-time'
-                  style={{
+                  sx={{
                     display: 'flex',
                     alignItems: 'center',
                     marginLeft: '8px',
@@ -134,7 +134,7 @@ function SelectedRevisionItem({
                     fontSize='small'
                   />
                   <DateTimeDisplay itemDate={itemDate} />
-                </span>
+                </Box>
               </Typography>
             </React.Fragment>
           }

--- a/src/styles/CompareCards.ts
+++ b/src/styles/CompareCards.ts
@@ -192,7 +192,7 @@ export const SearchStyles = (mode: string) => {
       left: '288px',
       $nest: {
         '&.big': {
-          left: '212px',
+          left: '276px',
           minWidth: `${850 - repoDropdownWidth - Spacing.Default}px`,
         },
         '&.base-search-input--mobile, &.new-search-input--mobile': {

--- a/src/styles/CompareCards.ts
+++ b/src/styles/CompareCards.ts
@@ -20,7 +20,8 @@ const textDarkMode = {
   color: `${Colors.PrimaryTextDark} !important`,
 };
 
-const repoDropdownWidth = 200;
+const repoDropdownWidth = 239;
+const searchInputWidth = 588;
 
 export const CompareCardsStyles = (mode: string) => {
   const isTrueLight = mode == 'light' ? true : false;
@@ -186,9 +187,9 @@ export const SearchStyles = (mode: string) => {
     },
 
     baseSearchInput: {
-      minWidth: '530px',
+      minWidth: `${searchInputWidth}px`,
       position: 'absolute',
-      left: '220px',
+      left: '288px',
       $nest: {
         '&.big': {
           left: '212px',

--- a/src/styles/CompareCards.ts
+++ b/src/styles/CompareCards.ts
@@ -191,10 +191,6 @@ export const SearchStyles = (mode: string) => {
       position: 'absolute',
       left: '288px',
       $nest: {
-        '&.big': {
-          left: '276px',
-          minWidth: `${850 - repoDropdownWidth - Spacing.Default}px`,
-        },
         '&.base-search-input--mobile, &.new-search-input--mobile': {
           position: 'unset',
         },

--- a/src/styles/Fonts.ts
+++ b/src/styles/Fonts.ts
@@ -17,11 +17,32 @@ const sharedFontStyles = {
   fontStyle: 'normal',
 };
 
+export const FontSizeRaw = {
+  xSmall: {
+    fontSize: `${12 / 16}rem`,
+  },
+  Small: {
+    fontSize: `${14 / 16}rem`,
+  },
+  Normal: {
+    fontSize: '1rem',
+  },
+  Large: {
+    fontSize: `${18 / 16}rem`,
+  },
+  xLarge: {
+    fontSize: `${20 / 16}rem`,
+  },
+  xxLarge: {
+    fontSize: `${24 / 16}rem`,
+  },
+};
+
 export const FontsRaw = {
   HeadingDefault: {
     ...sharedFontStyles,
     fontWeight: '600',
-    fontSize: '17px',
+    fontSize: FontSizeRaw.Large.fontSize,
     fontFamily: 'SF Pro',
     fontStyle: 'normal',
   },
@@ -35,7 +56,7 @@ export const FontsRaw = {
   BodyDefault: {
     ...sharedFontStyles,
     fontWeight: '400',
-    fontSize: '16px',
+    fontSize: FontSizeRaw.Normal.fontSize,
     fontFamily: 'SF Pro',
   },
 
@@ -57,7 +78,7 @@ export const FontsRaw = {
   BodyDefaultDark: {
     ...sharedFontStyles,
     fontWeight: '400',
-    fontSize: '14px',
+    fontSize: FontSizeRaw.Normal.fontSize,
     fontFamily: 'SF Pro',
   },
 };
@@ -69,27 +90,6 @@ export const Fonts = {
   HeadingDefaultDark: style(FontsRaw.HeadingDefaultDark),
   HeadingXSDark: style(FontsRaw.HeadingXSDark),
   BodyDefaultDark: style(FontsRaw.BodyDefaultDark),
-};
-
-export const FontSizeRaw = {
-  xSmall: {
-    fontSize: `${12 / 16}rem`,
-  },
-  Small: {
-    fontSize: `${14 / 16}rem`,
-  },
-  Normal: {
-    fontSize: '1rem',
-  },
-  Large: {
-    fontSize: `${18 / 16}rem`,
-  },
-  xLarge: {
-    fontSize: `${20 / 16}rem`,
-  },
-  xxLarge: {
-    fontSize: `${24 / 16}rem`,
-  },
 };
 
 export const FontSize = {

--- a/src/styles/SearchContainerStyles.ts
+++ b/src/styles/SearchContainerStyles.ts
@@ -7,7 +7,9 @@ export const SearchContainerStyles = (mode: string, isHome: boolean) => {
 
   const styles = stylesheet({
     container: {
-      maxWidth: isHome ? '850px' : '950px',
+      /*** maxWidth based on mozilla protocol large cards size; see https://protocol.mozilla.org/components/detail/card--large
+       ***/
+      maxWidth: '973px',
       marginTop: isHome ? `${Spacing.layoutLarge + 20}px` : '0px',
       margin: '0 auto',
       marginBottom: isHome ? '0px' : `${Spacing.layoutXLarge + 4}px`,

--- a/src/styles/SelectedRevsStyle.ts
+++ b/src/styles/SelectedRevsStyle.ts
@@ -62,6 +62,7 @@ export const SelectRevsStyles = (mode: string) => {
         '.search-revision-item-text': {
           margin: 0,
           flex: 1,
+          fontSize: FontSizeRaw.Normal.fontSize,
         },
 
         '.revision-hash': {
@@ -80,8 +81,10 @@ export const SelectRevsStyles = (mode: string) => {
           flexGrow: 1,
         },
         '.info-caption': {
-          flex: 2,
-          textAlign: 'right',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          maxWidth: '100%',
+          marginLeft: `${Spacing.Small}px`,
           ...(isTrueLight ? captionStylesLight : captionStylesDark),
           fontSize: FontSizeRaw.Normal.fontSize,
           $nest: {
@@ -97,6 +100,8 @@ export const SelectRevsStyles = (mode: string) => {
               fontSize: '1rem',
             },
             '.item-author': {
+              maxWidth: '100%',
+              overflow: 'hidden',
               marginRight: `${Spacing.xSmall + 1}px`,
             },
           },

--- a/src/styles/SelectedRevsStyle.ts
+++ b/src/styles/SelectedRevsStyle.ts
@@ -42,7 +42,7 @@ export const SelectRevsStyles = (mode: string) => {
     },
 
     repo: {
-      minWidth: '125px',
+      minWidth: '275px',
       display: 'flex',
       $nest: {
         '.warning-icon': {

--- a/src/theme/components.js
+++ b/src/theme/components.js
@@ -152,7 +152,7 @@ const components = {
         ...FontsRaw.BodyDefault,
         lineHeight: '1.5',
       },
-      body2: { fontSize: '16px' },
+      body2: { fontSize: FontSizeRaw.Normal.fontSize },
       root: {
         '&.perfcompare-header': {
           '&:after': {

--- a/src/theme/components.js
+++ b/src/theme/components.js
@@ -32,7 +32,7 @@ const components = {
           width: '100%',
           justifyContent: 'end',
           fontSize: FontSizeRaw.xSmall.fontSize,
-          maxWidth: '100px',
+          maxWidth: '105px',
           padding: `${Spacing.xSmall}px ${Spacing.Small}px`,
           backgroundColor: 'transparent',
           '&:hover': {


### PR DESCRIPTION
The latest deploy included some major font size UI bugs. This PR aims to fix these bugs.
Once this is approved, I'll go ahead and deploy to make sure production includes these changes. 

[Production Link](https://perf.compare/compare-results?baseRev=1e0be90a5631ba3c6f5f7f5e9b031bb0f635fe36&baseRepo=try&newRev=8ac2379c2250aff50be8b4c1c18b6344e92d399c&newRepo=try&framework=1)

<img width="1045" alt="Screenshot 2025-04-09 at 12 10 34" src="https://github.com/user-attachments/assets/7c00fe94-eda3-4bd2-8ed9-2764c425a1c6" />

<img width="997" alt="Screenshot 2025-04-09 at 14 10 59" src="https://github.com/user-attachments/assets/00a5099c-9902-471a-83b9-0fef84a37aee" />

<img width="1207" alt="Screenshot 2025-04-09 at 14 26 13" src="https://github.com/user-attachments/assets/db0c3fb5-2e6a-462c-992d-7f5cd76f4b47" />

<img width="1085" alt="Screenshot 2025-04-09 at 14 29 47" src="https://github.com/user-attachments/assets/1fb3a1c1-ab3c-4c7f-b8f1-57882f820a88" />

*********************************

[Deploy Link](https://deploy-preview-873--mozilla-perfcompare.netlify.app/compare-results?baseRev=1e0be90a5631ba3c6f5f7f5e9b031bb0f635fe36&baseRepo=try&newRev=8ac2379c2250aff50be8b4c1c18b6344e92d399c&newRepo=try&framework=1)

### [Commit 1: Fix the font bugs for Compare with a base](https://github.com/mozilla/perfcompare/pull/873/commits/89701547d9241affaa1404b1b81d9ce19d126bb9)

<img width="986" alt="Screenshot 2025-04-09 at 14 06 07" src="https://github.com/user-attachments/assets/f01d98f5-8c13-45fe-abad-15cc0b002835" />


Details:
- [x] increase widths of the container, dropdowns, inputs to accommodate new font-size
- [x] enable ellipses for long email addresses
- [x] consistent font sizes throughout for body text 


### [Commit 2 Fix the widths for Compare over time and Results page selected revisions](https://github.com/mozilla/perfcompare/pull/873/commits/80c9605c125dd500971043c42a66de99816644c4)

<img width="1033" alt="Screenshot 2025-04-09 at 14 49 56" src="https://github.com/user-attachments/assets/a9946000-93a9-4535-92dc-bd6d00051da3" />

<img width="1147" alt="Screenshot 2025-04-09 at 14 33 46" src="https://github.com/user-attachments/assets/ae55a1b3-6f47-4ef4-a7fe-23e2a45830c0" />

<img width="1112" alt="Screenshot 2025-04-09 at 14 36 19" src="https://github.com/user-attachments/assets/cf638609-5b65-4a0d-b13a-7770bb71aaef" />
