### PR TITLE
Change how the filters are implemented so that the behavior is a bit better

### DIFF
--- a/src/components/CompareResults/TableHeader.tsx
+++ b/src/components/CompareResults/TableHeader.tsx
@@ -72,7 +72,7 @@ type FilterableColumnHeaderProps = {
 
   /* Properties for filtering */
   possibleValues: FilterableColumn['possibleValues'];
-  uncheckedValues?: Set<string>;
+  checkedValues?: Set<string>;
   onToggleFilter: (checkedValues: Set<string>) => unknown;
   onClearFilter: () => unknown;
   tooltip?: string;
@@ -82,35 +82,33 @@ function FilterableColumnHeader({
   name,
   columnId,
   possibleValues,
-  uncheckedValues,
+  checkedValues,
   onToggleFilter,
   onClearFilter,
   tooltip,
 }: FilterableColumnHeaderProps) {
   const popupState = usePopupState({ variant: 'popover', popupId: columnId });
-  const possibleCheckedValues =
-    possibleValues.length - (uncheckedValues?.size || 0);
+  const possibleCheckedValues = checkedValues?.size ?? possibleValues.length;
 
   const onClickFilter = (valueKey: string) => {
-    const newUncheckedValues = new Set(uncheckedValues);
-    if (newUncheckedValues.has(valueKey)) {
-      newUncheckedValues.delete(valueKey);
+    const newCheckedValues = checkedValues
+      ? new Set(checkedValues)
+      : new Set(possibleValues.map(({ key }) => key));
+    if (newCheckedValues.has(valueKey)) {
+      newCheckedValues.delete(valueKey);
     } else {
-      newUncheckedValues.add(valueKey);
+      newCheckedValues.add(valueKey);
     }
-    onToggleFilter(newUncheckedValues);
+    onToggleFilter(newCheckedValues);
   };
 
   const onClickOnlyFilter = (valueKey: string) => {
-    const newUncheckedValues = new Set(
-      possibleValues
-        .filter(({ key }) => key !== valueKey)
-        .map(({ key }) => key),
-    );
-    onToggleFilter(newUncheckedValues);
+    const newCheckedValues = new Set([valueKey]);
+    onToggleFilter(newCheckedValues);
   };
 
-  const hasFilteredValues = uncheckedValues && uncheckedValues.size;
+  const hasFilteredValues =
+    checkedValues && checkedValues.size < possibleValues.length;
   const buttonAriaLabel = hasFilteredValues
     ? `${name} (Click to filter values. Some filters are active.)`
     : `${name} (Click to filter values)`;
@@ -161,7 +159,7 @@ function FilterableColumnHeader({
         <Divider />
         {possibleValues.map((possibleValue) => {
           const isChecked =
-            !uncheckedValues || !uncheckedValues.has(possibleValue.key);
+            !checkedValues || checkedValues.has(possibleValue.key);
           return (
             <MenuItem
               dense
@@ -343,7 +341,7 @@ function TableHeader({
             possibleValues={header.possibleValues}
             name={header.name}
             columnId={header.key}
-            uncheckedValues={filters.get(header.key)}
+            checkedValues={filters.get(header.key)}
             onClearFilter={() => onClearFilter(header.key)}
             onToggleFilter={(checkedValues) =>
               onToggleFilter(header.key, checkedValues)
@@ -369,7 +367,7 @@ function TableHeader({
           possibleValues={header.possibleValues}
           name={header.name}
           columnId={header.key}
-          uncheckedValues={filters.get(header.key)}
+          checkedValues={filters.get(header.key)}
           onClearFilter={() => onClearFilter(header.key)}
           onToggleFilter={(checkedValues) =>
             onToggleFilter(header.key, checkedValues)


### PR DESCRIPTION
Previously the internal state was keeping the _unchecked_ checkboxes, now it keeps the _checked_ checkboxes. This makes the code easier to follow.
    
The user-visible change is that unknown values are not filtered out as expected when the user selects specific filters. They are still visible when all filters are checked. This was the motivation to write this patch.

You can test with these links:
[main branch](https://main--mozilla-perfcompare.netlify.app/compare-results?baseRev=ba56f7ee55792aaf974891449b64ace32bc9e1b8&baseRepo=mozilla-central&newRev=30d833468eba8358571c55ec3e7e8991f4952fb9&newRepo=mozilla-central&framework=2&search=fetch_content) / [deploy preview](https://deploy-preview-882--mozilla-perfcompare.netlify.app/compare-results?baseRev=ba56f7ee55792aaf974891449b64ace32bc9e1b8&baseRepo=mozilla-central&newRev=30d833468eba8358571c55ec3e7e8991f4952fb9&newRepo=mozilla-central&framework=2&search=fetch_content)

This is using the build_metrics framework, and searching for `fetch_content` which has some of these "unknown" platforms. For example `updatebot` near the top. 

Now you can try selecting other platforms from the menu. It is especially visible when using one of the `Select only XXX` options. When using one of these options the user expects to see _only_ these, but in production the user sees also the unknown platforms. Now with this patch they disappear as I'd expect as a user.

Tell me what you think!

