### PR TITLE
#1931317 Show N/A string instead of 0 deviation

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -95,11 +95,7 @@ exports[`Results View Should display Base, New and Common graphs with replicates
               <div
                 class="fnujpat"
               >
-                6.96
-                 
-                 = 
-                1.17
-                % standard deviation
+                6.96  = 1.17% standard deviation
               </div>
             </div>
             <div
@@ -162,11 +158,7 @@ exports[`Results View Should display Base, New and Common graphs with replicates
               <div
                 class="fnujpat"
               >
-                0.84
-                 
-                 = 
-                0.14
-                % standard deviation
+                0.84  = 0.14% standard deviation
               </div>
             </div>
           </div>
@@ -404,11 +396,7 @@ exports[`Results View Should display Base, New and Common graphs with tooltips 1
               <div
                 class="fnujpat"
               >
-                6.96
-                 
-                 = 
-                1.17
-                % standard deviation
+                6.96  = 1.17% standard deviation
               </div>
             </div>
             <div
@@ -471,11 +459,7 @@ exports[`Results View Should display Base, New and Common graphs with tooltips 1
               <div
                 class="fnujpat"
               >
-                0.84
-                 
-                 = 
-                0.14
-                % standard deviation
+                0.84  = 0.14% standard deviation
               </div>
             </div>
           </div>

--- a/src/components/CompareResults/RunValues.tsx
+++ b/src/components/CompareResults/RunValues.tsx
@@ -88,7 +88,7 @@ function RunValues(props: RunValuesProps) {
       <div className={styles.deviation}>
         {values.length > 1
           ? `${stddev} ${unit} = ${stddevPercent}% standard deviation`
-          : `${stddev} ${unit} = N/A standard deviation`}
+          : 'N/A standard deviation'}
       </div>
     </>
   );

--- a/src/components/CompareResults/RunValues.tsx
+++ b/src/components/CompareResults/RunValues.tsx
@@ -37,7 +37,6 @@ function RunValues(props: RunValuesProps) {
   const displayedValues = 100;
   const firstValues = values.slice(0, displayedValues);
   const lastValues = values.slice(displayedValues);
-
   const [expanded, setExpanded] = useState(false);
   const toggleIsExpanded = () => {
     setExpanded(!expanded);
@@ -87,7 +86,9 @@ function RunValues(props: RunValuesProps) {
         {measurementUnit}
       </div>
       <div className={styles.deviation}>
-        {stddev} {unit} = {stddevPercent}% standard deviation
+        {values.length > 1
+          ? `${stddev} ${unit} = ${stddevPercent}% standard deviation`
+          : `${stddev} ${unit} = N/A standard deviation`}
       </div>
     </>
   );


### PR DESCRIPTION
I'm a bit unsure about understanding the business logic correctly on the bug. Or what we would want as the string response for the standard deviation but I figure I'll just do the PR and get eyes on it quickly. 

<img width="1162" height="505" alt="Screenshot 2025-08-13 at 2 07 35 PM" src="https://github.com/user-attachments/assets/2abfb877-c31b-4cd8-b890-947f51e784ba" />


[Deploy preview](https://deploy-preview-924--mozilla-perfcompare.netlify.app/compare-results?baseRev=7d880ff29269122bc521b3f69a643a3b7158a8eb&baseRepo=mozilla-central&newRev=31224efda311facc4ea54446610fd7c52d5d22a1&newRepo=try&framework=13&search=wikipedia)