### PR TITLE
Refactor: Move Disabled Variants of DownloadButton and RetriggerButton

### DIFF
--- a/src/__tests__/CompareResults/Retrigger.test.tsx
+++ b/src/__tests__/CompareResults/Retrigger.test.tsx
@@ -1,7 +1,7 @@
 import userEvent from '@testing-library/user-event';
 import { Hooks } from 'taskcluster-client-web';
 
-import RetriggerButton from '../../components/CompareResults/Retrigger/RetriggerButton';
+import { RetriggerButton } from '../../components/CompareResults/Retrigger/RetriggerButton';
 import { loader } from '../../components/CompareResults/subtestsLoader';
 import SubtestsResultsMain from '../../components/CompareResults/SubtestsResults/SubtestsResultsMain';
 import { getLocationOrigin } from '../../utils/location';

--- a/src/components/CompareResults/DownloadButton.tsx
+++ b/src/components/CompareResults/DownloadButton.tsx
@@ -83,11 +83,31 @@ const styles = {
   }),
 };
 
+export function DisabledDownloadButton() {
+  return (
+    <Button
+      variant='contained'
+      color='secondary'
+      disabled
+      sx={{
+        height: '41px',
+        flex: 'none',
+        '& .MuiButtonBase-root': {
+          height: '100%',
+          width: '100%',
+        },
+      }}
+    >
+      Download JSON
+    </Button>
+  );
+}
+
 interface DownloadButtonProps {
   resultsPromise: Promise<CompareResultsItem[][]> | CompareResultsItem[][];
 }
 
