### PR TITLE
Bug 1962486 - Optimize and create new perfcompare loader

### DIFF
--- a/src/__tests__/Search/fetchRevisionFromHash.test.tsx
+++ b/src/__tests__/Search/fetchRevisionFromHash.test.tsx
@@ -2,6 +2,36 @@ import App, { router } from '../../components/App';
 import { FetchMockSandbox, render } from '../utils/test-utils';
 
 describe('Hash to commit good run validating', () => {
+  it('Should return a baseRev not found if we return a null baseRev', async () => {
+    // Silence console.error for a better console output. We'll check its result later.
+    // If an expectation toHaveBeenCalledTimes fails, it might be easier to
+    // remove the mockImplementation part to debug.
+
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    (global.fetch as FetchMockSandbox).get(
+      'glob:https://treeherder.mozilla.org/api/project/*/hash/*',
+      (url) => {
+        return url.includes('tocommit')
+          ? {
+              baseRevision: null,
+              newRevision: 'Another',
+            }
+          : {};
+      },
+    );
+
+    // Error 1: no baseRev
+    await router.navigate(
+      '/compare-hash-results?baseHash=7844063918536384434&baseRepo=try&newHash=83782697878z014813466&newHashDate=03-20-2025&baseHashDate=03-20-2025&newRepo=try&framework=1',
+    );
+    render(<App />);
+    expect(console.error).toHaveBeenCalledWith(
+      new Error('The parameter baseRev is missing.'),
+    );
+    expect(console.error).toHaveBeenCalledTimes(1);
+    (console.error as jest.Mock).mockClear();
+  });
+
   it('should reject hashes not associated with any commits', async () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -18,7 +48,7 @@ describe('Hash to commit good run validating', () => {
     );
 
     await router.navigate(
-      '/compare-results?baseHash=7844063918536384434&baseRepo=try&newHash=83782697878014813466&newRepo=try&framework=1',
+      '/compare-hash-results?baseHash=7844063918536384434&baseRepo=try&newHash=83782697878z014813466&newHashDate=03-20-2025&baseHashDate=03-20-2025&newRepo=try&framework=1',
     );
     render(<App />);
     // Expecting to have a hashes do not correlate with revision error
@@ -31,29 +61,46 @@ describe('Hash to commit good run validating', () => {
     (console.error as jest.Mock).mockClear();
   });
 
-  it('should reject invalid results returned from treeherder', async () => {
+  it('should display a different error message if the datehash is today and not found', async () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
 
     (global.fetch as FetchMockSandbox).get(
       'glob:https://treeherder.mozilla.org/api/project/*/hash/*',
-      (url) => {
-        return url.includes('tocommit')
+      (url) =>
+        url.includes('tocommit')
           ? {
-              badbaseRevision: 'Press',
-              newRevision: 'Another',
+              throws: new Error(
+                'Error when requesting treeherder: ["83782697878014813466 or 7844063918536384434 do not correspond to any existing hashes please double check both hashes you provided"]',
+              ),
             }
-          : {};
-      },
+          : {},
     );
 
     await router.navigate(
-      '/compare-results?baseHash=7844063918536384434&baseRepo=try&newHash=83782697878014813466&newRepo=try&framework=1',
+      '/compare-hash-results?baseHash=7844063918536384434&baseRepo=try&newHash=83782697878z014813466&newHashDate=' +
+        new Date().toISOString().split('T')[0] +
+        '&baseHashDate=03-20-2025&newRepo=try&framework=1',
+    );
+    render(<App />);
+    // Expecting to have a hashes do not correlate with revision error
+    expect(console.error).toHaveBeenCalledWith(
+      new Error('Results pushed today, still processing...'),
+    );
+    expect(console.error).toHaveBeenCalledTimes(1);
+    (console.error as jest.Mock).mockClear();
+  });
+
+  it('should reject invalid results returned from treeherder', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await router.navigate(
+      '/compare-hash-results?baseHash=7844063918536384434&baseRepo=try&newHash=83782697878014813466&newRepo=try&framework=1',
     );
     render(<App />);
     // Expecting to have an error about unable to parse baseRev and/or newRev returned from treeherder
     expect(console.error).toHaveBeenCalledWith(
       new Error(
-        'Unable to parse baseRev and/or newRev returned from treeherder',
+        'Not all values were supplied please check you provided all 4 of: baseHash, baseHashDate, newHash, newHashDate',
       ),
     );
     expect(console.error).toHaveBeenCalledTimes(1);

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -16,6 +16,7 @@ import { useAppSelector } from '../hooks/app';
 import { Strings } from '../resources/Strings';
 import { Banner } from '../styles/Banner';
 import getProtocolTheme from '../theme/protocolTheme';
+import { loader as hashToCommitLoader } from './CompareResults/hashToCommitLoader';
 import { loader as compareLoader } from './CompareResults/loader';
 import { loader as compareOverTimeLoader } from './CompareResults/overTimeLoader';
 import OverTimeResultsView from './CompareResults/OverTimeResultsView';
@@ -77,6 +78,13 @@ export const router = createBrowserRouter(
       <Route
         path='/compare-results'
         loader={compareLoader}
+        element={<ResultsView title={Strings.metaData.pageTitle.results} />}
+        errorElement={<PageError title={Strings.metaData.pageTitle.results} />}
+      />
+
+      <Route
+        path='/compare-hash-results'
+        loader={hashToCommitLoader}
         element={<ResultsView title={Strings.metaData.pageTitle.results} />}
         errorElement={<PageError title={Strings.metaData.pageTitle.results} />}
       />

--- a/src/components/CompareResults/ResultsView.tsx
+++ b/src/components/CompareResults/ResultsView.tsx
@@ -4,6 +4,7 @@ import Grid from '@mui/material/Grid';
 import { useLoaderData } from 'react-router-dom';
 import { style } from 'typestyle';
 
+import type { HashLoaderReturnValue } from './hashToCommitLoader';
 import type { LoaderReturnValue } from './loader';
 import ResultsMain from './ResultsMain';
 import { useAppSelector } from '../../hooks/app';
@@ -17,7 +18,7 @@ interface ResultsViewProps {
 }
 function ResultsView(props: ResultsViewProps) {
   const { baseRevInfo, newRevsInfo, frameworkId, baseRepo, newRepos } =
-    useLoaderData() as LoaderReturnValue;
+    useLoaderData() as LoaderReturnValue | HashLoaderReturnValue;
 
   const newRepo = newRepos[0];
   const { title } = props;

--- a/src/components/CompareResults/hashToCommitLoader.ts
+++ b/src/components/CompareResults/hashToCommitLoader.ts
@@ -1,0 +1,96 @@
+import { checkValues, getComparisonInformation } from './loader';
+import { compareView } from '../../common/constants';
+import { fetchRevisionFromHash } from '../../logic/treeherder';
+import { Changeset, CompareResultsItem, Repository } from '../../types/state';
+import { Framework } from '../../types/types';
+
+// This function is responsible for fetching the data from the URL. It's called
+// by React Router DOM when the compare-hash-results path is requested.
+// This loader is the only one used by ./mach try perf, and due to recent
+// changes mach try perf we can't get instant push links to try when we push.
+// We attach a hash to the commit message and search for that hash, and return
+// the commit associated with that hash and update the baseRev and newRev
+export async function loader({ request }: { request: Request }) {
+  const url = new URL(request.url);
+  const baseHashFromUrl = url.searchParams.get('baseHash');
+  const baseHashDateFromUrl = url.searchParams.get('baseHashDate');
+  const newHashFromUrl = url.searchParams.get('newHash');
+  const newHashDateFromUrl = url.searchParams.get('newHashDate') as string;
+  const baseRepoFromUrl = url.searchParams.get('baseRepo') as
+    | Repository['name']
+    | null;
+  const newReposFromUrl = url.searchParams.getAll(
+    'newRepo',
+  ) as Repository['name'][];
+  const frameworkFromUrl = url.searchParams.get('framework');
+  const pushed_today =
+    new Date(newHashDateFromUrl).toISOString().split('T')[0] ==
+    new Date().toISOString().split('T')[0];
+  let commits_from_hashes: CommitFromHashData = {
+    baseRevision: '',
+    newRevision: '',
+  };
+  if (
+    !baseHashFromUrl ||
+    !baseHashDateFromUrl ||
+    !newHashFromUrl ||
+    !newHashDateFromUrl
+  ) {
+    throw new Error(
+      'Not all values were supplied please check you provided all 4 of: baseHash, baseHashDate, newHash, newHashDate',
+    );
+  }
+  try {
+    commits_from_hashes = await fetchRevisionFromHash(
+      baseHashFromUrl,
+      baseHashDateFromUrl,
+      newHashFromUrl,
+      newHashDateFromUrl,
+      'try',
+    );
+  } catch (e) {
+    if (pushed_today) {
+      throw new Error('Results pushed today, still processing...');
+    } else {
+      throw e;
+    }
+  }
+  const baseRevsFromHash = commits_from_hashes.baseRevision;
+  const newRevsFromHash = [commits_from_hashes.newRevision];
+  const { baseRev, baseRepo, newRevs, newRepos, frameworkId, frameworkName } =
+    checkValues({
+      baseRev: baseRevsFromHash,
+      baseRepo: baseRepoFromUrl,
+      newRevs: newRevsFromHash,
+      newRepos: newReposFromUrl,
+      framework: frameworkFromUrl,
+    });
+  return await getComparisonInformation(
+    baseRev,
+    baseRepo,
+    newRevs,
+    newRepos,
+    frameworkId,
+    frameworkName,
+  );
+}
+
+type HashLoaderData = {
+  results: Promise<CompareResultsItem[][]>;
+  baseRev: string;
+  baseRevInfo: Changeset;
+  baseRepo: Repository['name'];
+  newRevs: string[];
+  newRevsInfo: Changeset[];
+  newRepos: Repository['name'][];
+  frameworkId: Framework['id'];
+  frameworkName: Framework['name'];
+  view: typeof compareView;
+  generation: number;
+};
+
+type CommitFromHashData = {
+  baseRevision: string;
+  newRevision: string;
+};
+export type HashLoaderReturnValue = HashLoaderData;

--- a/src/logic/treeherder.ts
+++ b/src/logic/treeherder.ts
@@ -49,6 +49,24 @@ type FetchSubtestsOverTimeProps = {
   newParentSignature: string;
 };
 
+export async function fetchRevisionFromHash(
+  basehash: string,
+  basehashdate: string,
+  newhash: string,
+  newhashdate: string,
+  repo: string,
+) {
+  const searchParams = new URLSearchParams({
+    basehash: basehash,
+    newhash: newhash,
+    basehashdate: basehashdate,
+    newhashdate: newhashdate,
+  });
+  const url = `${treeherderBaseURL}/api/project/${repo}/hash/tocommit/?${searchParams.toString()}`;
+  const response = await fetchFromTreeherder(url);
+  return response.json() as Promise<CommitToHash>;
+}
+
 async function fetchFromTreeherder(url: string) {
   const response = await fetch(url);
   if (!response.ok) {
@@ -64,21 +82,7 @@ async function fetchFromTreeherder(url: string) {
   }
   return response;
 }
-
-// This fetches the revision with the hash inside the ./mach try perf pushed job
-export async function fetchRevisionFromHash(
-  basehash: string,
-  newhash: string,
-  repo: string,
-) {
-  const searchParams = new URLSearchParams({
-    basehash: basehash,
-    newhash: newhash,
-  });
-  const url = `${treeherderBaseURL}/api/project/${repo}/hash/tocommit/?${searchParams.toString()}`;
-  const response = await fetchFromTreeherder(url);
-  return response.json() as Promise<CommitToHash>;
-}
+// This fetches the based on the hash inside the commit message of ./mach try perf pushed jobs
 
 // This fetches data from the Treeherder API /api/perfcompare/results.
 // This API returns the results of a comparison between 2 revisions.


### PR DESCRIPTION
What we are doing:
- 1) We are creating a new loader for perfcompare
- 2) Accomodating the updated tocommit api on treeherder to get back results faster

Why:
- 1) To leave the main loader alone and to create one specific to ./mach try perf
- 2) Treeherder needs extra information to get results faster, we are passing those results along to it 