### PR TITLE
Fix alignment of icon and text for the status column

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -578,7 +578,7 @@ exports[`Results View The table should match snapshot and other elements should 
               class="fw0pvlu"
             >
               <div
-                class="revisionRow f1r4bj33 f1dlt78d MuiBox-root css-oluxz7"
+                class="revisionRow f1macqb f1dlt78d MuiBox-root css-oluxz7"
                 role="row"
               >
                 <div
@@ -792,7 +792,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1r4bj33 f1dlt78d MuiBox-root css-oluxz7"
+                class="revisionRow f1macqb f1dlt78d MuiBox-root css-oluxz7"
                 role="row"
               >
                 <div
@@ -1007,7 +1007,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1r4bj33 f1dlt78d MuiBox-root css-oluxz7"
+                class="revisionRow f1macqb f1dlt78d MuiBox-root css-oluxz7"
                 role="row"
               >
                 <div
@@ -1200,7 +1200,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1r4bj33 f1dlt78d MuiBox-root css-oluxz7"
+                class="revisionRow f1macqb f1dlt78d MuiBox-root css-oluxz7"
                 role="row"
               >
                 <div

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -1361,7 +1361,7 @@ exports[`Results Table Should match snapshot 1`] = `
                           class="fw0pvlu"
                         >
                           <div
-                            class="revisionRow f1r4bj33 f1dlt78d MuiBox-root css-oluxz7"
+                            class="revisionRow f1macqb f1dlt78d MuiBox-root css-oluxz7"
                             role="row"
                           >
                             <div
@@ -1575,7 +1575,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </div>
                           </div>
                           <div
-                            class="revisionRow f1r4bj33 f1dlt78d MuiBox-root css-oluxz7"
+                            class="revisionRow f1macqb f1dlt78d MuiBox-root css-oluxz7"
                             role="row"
                           >
                             <div
@@ -1790,7 +1790,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </div>
                           </div>
                           <div
-                            class="revisionRow f1r4bj33 f1dlt78d MuiBox-root css-oluxz7"
+                            class="revisionRow f1macqb f1dlt78d MuiBox-root css-oluxz7"
                             role="row"
                           >
                             <div
@@ -2075,7 +2075,7 @@ exports[`Results Table Should match snapshot 1`] = `
                           class="fw0pvlu"
                         >
                           <div
-                            class="revisionRow f1r4bj33 f1dlt78d MuiBox-root css-oluxz7"
+                            class="revisionRow f1macqb f1dlt78d MuiBox-root css-oluxz7"
                             role="row"
                           >
                             <div
@@ -2645,7 +2645,7 @@ exports[`Results Table should render different blocks when rendering several rev
       </span>
     </div>
     <div
-      class="revisionRow f1r4bj33 f1dlt78d MuiBox-root css-oluxz7"
+      class="revisionRow f1macqb f1dlt78d MuiBox-root css-oluxz7"
       role="row"
     >
       <div
@@ -2899,7 +2899,7 @@ exports[`Results Table should render different blocks when rendering several rev
       </span>
     </div>
     <div
-      class="revisionRow f1r4bj33 f1dlt78d MuiBox-root css-oluxz7"
+      class="revisionRow f1macqb f1dlt78d MuiBox-root css-oluxz7"
       role="row"
     >
       <div

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -1261,7 +1261,7 @@ exports[`Results View The table should match snapshot and other elements should 
               class="fw0pvlu"
             >
               <div
-                class="revisionRow f1r4bj33 f1dlt78d MuiBox-root css-oluxz7"
+                class="revisionRow f1macqb f1dlt78d MuiBox-root css-oluxz7"
                 role="row"
               >
                 <div
@@ -1475,7 +1475,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1r4bj33 f1dlt78d MuiBox-root css-oluxz7"
+                class="revisionRow f1macqb f1dlt78d MuiBox-root css-oluxz7"
                 role="row"
               >
                 <div
@@ -1690,7 +1690,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1r4bj33 f1dlt78d MuiBox-root css-oluxz7"
+                class="revisionRow f1macqb f1dlt78d MuiBox-root css-oluxz7"
                 role="row"
               >
                 <div
@@ -1883,7 +1883,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1r4bj33 f1dlt78d MuiBox-root css-oluxz7"
+                class="revisionRow f1macqb f1dlt78d MuiBox-root css-oluxz7"
                 role="row"
               >
                 <div

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -610,7 +610,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 />
               </div>
               <div
-                class="revisionRow fmlrvsb f161t6v MuiBox-root css-ofrz12"
+                class="revisionRow f1l4wgcn f161t6v MuiBox-root css-ofrz12"
                 role="row"
               >
                 <div
@@ -787,7 +787,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow fmlrvsb f161t6v MuiBox-root css-ofrz12"
+                class="revisionRow f1l4wgcn f161t6v MuiBox-root css-ofrz12"
                 role="row"
               >
                 <div
@@ -939,7 +939,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow fmlrvsb f161t6v MuiBox-root css-ofrz12"
+                class="revisionRow f1l4wgcn f161t6v MuiBox-root css-ofrz12"
                 role="row"
               >
                 <div
@@ -1102,7 +1102,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow fmlrvsb f161t6v MuiBox-root css-ofrz12"
+                class="revisionRow f1l4wgcn f161t6v MuiBox-root css-ofrz12"
                 role="row"
               >
                 <div
@@ -1265,7 +1265,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow fmlrvsb f161t6v MuiBox-root css-ofrz12"
+                class="revisionRow f1l4wgcn f161t6v MuiBox-root css-ofrz12"
                 role="row"
               >
                 <div
@@ -2412,7 +2412,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 />
               </div>
               <div
-                class="revisionRow fmlrvsb f161t6v MuiBox-root css-ofrz12"
+                class="revisionRow f1l4wgcn f161t6v MuiBox-root css-ofrz12"
                 role="row"
               >
                 <div
@@ -2589,7 +2589,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow fmlrvsb f161t6v MuiBox-root css-ofrz12"
+                class="revisionRow f1l4wgcn f161t6v MuiBox-root css-ofrz12"
                 role="row"
               >
                 <div
@@ -2741,7 +2741,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow fmlrvsb f161t6v MuiBox-root css-ofrz12"
+                class="revisionRow f1l4wgcn f161t6v MuiBox-root css-ofrz12"
                 role="row"
               >
                 <div
@@ -2904,7 +2904,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow fmlrvsb f161t6v MuiBox-root css-ofrz12"
+                class="revisionRow f1l4wgcn f161t6v MuiBox-root css-ofrz12"
                 role="row"
               >
                 <div
@@ -3067,7 +3067,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow fmlrvsb f161t6v MuiBox-root css-ofrz12"
+                class="revisionRow f1l4wgcn f161t6v MuiBox-root css-ofrz12"
                 role="row"
               >
                 <div

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsRevisionRow.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsRevisionRow.test.tsx.snap
@@ -1,10 +1,10 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SubtestsRevisionRow Component renders browser name when base and new apps are different 1`] = `
 <body>
   <div>
     <div
-      class="revisionRow fmlrvsb f161t6v MuiBox-root css-1uflkrc"
+      class="revisionRow f1l4wgcn f161t6v MuiBox-root css-1uflkrc"
       role="row"
     >
       <div
@@ -188,7 +188,7 @@ exports[`SubtestsRevisionRow Component renders doesnt render browser name when b
 <body>
   <div>
     <div
-      class="revisionRow fmlrvsb f161t6v MuiBox-root css-1uflkrc"
+      class="revisionRow f1l4wgcn f161t6v MuiBox-root css-1uflkrc"
       role="row"
     >
       <div
@@ -347,7 +347,7 @@ exports[`SubtestsRevisionRow Component renders the component with correct data 1
 <body>
   <div>
     <div
-      class="revisionRow fmlrvsb f161t6v MuiBox-root css-1uflkrc"
+      class="revisionRow f1l4wgcn f161t6v MuiBox-root css-1uflkrc"
       role="row"
     >
       <div

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -99,6 +99,7 @@ const revisionRow = style({
       gap: '6px',
       borderRadius: '4px',
       padding: '4px 10px',
+      alignItems: 'center',
     },
 
     '.status-hint .MuiSvgIcon-root': {

--- a/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
@@ -59,6 +59,7 @@ const revisionRow = style({
       gap: '6px',
       borderRadius: '4px',
       padding: '4px 10px',
+      alignItems: 'center',
     },
 
     '.status-hint .MuiSvgIcon-root': {


### PR DESCRIPTION
Reported by @padenot

May be regressed by https://github.com/mozilla/perfcompare/pull/899 (I touched a little bit this code in that PR)

Before:
![image](https://github.com/user-attachments/assets/e3e25d8a-9d91-4a47-aebf-525fb941fab1)

After:
![image](https://github.com/user-attachments/assets/a383c797-0837-4ba2-bcc0-ccd29551c3e2)


[Production](https://perf.compare/compare-lando-results?baseLando=140271&newLando=140282&baseRepo=try&newRepo=try&framework=15) / [Deploy preview](https://deploy-preview-914--mozilla-perfcompare.netlify.app/compare-lando-results?baseLando=140271&newLando=140282&baseRepo=try&newRepo=try&framework=15)