### PR TITLE
Add missing platforms and show them when not found

### DIFF
--- a/src/__tests__/CompareResults/ResultsTable.test.tsx
+++ b/src/__tests__/CompareResults/ResultsTable.test.tsx
@@ -200,7 +200,7 @@ describe('Results Table', () => {
       '  - macOS 10.15, Improvement, 1.08 %, Low',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
-      platform: ['osx', 'linux', 'android'],
+      platform: ['osx', 'linux', 'android', 'ios'],
     });
 
     await clickMenuItem(user, 'Platform', /Linux/);
@@ -210,7 +210,7 @@ describe('Results Table', () => {
       '  - macOS 10.15, Improvement, 1.08 %, Low',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
-      platform: ['osx', 'android'],
+      platform: ['osx', 'android', 'ios'],
     });
 
     await clickMenuItem(user, 'Platform', /Linux/);
@@ -221,7 +221,7 @@ describe('Results Table', () => {
       '  - macOS 10.15, Improvement, 1.08 %, Low',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
-      platform: ['osx', 'linux', 'android'],
+      platform: ['osx', 'linux', 'android', 'ios'],
     });
 
     await clickMenuItem(user, 'Platform', 'Select all values');
@@ -244,7 +244,7 @@ describe('Results Table', () => {
       '  - Windows 10, -, -2.4 %, High',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
-      platform: ['windows', 'linux', 'android'],
+      platform: ['windows', 'linux', 'android', 'ios'],
     });
 
     await clickMenuItem(user, 'Platform', /Android/);
@@ -255,7 +255,7 @@ describe('Results Table', () => {
       '  - Windows 10, -, -2.4 %, High',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
-      platform: ['windows', 'linux'],
+      platform: ['windows', 'linux', 'ios'],
     });
 
     await clickMenuItem(user, 'Platform', /Select only.*Android/);

--- a/src/__tests__/CompareResults/RevisionRow.test.tsx
+++ b/src/__tests__/CompareResults/RevisionRow.test.tsx
@@ -57,7 +57,7 @@ describe('<RevisionRow>', () => {
     },
     {
       platform: 'i am not an operating system',
-      shortName: 'Unspecified',
+      shortName: 'i am not an operating system',
       hasIcon: false,
     },
   ])(

--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -267,11 +267,11 @@ exports[`Results View The table should match snapshot and other elements should 
         >
           Platform
           <div
-            aria-label="4 items selected"
+            aria-label="5 items selected"
             class="MuiBox-root css-18uhbjh"
           >
             (
-            4
+            5
             )
           </div>
           <svg

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -1066,11 +1066,11 @@ exports[`Results Table Should match snapshot 1`] = `
                     >
                       Platform
                       <div
-                        aria-label="4 items selected"
+                        aria-label="5 items selected"
                         class="MuiBox-root css-18uhbjh"
                       >
                         (
-                        4
+                        5
                         )
                       </div>
                       <svg

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -1219,11 +1219,11 @@ exports[`Results View The table should match snapshot and other elements should 
         >
           Platform
           <div
-            aria-label="4 items selected"
+            aria-label="5 items selected"
             class="MuiBox-root css-18uhbjh"
           >
             (
-            4
+            5
             )
           </div>
           <svg

--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -29,6 +29,7 @@ const columnsConfiguration: CompareResultsTableConfig = [
       { label: 'macOS', key: 'osx' },
       { label: 'Linux', key: 'linux' },
       { label: 'Android', key: 'android' },
+      { label: 'iOS', key: 'ios' },
     ],
     matchesFunction(result, valueKey) {
       const label = this.possibleValues.find(

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -220,6 +220,7 @@ function determineSign(baseMedianValue: number, newMedianValue: number) {
 const platformIcons: Record<PlatformShortName, ReactNode> = {
   Linux: <LinuxIcon />,
   macOS: <AppleIcon />,
+  iOS: <AppleIcon />,
   Windows: <WindowsIcon />,
   Android: <AndroidIcon />,
   Unspecified: '',

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -299,6 +299,7 @@ function RevisionRow(props: RevisionRowProps) {
 
   const platformShortName = getPlatformShortName(platform);
   const platformIcon = platformIcons[platformShortName];
+  const platformNameAndVersion = getPlatformAndVersion(platform);
 
   const [expanded, setExpanded] = useState(false);
 
@@ -332,7 +333,11 @@ function RevisionRow(props: RevisionRowProps) {
           >
             <div className='platform-container'>
               {platformIcon}
-              <span>{getPlatformAndVersion(platform)}</span>
+              <span>
+                {platformNameAndVersion === 'Unspecified'
+                  ? platform
+                  : platformNameAndVersion}
+              </span>
             </div>
           </Tooltip>
         </div>

--- a/src/components/CompareResults/SubtestsResults/SubtestsRevisionHeader.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsRevisionHeader.tsx
@@ -137,6 +137,7 @@ function SubtestsRevisionHeader(props: SubtestsRevisionHeaderProps) {
   const platformIcons: Record<PlatformShortName, ReactNode> = {
     Linux: <LinuxIcon />,
     macOS: <AppleIcon />,
+    iOS: <AppleIcon />,
     Windows: <WindowsIcon />,
     Android: <AndroidIcon />,
     Unspecified: '',

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -129,4 +129,5 @@ export type PlatformShortName =
   | 'macOS'
   | 'Windows'
   | 'Android'
+  | 'iOS'
   | 'Unspecified';

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -11,6 +11,7 @@ export const getPlatformShortName = (
     return 'macOS';
   if (platformName.toLowerCase().startsWith('win')) return 'Windows';
   if (platformName.toLowerCase().includes('android')) return 'Android';
+  if (platformName.toLowerCase().startsWith('ios')) return 'iOS';
   return 'Unspecified';
 };
 
@@ -27,6 +28,7 @@ const osMapping = {
   macosx1300: 'macOS 13',
   macosx1400: 'macOS 14.00',
   macosx1470: 'macOS 14.70',
+  macosx1500: 'macOS 15',
   win32: 'Windows x86',
   win64: 'Windows x64',
   windows7: 'Windows 7',


### PR DESCRIPTION
This is adding macOS 15, iOS as well as display the platforms in full when they're not recognized. Except for macOS 15, they are especially useful for the build_metrics framework.

[production](https://perf.compare/compare-results?baseRev=ba56f7ee55792aaf974891449b64ace32bc9e1b8&baseRepo=mozilla-central&newRev=30d833468eba8358571c55ec3e7e8991f4952fb9&newRepo=mozilla-central&framework=2) / [deploy preview](https://deploy-preview-881--mozilla-perfcompare.netlify.app/compare-results?baseRev=ba56f7ee55792aaf974891449b64ace32bc9e1b8&baseRepo=mozilla-central&newRev=30d833468eba8358571c55ec3e7e8991f4952fb9&newRepo=mozilla-central&framework=2)

![image](https://github.com/user-attachments/assets/7ad6f4d2-a379-4436-9529-c80d18b639ac)
![image](https://github.com/user-attachments/assets/f6ded242-c9e6-42af-a9c0-03d3dfa4aea3)
![image](https://github.com/user-attachments/assets/bcd71f49-5065-4521-a333-10890f916f49)
