### PR TITLE
Deploy May 9, 2025

### DIFF
--- a/src/__tests__/CompareResults/ResultsTable.test.tsx
+++ b/src/__tests__/CompareResults/ResultsTable.test.tsx
@@ -200,7 +200,7 @@ describe('Results Table', () => {
       '  - macOS 10.15, Improvement, 1.08 %, Low',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
-      platform: ['osx', 'linux', 'android'],
+      platform: ['osx', 'linux', 'android', 'ios'],
     });
 
     await clickMenuItem(user, 'Platform', /Linux/);
@@ -210,7 +210,7 @@ describe('Results Table', () => {
       '  - macOS 10.15, Improvement, 1.08 %, Low',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
-      platform: ['osx', 'android'],
+      platform: ['osx', 'android', 'ios'],
     });
 
     await clickMenuItem(user, 'Platform', /Linux/);
@@ -221,7 +221,7 @@ describe('Results Table', () => {
       '  - macOS 10.15, Improvement, 1.08 %, Low',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
-      platform: ['osx', 'linux', 'android'],
+      platform: ['osx', 'linux', 'android', 'ios'],
     });
 
     await clickMenuItem(user, 'Platform', 'Select all values');
@@ -244,7 +244,7 @@ describe('Results Table', () => {
       '  - Windows 10, -, -2.4 %, High',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
-      platform: ['windows', 'linux', 'android'],
+      platform: ['windows', 'linux', 'android', 'ios'],
     });
 
     await clickMenuItem(user, 'Platform', /Android/);
@@ -255,7 +255,7 @@ describe('Results Table', () => {
       '  - Windows 10, -, -2.4 %, High',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
-      platform: ['windows', 'linux'],
+      platform: ['windows', 'linux', 'ios'],
     });
 
     await clickMenuItem(user, 'Platform', /Select only.*Android/);

