### PR TITLE
Add ability to compare commits from ./mach try perf with lando ids

### DIFF
--- a/src/__tests__/Search/fetchRevisionFromLando.test.tsx
+++ b/src/__tests__/Search/fetchRevisionFromLando.test.tsx
@@ -1,0 +1,82 @@
+import App, { router } from '../../components/App';
+import { FetchMockSandbox, render } from '../utils/test-utils';
+
+describe('Lando to commit validating', () => {
+  it('Should tell us not all paramaters were provided', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    // Error 1: no newLando=5678
+    await router.navigate(
+      '/compare-lando-results?baseLando=1234&baseRepo=try&newRepo=try&framework=1',
+    );
+    render(<App />);
+    expect(console.error).toHaveBeenCalledWith(
+      new Error(
+        'Not all values were supplied please check you provided both baseLando and newLando',
+      ),
+    );
+    expect(console.error).toHaveBeenCalledTimes(1);
+    (console.error as jest.Mock).mockClear();
+  });
+
+  it('should reject hashes not associated with any commits error 404', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    (global.fetch as FetchMockSandbox).get(
+      'glob:https://api.lando.services.mozilla.com/*',
+      (url) => {
+        return url.includes('123')
+          ? {
+              status: 404,
+              body: {
+                detail: 'A landing job with ID 456789 was not found.',
+                status: 404,
+                title: 'Landing job not found',
+                type: 'https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404',
+              },
+            }
+          : {
+              commit_id: '096aa2c25fb2f031021de8c58baf9c46c052ab2e',
+              id: 108,
+              status: 'LANDED',
+            };
+      },
+    );
+    await router.navigate(
+      '/compare-lando-results?baseLando=123&baseRepo=try&newLando=456789&newRepo=try&framework=1',
+    );
+    render(<App />);
+    expect(console.error).toHaveBeenCalledWith(
+      new Error('Error when requesting lando: (404) Not Found'),
+    );
+    expect(console.error).toHaveBeenCalledTimes(1);
+    (console.error as jest.Mock).mockClear();
+  });
+
+  it('should reject', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    (global.fetch as FetchMockSandbox).get(
+      'glob:https://api.lando.services.mozilla.com/*',
+      (url) => {
+        return url.includes('123')
+          ? {
+              commit_id: null,
+              id: 108,
+              status: 'LANDED',
+            }
+          : {
+              commit_id: '6331cb86f104e2587160208d8e47d8bef8b38ffc',
+              id: 96,
+              status: 'LANDED',
+            };
+      },
+    );
+    await router.navigate(
+      '/compare-lando-results?baseLando=123&baseRepo=try&newLando=456&newRepo=try&framework=1',
+    );
+    render(<App />);
+    expect(console.error).toHaveBeenCalledWith(
+      new Error('The parameter baseRev is missing.'),
+    );
+    expect(console.error).toHaveBeenCalledTimes(1);
+    (console.error as jest.Mock).mockClear();
+  });
+});

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -17,6 +17,7 @@ import { Strings } from '../resources/Strings';
 import { Banner } from '../styles/Banner';
 import getProtocolTheme from '../theme/protocolTheme';
 import { loader as hashToCommitLoader } from './CompareResults/hashToCommitLoader';
+import { loader as landoToCommitLoader } from './CompareResults/landoToCommitLoader';
 import { loader as compareLoader } from './CompareResults/loader';
 import { loader as compareOverTimeLoader } from './CompareResults/overTimeLoader';
 import OverTimeResultsView from './CompareResults/OverTimeResultsView';