-function DownloadButton({ resultsPromise }: DownloadButtonProps) {
+export function DownloadButton({ resultsPromise }: DownloadButtonProps) {
   const activeComparison = useAppSelector(
     (state) => state.comparison.activeComparison,
   );
@@ -138,5 +158,3 @@ function DownloadButton({ resultsPromise }: DownloadButtonProps) {
     </div>
   );
 }
-
-export default DownloadButton;

--- a/src/components/CompareResults/DownloadButton.tsx
+++ b/src/components/CompareResults/DownloadButton.tsx
@@ -85,21 +85,11 @@ const styles = {
 
 export function DisabledDownloadButton() {
   return (
-    <Button
-      variant='contained'
-      color='secondary'
-      disabled
-      sx={{
-        height: '41px',
-        flex: 'none',
-        '& .MuiButtonBase-root': {
-          height: '100%',
-          width: '100%',
-        },
-      }}
-    >
-      Download JSON
-    </Button>
+    <div className={styles.downloadButton}>
+      <Button variant='contained' color='secondary' disabled>
+        Download JSON
+      </Button>
+    </div>
   );
 }
 

--- a/src/components/CompareResults/ResultsControls.tsx
+++ b/src/components/CompareResults/ResultsControls.tsx
@@ -2,7 +2,7 @@ import FormControl from '@mui/material/FormControl';
 import Grid from '@mui/material/Grid';
 import { style } from 'typestyle';
 
-import DownloadButton from './DownloadButton';
+import { DownloadButton } from './DownloadButton';
 import RevisionSelect from './RevisionSelect';
 import SearchInput from './SearchInput';
 import { useAppSelector } from '../../hooks/app';

--- a/src/components/CompareResults/Retrigger/RetriggerButton.tsx
+++ b/src/components/CompareResults/Retrigger/RetriggerButton.tsx
@@ -23,12 +23,26 @@ import SnackbarCloseButton from '../../Shared/SnackbarCloseButton';
 
 type Status = 'pending' | 'signin-modal' | 'retrigger-modal';
 
+export function DisabledRetriggerButton() {
+  return (
+    <Button
+      title='Retrigger test'
+      color='primary'
+      variant='text'
+      startIcon={<RefreshOutlinedIcon />}
+      disabled
+    >
+      Retrigger test
+    </Button>
+  );
+}
+
 interface RetriggerButtonProps {
   result: CompareResultsItem;
   variant: 'icon' | 'text';
 }
 
-function RetriggerButton({ result, variant }: RetriggerButtonProps) {
+export function RetriggerButton({ result, variant }: RetriggerButtonProps) {
   const {
     base_repository_name: baseRepository,
     base_retriggerable_job_ids: baseRetriggerableJobIds,
@@ -190,5 +204,3 @@ function RetriggerButton({ result, variant }: RetriggerButtonProps) {
     </>
   );
 }
-
-export default RetriggerButton;

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -13,7 +13,7 @@ import { IconButton, Box } from '@mui/material';
 import Tooltip from '@mui/material/Tooltip';
 import { style } from 'typestyle';
 
-import RetriggerButton from './Retrigger/RetriggerButton';
+import { RetriggerButton } from './Retrigger/RetriggerButton';
 import RevisionRowExpandable from './RevisionRowExpandable';
 import { compareView, compareOverTimeView } from '../../common/constants';
 import { useAppSelector } from '../../hooks/app';

--- a/src/components/CompareResults/SubtestsResults/SubtestsResultsMain.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsResultsMain.tsx
@@ -1,7 +1,6 @@
 import { useState, Suspense } from 'react';
 
-import RefreshOutlinedIcon from '@mui/icons-material/RefreshOutlined';
-import { Grid, Skeleton, Stack, Link, Button } from '@mui/material';
+import { Grid, Skeleton, Stack, Link } from '@mui/material';
 import Alert from '@mui/material/Alert';
 import { Container } from '@mui/system';
 import { useLoaderData, Await } from 'react-router-dom';
@@ -10,7 +9,7 @@ import { style } from 'typestyle';
 import SubtestsBreadcrumbs from './SubtestsBreadcrumbs';
 import SubtestsResultsTable from './SubtestsResultsTable';
 import SubtestsRevisionHeader from './SubtestsRevisionHeader';
-import DownloadButton from '.././DownloadButton';
+import { DownloadButton, DisabledDownloadButton } from '.././DownloadButton';
 import SearchInput from '.././SearchInput';
 import { subtestsView, subtestsOverTimeView } from '../../../common/constants';
 import { useAppSelector } from '../../../hooks/app';
@@ -20,7 +19,10 @@ import type {
   CompareResultsItem,
   SubtestsRevisionsHeader,
 } from '../../../types/state';
-import RetriggerButton from '../Retrigger/RetriggerButton';
+import {
+  RetriggerButton,
+  DisabledRetriggerButton,
+} from '../Retrigger/RetriggerButton';
 import { LoaderReturnValue } from '../subtestsLoader';
 import { LoaderReturnValue as OvertimeLoaderReturnValue } from '../subtestsOverTimeLoader';
 
@@ -151,32 +153,10 @@ function SubtestsResultsMain({ view }: SubtestsResultsMainProps) {
                   />
                 </Grid>
                 <Grid item xs='auto'>
-                  <Button
-                    variant='contained'
-                    color='secondary'
-                    disabled
-                    sx={{
-                      height: '41px',
-                      flex: 'none',
-                      '& .MuiButtonBase-root': {
-                        height: '100%',
-                        width: '100%',
-                      },
-                    }}
-                  >
-                    Download JSON
-                  </Button>
+                  <DisabledDownloadButton />
                 </Grid>
                 <Grid item xs='auto'>
-                  <Button
-                    title='Retrigger test'
-                    color='primary'
-                    variant='text'
-                    startIcon={<RefreshOutlinedIcon />}
-                    disabled
-                  >
-                    Retrigger test
-                  </Button>
+                  <DisabledRetriggerButton />
                 </Grid>
               </Grid>
             </>


### PR DESCRIPTION
**Related PR: https://github.com/mozilla/perfcompare/pull/849**

## Summary

This PR co-locates their respective disabled variants (`DisabledRetriggerButton` and `DisabledDownloadButton`) into the same files and also refactors the export style of `RetriggerButton` and `DownloadButton` by converting them to named exports to ensure consistency. These disabled buttons were previously defined inline in `SubtestsResultsMain` and have now been extracted for better separation of concerns.

### Changes

- Converted `RetriggerButton` from default to named export to ensure consistency.
- Moved `DisabledRetriggerButton` from `SubtestsResultsMain` into the `RetriggerButton` file.
- Converted `DownloadButton` from default to named export to ensure consistency.
- Moved `DisabledDownloadButton` from `SubtestsResultsMain` into the `DownloadButton` file.
- Refactor `DisabledDownloadButton` to use `downloadButton` styles. 