--- a/src/__tests__/CompareResults/RevisionRow.test.tsx
+++ b/src/__tests__/CompareResults/RevisionRow.test.tsx
@@ -57,7 +57,7 @@ describe('<RevisionRow>', () => {
     },
     {
       platform: 'i am not an operating system',
-      shortName: 'Unspecified',
+      shortName: 'i am not an operating system',
       hasIcon: false,
     },
   ])(

--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -267,11 +267,11 @@ exports[`Results View The table should match snapshot and other elements should 
         >
           Platform
           <div
-            aria-label="4 items selected"
+            aria-label="5 items selected"
             class="MuiBox-root css-18uhbjh"
           >
             (
-            4
+            5
             )
           </div>
           <svg

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -1066,11 +1066,11 @@ exports[`Results Table Should match snapshot 1`] = `
                     >
                       Platform
                       <div
-                        aria-label="4 items selected"
+                        aria-label="5 items selected"
                         class="MuiBox-root css-18uhbjh"
                       >
                         (
-                        4
+                        5
                         )
                       </div>
                       <svg

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -1219,11 +1219,11 @@ exports[`Results View The table should match snapshot and other elements should 
         >
           Platform
           <div
-            aria-label="4 items selected"
+            aria-label="5 items selected"
             class="MuiBox-root css-18uhbjh"
           >
             (
-            4
+            5
             )
           </div>
           <svg

--- a/src/__tests__/Search/fetchRevisionFromHash.test.tsx
+++ b/src/__tests__/Search/fetchRevisionFromHash.test.tsx
@@ -2,6 +2,36 @@ import App, { router } from '../../components/App';
 import { FetchMockSandbox, render } from '../utils/test-utils';
 
 describe('Hash to commit good run validating', () => {
+  it('Should return a baseRev not found if we return a null baseRev', async () => {
+    // Silence console.error for a better console output. We'll check its result later.
+    // If an expectation toHaveBeenCalledTimes fails, it might be easier to
+    // remove the mockImplementation part to debug.
+
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    (global.fetch as FetchMockSandbox).get(
+      'glob:https://treeherder.mozilla.org/api/project/*/hash/*',
+      (url) => {
+        return url.includes('tocommit')
+          ? {
+              baseRevision: null,
+              newRevision: 'Another',
+            }
+          : {};
+      },
+    );
+
+    // Error 1: no baseRev
+    await router.navigate(
+      '/compare-hash-results?baseHash=7844063918536384434&baseRepo=try&newHash=83782697878z014813466&newHashDate=03-20-2025&baseHashDate=03-20-2025&newRepo=try&framework=1',
+    );
+    render(<App />);
+    expect(console.error).toHaveBeenCalledWith(
+      new Error('The parameter baseRev is missing.'),
+    );
+    expect(console.error).toHaveBeenCalledTimes(1);
+    (console.error as jest.Mock).mockClear();
+  });
+
   it('should reject hashes not associated with any commits', async () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -18,7 +48,7 @@ describe('Hash to commit good run validating', () => {
     );
 
     await router.navigate(
-      '/compare-results?baseHash=7844063918536384434&baseRepo=try&newHash=83782697878014813466&newRepo=try&framework=1',
+      '/compare-hash-results?baseHash=7844063918536384434&baseRepo=try&newHash=83782697878z014813466&newHashDate=03-20-2025&baseHashDate=03-20-2025&newRepo=try&framework=1',
     );
     render(<App />);
     // Expecting to have a hashes do not correlate with revision error
@@ -31,29 +61,46 @@ describe('Hash to commit good run validating', () => {
     (console.error as jest.Mock).mockClear();
   });
 
-  it('should reject invalid results returned from treeherder', async () => {
+  it('should display a different error message if the datehash is today and not found', async () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
 
     (global.fetch as FetchMockSandbox).get(
       'glob:https://treeherder.mozilla.org/api/project/*/hash/*',
-      (url) => {
-        return url.includes('tocommit')
+      (url) =>
+        url.includes('tocommit')
           ? {
-              badbaseRevision: 'Press',
-              newRevision: 'Another',
+              throws: new Error(
+                'Error when requesting treeherder: ["83782697878014813466 or 7844063918536384434 do not correspond to any existing hashes please double check both hashes you provided"]',
+              ),
             }
-          : {};
-      },
+          : {},
     );
 
     await router.navigate(
-      '/compare-results?baseHash=7844063918536384434&baseRepo=try&newHash=83782697878014813466&newRepo=try&framework=1',
+      '/compare-hash-results?baseHash=7844063918536384434&baseRepo=try&newHash=83782697878z014813466&newHashDate=' +
+        new Date().toISOString().split('T')[0] +
+        '&baseHashDate=03-20-2025&newRepo=try&framework=1',
+    );
+    render(<App />);
+    // Expecting to have a hashes do not correlate with revision error
+    expect(console.error).toHaveBeenCalledWith(
+      new Error('Results pushed today, still processing...'),
+    );
+    expect(console.error).toHaveBeenCalledTimes(1);
+    (console.error as jest.Mock).mockClear();
+  });
+
+  it('should reject invalid results returned from treeherder', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await router.navigate(
+      '/compare-hash-results?baseHash=7844063918536384434&baseRepo=try&newHash=83782697878014813466&newRepo=try&framework=1',
     );
     render(<App />);
     // Expecting to have an error about unable to parse baseRev and/or newRev returned from treeherder
     expect(console.error).toHaveBeenCalledWith(
       new Error(
-        'Unable to parse baseRev and/or newRev returned from treeherder',
+        'Not all values were supplied please check you provided all 4 of: baseHash, baseHashDate, newHash, newHashDate',
       ),
     );
     expect(console.error).toHaveBeenCalledTimes(1);

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -16,6 +16,7 @@ import { useAppSelector } from '../hooks/app';
 import { Strings } from '../resources/Strings';
 import { Banner } from '../styles/Banner';
 import getProtocolTheme from '../theme/protocolTheme';
+import { loader as hashToCommitLoader } from './CompareResults/hashToCommitLoader';
 import { loader as compareLoader } from './CompareResults/loader';
 import { loader as compareOverTimeLoader } from './CompareResults/overTimeLoader';
 import OverTimeResultsView from './CompareResults/OverTimeResultsView';
@@ -77,6 +78,13 @@ export const router = createBrowserRouter(
       <Route
         path='/compare-results'
         loader={compareLoader}
+        element={<ResultsView title={Strings.metaData.pageTitle.results} />}
+        errorElement={<PageError title={Strings.metaData.pageTitle.results} />}
+      />
+
+      <Route
+        path='/compare-hash-results'
+        loader={hashToCommitLoader}
         element={<ResultsView title={Strings.metaData.pageTitle.results} />}
         errorElement={<PageError title={Strings.metaData.pageTitle.results} />}
       />

--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -29,6 +29,7 @@ const columnsConfiguration: CompareResultsTableConfig = [
       { label: 'macOS', key: 'osx' },
       { label: 'Linux', key: 'linux' },
       { label: 'Android', key: 'android' },
+      { label: 'iOS', key: 'ios' },
     ],
     matchesFunction(result, valueKey) {
       const label = this.possibleValues.find(

--- a/src/components/CompareResults/ResultsView.tsx
+++ b/src/components/CompareResults/ResultsView.tsx
@@ -4,6 +4,7 @@ import Grid from '@mui/material/Grid';
 import { useLoaderData } from 'react-router-dom';
 import { style } from 'typestyle';
 
+import type { HashLoaderReturnValue } from './hashToCommitLoader';
 import type { LoaderReturnValue } from './loader';
 import ResultsMain from './ResultsMain';
 import { useAppSelector } from '../../hooks/app';
@@ -17,7 +18,7 @@ interface ResultsViewProps {
 }
 function ResultsView(props: ResultsViewProps) {
   const { baseRevInfo, newRevsInfo, frameworkId, baseRepo, newRepos } =
-    useLoaderData() as LoaderReturnValue;
+    useLoaderData() as LoaderReturnValue | HashLoaderReturnValue;
 
   const newRepo = newRepos[0];
   const { title } = props;

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -220,6 +220,7 @@ function determineSign(baseMedianValue: number, newMedianValue: number) {
 const platformIcons: Record<PlatformShortName, ReactNode> = {
   Linux: <LinuxIcon />,
   macOS: <AppleIcon />,
+  iOS: <AppleIcon />,
   Windows: <WindowsIcon />,
   Android: <AndroidIcon />,
   Unspecified: '',
@@ -298,6 +299,7 @@ function RevisionRow(props: RevisionRowProps) {
 
   const platformShortName = getPlatformShortName(platform);
   const platformIcon = platformIcons[platformShortName];
+  const platformNameAndVersion = getPlatformAndVersion(platform);
 
   const [expanded, setExpanded] = useState(false);
 
@@ -331,7 +333,11 @@ function RevisionRow(props: RevisionRowProps) {
           >
             <div className='platform-container'>
               {platformIcon}
-              <span>{getPlatformAndVersion(platform)}</span>
+              <span>
+                {platformNameAndVersion === 'Unspecified'
+                  ? platform
+                  : platformNameAndVersion}
+              </span>
             </div>
           </Tooltip>
         </div>

--- a/src/components/CompareResults/SubtestsResults/SubtestsRevisionHeader.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsRevisionHeader.tsx
@@ -137,6 +137,7 @@ function SubtestsRevisionHeader(props: SubtestsRevisionHeaderProps) {
   const platformIcons: Record<PlatformShortName, ReactNode> = {
     Linux: <LinuxIcon />,
     macOS: <AppleIcon />,
+    iOS: <AppleIcon />,
     Windows: <WindowsIcon />,
     Android: <AndroidIcon />,
     Unspecified: '',

--- a/src/components/CompareResults/TableHeader.tsx
+++ b/src/components/CompareResults/TableHeader.tsx
@@ -72,7 +72,7 @@ type FilterableColumnHeaderProps = {
 
   /* Properties for filtering */
   possibleValues: FilterableColumn['possibleValues'];
-  uncheckedValues?: Set<string>;
+  checkedValues?: Set<string>;
   onToggleFilter: (checkedValues: Set<string>) => unknown;
   onClearFilter: () => unknown;
   tooltip?: string;
@@ -82,35 +82,33 @@ function FilterableColumnHeader({
   name,
   columnId,
   possibleValues,
-  uncheckedValues,
+  checkedValues,
   onToggleFilter,
   onClearFilter,
   tooltip,
 }: FilterableColumnHeaderProps) {
   const popupState = usePopupState({ variant: 'popover', popupId: columnId });
-  const possibleCheckedValues =
-    possibleValues.length - (uncheckedValues?.size || 0);
+  const possibleCheckedValues = checkedValues?.size ?? possibleValues.length;
 
   const onClickFilter = (valueKey: string) => {
-    const newUncheckedValues = new Set(uncheckedValues);
-    if (newUncheckedValues.has(valueKey)) {
-      newUncheckedValues.delete(valueKey);
+    const newCheckedValues = checkedValues
+      ? new Set(checkedValues)
+      : new Set(possibleValues.map(({ key }) => key));
+    if (newCheckedValues.has(valueKey)) {
+      newCheckedValues.delete(valueKey);
     } else {
-      newUncheckedValues.add(valueKey);
+      newCheckedValues.add(valueKey);
     }
-    onToggleFilter(newUncheckedValues);
+    onToggleFilter(newCheckedValues);
   };
 
   const onClickOnlyFilter = (valueKey: string) => {
-    const newUncheckedValues = new Set(
-      possibleValues
-        .filter(({ key }) => key !== valueKey)
-        .map(({ key }) => key),
-    );
-    onToggleFilter(newUncheckedValues);
+    const newCheckedValues = new Set([valueKey]);
+    onToggleFilter(newCheckedValues);
   };
 
-  const hasFilteredValues = uncheckedValues && uncheckedValues.size;
+  const hasFilteredValues =
+    checkedValues && checkedValues.size < possibleValues.length;
   const buttonAriaLabel = hasFilteredValues
     ? `${name} (Click to filter values. Some filters are active.)`
     : `${name} (Click to filter values)`;
@@ -161,7 +159,7 @@ function FilterableColumnHeader({
         <Divider />
         {possibleValues.map((possibleValue) => {
           const isChecked =
-            !uncheckedValues || !uncheckedValues.has(possibleValue.key);
+            !checkedValues || checkedValues.has(possibleValue.key);
           return (
             <MenuItem
               dense
@@ -343,7 +341,7 @@ function TableHeader({
             possibleValues={header.possibleValues}
             name={header.name}
             columnId={header.key}
-            uncheckedValues={filters.get(header.key)}
+            checkedValues={filters.get(header.key)}
             onClearFilter={() => onClearFilter(header.key)}
             onToggleFilter={(checkedValues) =>
               onToggleFilter(header.key, checkedValues)
@@ -369,7 +367,7 @@ function TableHeader({
           possibleValues={header.possibleValues}
           name={header.name}
           columnId={header.key}
-          uncheckedValues={filters.get(header.key)}
+          checkedValues={filters.get(header.key)}
           onClearFilter={() => onClearFilter(header.key)}
           onToggleFilter={(checkedValues) =>
             onToggleFilter(header.key, checkedValues)

--- a/src/components/CompareResults/hashToCommitLoader.ts
+++ b/src/components/CompareResults/hashToCommitLoader.ts
@@ -1,0 +1,96 @@
+import { checkValues, getComparisonInformation } from './loader';
+import { compareView } from '../../common/constants';
+import { fetchRevisionFromHash } from '../../logic/treeherder';
+import { Changeset, CompareResultsItem, Repository } from '../../types/state';
+import { Framework } from '../../types/types';
+
+// This function is responsible for fetching the data from the URL. It's called
+// by React Router DOM when the compare-hash-results path is requested.
+// This loader is the only one used by ./mach try perf, and due to recent
+// changes mach try perf we can't get instant push links to try when we push.
+// We attach a hash to the commit message and search for that hash, and return
+// the commit associated with that hash and update the baseRev and newRev
+export async function loader({ request }: { request: Request }) {
+  const url = new URL(request.url);
+  const baseHashFromUrl = url.searchParams.get('baseHash');
+  const baseHashDateFromUrl = url.searchParams.get('baseHashDate');
+  const newHashFromUrl = url.searchParams.get('newHash');
+  const newHashDateFromUrl = url.searchParams.get('newHashDate') as string;
+  const baseRepoFromUrl = url.searchParams.get('baseRepo') as
+    | Repository['name']
+    | null;
+  const newReposFromUrl = url.searchParams.getAll(
+    'newRepo',
+  ) as Repository['name'][];
+  const frameworkFromUrl = url.searchParams.get('framework');
+  const pushed_today =
+    new Date(newHashDateFromUrl).toISOString().split('T')[0] ==
+    new Date().toISOString().split('T')[0];
+  let commits_from_hashes: CommitFromHashData = {
+    baseRevision: '',
+    newRevision: '',
+  };
+  if (
+    !baseHashFromUrl ||
+    !baseHashDateFromUrl ||
+    !newHashFromUrl ||
+    !newHashDateFromUrl
+  ) {
+    throw new Error(
+      'Not all values were supplied please check you provided all 4 of: baseHash, baseHashDate, newHash, newHashDate',
+    );
+  }
+  try {
+    commits_from_hashes = await fetchRevisionFromHash(
+      baseHashFromUrl,
+      baseHashDateFromUrl,
+      newHashFromUrl,
+      newHashDateFromUrl,
+      'try',
+    );
+  } catch (e) {
+    if (pushed_today) {
+      throw new Error('Results pushed today, still processing...');
+    } else {
+      throw e;
+    }
+  }
+  const baseRevsFromHash = commits_from_hashes.baseRevision;
+  const newRevsFromHash = [commits_from_hashes.newRevision];
+  const { baseRev, baseRepo, newRevs, newRepos, frameworkId, frameworkName } =
+    checkValues({
+      baseRev: baseRevsFromHash,
+      baseRepo: baseRepoFromUrl,
+      newRevs: newRevsFromHash,
+      newRepos: newReposFromUrl,
+      framework: frameworkFromUrl,
+    });
+  return await getComparisonInformation(
+    baseRev,
+    baseRepo,
+    newRevs,
+    newRepos,
+    frameworkId,
+    frameworkName,
+  );
+}
+
+type HashLoaderData = {
+  results: Promise<CompareResultsItem[][]>;
+  baseRev: string;
+  baseRevInfo: Changeset;
+  baseRepo: Repository['name'];
+  newRevs: string[];
+  newRevsInfo: Changeset[];
+  newRepos: Repository['name'][];
+  frameworkId: Framework['id'];
+  frameworkName: Framework['name'];
+  view: typeof compareView;
+  generation: number;
+};
+
+type CommitFromHashData = {
+  baseRevision: string;
+  newRevision: string;
+};
+export type HashLoaderReturnValue = HashLoaderData;

--- a/src/logic/treeherder.ts
+++ b/src/logic/treeherder.ts
@@ -49,6 +49,24 @@ type FetchSubtestsOverTimeProps = {
   newParentSignature: string;
 };
 
+export async function fetchRevisionFromHash(
+  basehash: string,
+  basehashdate: string,
+  newhash: string,
+  newhashdate: string,
+  repo: string,
+) {
+  const searchParams = new URLSearchParams({
+    basehash: basehash,
+    newhash: newhash,
+    basehashdate: basehashdate,
+    newhashdate: newhashdate,
+  });
+  const url = `${treeherderBaseURL}/api/project/${repo}/hash/tocommit/?${searchParams.toString()}`;
+  const response = await fetchFromTreeherder(url);
+  return response.json() as Promise<CommitToHash>;
+}
+
 async function fetchFromTreeherder(url: string) {
   const response = await fetch(url);
   if (!response.ok) {
@@ -64,21 +82,7 @@ async function fetchFromTreeherder(url: string) {
   }
   return response;
 }
-
-// This fetches the revision with the hash inside the ./mach try perf pushed job
-export async function fetchRevisionFromHash(
-  basehash: string,
-  newhash: string,
-  repo: string,
-) {
-  const searchParams = new URLSearchParams({
-    basehash: basehash,
-    newhash: newhash,
-  });
-  const url = `${treeherderBaseURL}/api/project/${repo}/hash/tocommit/?${searchParams.toString()}`;
-  const response = await fetchFromTreeherder(url);
-  return response.json() as Promise<CommitToHash>;
-}
+// This fetches the based on the hash inside the commit message of ./mach try perf pushed jobs
 
 // This fetches data from the Treeherder API /api/perfcompare/results.
 // This API returns the results of a comparison between 2 revisions.

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -129,4 +129,5 @@ export type PlatformShortName =
   | 'macOS'
   | 'Windows'
   | 'Android'
+  | 'iOS'
   | 'Unspecified';

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -11,6 +11,7 @@ export const getPlatformShortName = (
     return 'macOS';
   if (platformName.toLowerCase().startsWith('win')) return 'Windows';
   if (platformName.toLowerCase().includes('android')) return 'Android';
+  if (platformName.toLowerCase().startsWith('ios')) return 'iOS';
   return 'Unspecified';
 };
 
@@ -27,6 +28,7 @@ const osMapping = {
   macosx1300: 'macOS 13',
   macosx1400: 'macOS 14.00',
   macosx1470: 'macOS 14.70',
+  macosx1500: 'macOS 15',
   win32: 'Windows x86',
   win64: 'Windows x64',
   windows7: 'Windows 7',


### PR DESCRIPTION
The latest version of PerfCompare is now live! Check out the changelog below to see the updates:
[Julien Wasjberg] 
[Add missing platforms and show them when not found (](https://github.com/mozilla/perfcompare/commit/ea276e9b317bb1d95e5e5971cefc7e9303fbd376)[#881](https://github.com/mozilla/perfcompare/pull/881)[)](https://github.com/mozilla/perfcompare/commit/ea276e9b317bb1d95e5e5971cefc7e9303fbd376)
[Change how the filters are implemented so that the behavior is a bit better (](https://github.com/mozilla/perfcompare/commit/3566259b5c9e38245cdbc82b59528c32715865e2)[#882](https://github.com/mozilla/perfcompare/pull/882)[)](https://github.com/mozilla/perfcompare/commit/3566259b5c9e38245cdbc82b59528c32715865e2)
[Andrej Glavic] [Bug 1962486 - Optimize and create new perfcompare loader](https://github.com/mozilla/perfcompare/commit/95d3d4abe4b3660ec92c7fc56e6dd7db6d24bfd7)