@@ -85,6 +86,13 @@ export const router = createBrowserRouter(
       <Route
         path='/compare-hash-results'
         loader={hashToCommitLoader}
+        element={<ResultsView title={Strings.metaData.pageTitle.results} />}
+        errorElement={<PageError title={Strings.metaData.pageTitle.results} />}
+      />
+
+      <Route
+        path='/compare-lando-results'
+        loader={landoToCommitLoader}
         element={<ResultsView title={Strings.metaData.pageTitle.results} />}
         errorElement={<PageError title={Strings.metaData.pageTitle.results} />}
       />

--- a/src/components/CompareResults/ResultsView.tsx
+++ b/src/components/CompareResults/ResultsView.tsx
@@ -5,6 +5,7 @@ import { useLoaderData } from 'react-router-dom';
 import { style } from 'typestyle';
 
 import type { HashLoaderReturnValue } from './hashToCommitLoader';
+import type { LandoLoaderReturnValue } from './landoToCommitLoader';
 import type { LoaderReturnValue } from './loader';
 import ResultsMain from './ResultsMain';
 import { useAppSelector } from '../../hooks/app';
@@ -18,7 +19,10 @@ interface ResultsViewProps {
 }
 function ResultsView(props: ResultsViewProps) {
   const { baseRevInfo, newRevsInfo, frameworkId, baseRepo, newRepos } =
-    useLoaderData() as LoaderReturnValue | HashLoaderReturnValue;
+    useLoaderData() as
+      | LoaderReturnValue
+      | HashLoaderReturnValue
+      | LandoLoaderReturnValue;
 
   const newRepo = newRepos[0];
   const { title } = props;

--- a/src/components/CompareResults/hashToCommitLoader.ts
+++ b/src/components/CompareResults/hashToCommitLoader.ts
@@ -1,13 +1,18 @@
 import { checkValues, getComparisonInformation } from './loader';
 import { compareView } from '../../common/constants';
 import { fetchRevisionFromHash } from '../../logic/treeherder';
-import { Changeset, CompareResultsItem, Repository } from '../../types/state';
+import {
+  Changeset,
+  CompareResultsItem,
+  Repository,
+  HashToCommit,
+} from '../../types/state';
 import { Framework } from '../../types/types';
 
 // This function is responsible for fetching the data from the URL. It's called
-// by React Router DOM when the compare-hash-results path is requested.
-// This loader is the only one used by ./mach try perf, and due to recent
-// changes mach try perf we can't get instant push links to try when we push.
+// by React Router DOM when the compare-hash-results route is requested.
+// This loader is the current default, soon to be old route that ./mach try perf
+// uses, this will be the default until the lando api work is completed.
 // We attach a hash to the commit message and search for that hash, and return
 // the commit associated with that hash and update the baseRev and newRev
 export async function loader({ request }: { request: Request }) {
@@ -26,7 +31,7 @@ export async function loader({ request }: { request: Request }) {
   const pushed_today =
     new Date(newHashDateFromUrl).toISOString().split('T')[0] ==
     new Date().toISOString().split('T')[0];
-  let commits_from_hashes: CommitFromHashData = {
+  let commits_from_hashes: HashToCommit = {
     baseRevision: '',
     newRevision: '',
   };
@@ -89,8 +94,4 @@ type HashLoaderData = {
   generation: number;
 };
 
-type CommitFromHashData = {
-  baseRevision: string;
-  newRevision: string;
-};
 export type HashLoaderReturnValue = HashLoaderData;

--- a/src/components/CompareResults/landoToCommitLoader.ts
+++ b/src/components/CompareResults/landoToCommitLoader.ts
@@ -1,0 +1,66 @@
+import { checkValues, getComparisonInformation } from './loader';
+import { compareView } from '../../common/constants';
+import { fetchRevisionFromLandoId } from '../../logic/lando';
+import { Changeset, CompareResultsItem, Repository } from '../../types/state';
+import { Framework } from '../../types/types';
+
+// This function is responsible for fetching the data from the URL. It's called
+// by React Router DOM when the compare-lando-results route is requested.
+// This loader is used by ./mach try perf, and due to recent changes in
+// we now add the lando id. The lando id can be determined within about 30 seconds
+// of pushing to resolve to the treeherder commit
+export async function loader({ request }: { request: Request }) {
+  const url = new URL(request.url);
+  const baseLandoIDFromUrl = url.searchParams.get('baseLando');
+  const newLandoIDFromUrl = url.searchParams.get('newLando');
+  const baseRepoFromUrl = url.searchParams.get('baseRepo') as
+    | Repository['name']
+    | null;
+  const newReposFromUrl = url.searchParams.getAll(
+    'newRepo',
+  ) as Repository['name'][];
+  const frameworkFromUrl = url.searchParams.get('framework');
+  if (!baseLandoIDFromUrl || !newLandoIDFromUrl) {
+    throw new Error(
+      'Not all values were supplied please check you provided both baseLando and newLando',
+    );
+  }
+
+  const baseRevisionsFromLando =
+    await fetchRevisionFromLandoId(baseLandoIDFromUrl);
+  const newRevisionsFromLando =
+    await fetchRevisionFromLandoId(newLandoIDFromUrl);
+
+  const { baseRev, baseRepo, newRevs, newRepos, frameworkId, frameworkName } =
+    checkValues({
+      baseRev: baseRevisionsFromLando.commit_id,
+      baseRepo: baseRepoFromUrl,
+      newRevs: [newRevisionsFromLando.commit_id],
+      newRepos: newReposFromUrl,
+      framework: frameworkFromUrl,
+    });
+  return await getComparisonInformation(
+    baseRev,
+    baseRepo,
+    newRevs,
+    newRepos,
+    frameworkId,
+    frameworkName,
+  );
+}
+
+type LandoLoaderData = {
+  results: Promise<CompareResultsItem[][]>;
+  baseRev: string;
+  baseRevInfo: Changeset;
+  baseRepo: Repository['name'];
+  newRevs: string[];
+  newRevsInfo: Changeset[];
+  newRepos: Repository['name'][];
+  frameworkId: Framework['id'];
+  frameworkName: Framework['name'];
+  view: typeof compareView;
+  generation: number;
+};
+
+export type LandoLoaderReturnValue = LandoLoaderData;

--- a/src/logic/lando.ts
+++ b/src/logic/lando.ts
@@ -1,0 +1,19 @@
+import { LandoToCommit } from '../types/state';
+
+const landoBaseUrl = 'https://api.lando.services.mozilla.com';
+
+async function fetchFromLando(url: string) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `Error when requesting lando: (${response.status}) ${response.statusText}`,
+    );
+  }
+  return response;
+}
+
+export async function fetchRevisionFromLandoId(landoid: string) {
+  const url = `${landoBaseUrl}/landing_jobs/${landoid}`;
+  const response = await fetchFromLando(url);
+  return response.json() as Promise<LandoToCommit>;
+}

--- a/src/logic/treeherder.ts
+++ b/src/logic/treeherder.ts
@@ -5,7 +5,7 @@ import {
   CompareResultsItem,
   Repository,
   Changeset,
-  CommitToHash,
+  HashToCommit,
 } from '../types/state';
 import { Framework, TimeRange } from '../types/types';
 
@@ -64,7 +64,7 @@ export async function fetchRevisionFromHash(
   });
   const url = `${treeherderBaseURL}/api/project/${repo}/hash/tocommit/?${searchParams.toString()}`;
   const response = await fetchFromTreeherder(url);
-  return response.json() as Promise<CommitToHash>;
+  return response.json() as Promise<HashToCommit>;
 }
 
 async function fetchFromTreeherder(url: string) {

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -109,9 +109,15 @@ export type CompareResultsItem = {
   has_subtests: boolean;
 };
 
-export type CommitToHash = {
+export type HashToCommit = {
   baseRevision: string;
   newRevision: string;
+};
+
+export type LandoToCommit = {
+  commit_id: string;
+  id: string;
+  status: string;
 };
 
 export type InputType = 'base' | 'new';


### PR DESCRIPTION
In a previous PR I created a loader for perfcompare that used the ResultsView and created a page ./mach try perf could output a link to, and now that lando has ids for each push we can use that to make the links much shorter and more elegant.

Background to patch:
- In [my last PR](https://github.com/mozilla/perfcompare/pull/879) I created a compare-hash loader, it took 4 arguments(baseHash, newHash, baseHashDate, and newHashDate), the hashes were unique hashes of the time and author, attached within each pushes commit message, the dates were provided to narrow down the search range.
- This solution gave really long ugly urls and was complicated

Developments since the last patch:
- We now have lando ids being provided when we push to try and we can take the ids returned and get the treeherder hash

What I am doing in this patch:
- Creating a new loader that uses lando ids instead of this messy solution before and doing this the way that was supposed to have been available for this problem but wasn't

Dependancies:
- https://bugzilla.mozilla.org/show_bug.cgi?id=1965576