### PR TITLE
Do not do a request to taskcluster if there's no job to retrigger

### DIFF
--- a/src/components/CompareResults/Retrigger/RetriggerButton.tsx
+++ b/src/components/CompareResults/Retrigger/RetriggerButton.tsx
@@ -128,21 +128,27 @@ export function RetriggerButton({ result, variant }: RetriggerButtonProps) {
   }) => {
     setStatus('pending');
 
-    const baseRetriggerConfigPromise = getRetriggerConfig(
-      baseRepository,
-      baseRetriggerableJobIds[0],
-      baseTimes,
-    );
+    let baseRetriggerPromise = null;
+    if (baseRetriggerableJobIds.length > 0) {
+      baseRetriggerPromise = getRetriggerConfig(
+        baseRepository,
+        baseRetriggerableJobIds[0],
+        baseTimes,
+      ).then(retrigger);
+    }
 
-    const newRetriggerConfigPromise = getRetriggerConfig(
-      newRepository,
-      newRetriggerableJobIds[0],
-      newTimes,
-    );
+    let newRetriggerPromise = null;
+    if (newRetriggerableJobIds.length > 0) {
+      newRetriggerPromise = getRetriggerConfig(
+        newRepository,
+        newRetriggerableJobIds[0],
+        newTimes,
+      ).then(retrigger);
+    }
 
     const [baseRetriggerTaskId, newRetriggerTaskId] = await Promise.all([
-      baseRetriggerConfigPromise.then(retrigger),
-      newRetriggerConfigPromise.then(retrigger),
+      baseRetriggerPromise,
+      newRetriggerPromise,
     ]);
 
     // Note that the notification for "new" is dispatched before the


### PR DESCRIPTION
While I was testing #907 I realized that we're doing a request to treeherder even when we don't have a job id to retrigger (this is when we don't have a run for the selected revision). That request was returning a 500 error. When testing locally, webpack was showing a full page error (fortunately that wasn't happening in production).

Ideally we should also be able to start a run by copying the other run's configuration (PCF-71), but that's some more work.
Also ideally the select input in the modal should be disabled with some information given to the user, but similarly this was more work than I was willing to do right now.

So the goal of this PR is simply to avoid sending requests when we don't have a job to retrigger, because this request was incorrect (had "undefined" as the job id in its URL), and was returning an error 500.