### PR TITLE
Add a CODEOWNERS file for automatically requesting reviews for dependency updates

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# Automatically request reviews for dependency updates
+/package.json @esanuandra @beatrice-acasandrei @julienw
+/package-lock.json @esanuandra @beatrice-acasandrei @julienw
+


### PR DESCRIPTION
This will make it possible to enable dependency updates and get review requests automatically.

To review dependency updates, my process is something like that:
* look at all the transitive dependencies in package-lock.json (github shows a nice view of it), in case one of the dependencies pull a lot of new transitive ones.
* look at the changelog for the direct dependencies, especially for major and minor updates.
* Test the deploy preview for the most important things. Sometimes test locally if needed.
* If some simple changes are needed (for example test changes), usually I pull the PR locally (with the github cli), add a commit, and just `git push` to push the changes to the same PR. If the changes are small enough I don't usually ask for another review by somebody else.

