### PR TITLE
Bug-2022758: Remove redundant Dark fonts

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -390,7 +390,7 @@ exports[`Results Table Should match snapshot 1`] = `
                           class="selectedRevision_fubtarc MuiBox-root css-0"
                         >
                           <div
-                            class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                            class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
                           >
                             <span
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -675,7 +675,7 @@ exports[`Results Table Should match snapshot 1`] = `
                           class="selectedRevision_fubtarc MuiBox-root css-0"
                         >
                           <div
-                            class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                            class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
                           >
                             <span
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -3073,7 +3073,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                           class="selectedRevision_fubtarc MuiBox-root css-0"
                         >
                           <div
-                            class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                            class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
                           >
                             <span
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -3358,7 +3358,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                           class="selectedRevision_fubtarc MuiBox-root css-0"
                         >
                           <div
-                            class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                            class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
                           >
                             <span
                               class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"

--- a/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
@@ -565,7 +565,7 @@ exports[`Compare Over Time renders correctly when there are no results: Initial 
               class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
-                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
               >
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -1223,7 +1223,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
               class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
-                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
               >
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -1553,7 +1553,7 @@ exports[`Compare Over Time should have an edit mode in Results View: Initial sta
               class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
-                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
               >
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -2269,7 +2269,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
               class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
-                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
               >
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -2408,7 +2408,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
               class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
-                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
               >
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -2911,7 +2911,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
               class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
-                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
               >
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -3241,7 +3241,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
               class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
-                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
               >
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"

--- a/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
@@ -218,7 +218,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
               class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
-                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
               >
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -523,7 +523,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
               class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
-                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
               >
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -1018,7 +1018,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
               class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
-                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
               >
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -1532,7 +1532,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
               class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
-                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
               >
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -1837,7 +1837,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
               class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
-                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
               >
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -2210,7 +2210,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
               class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
-                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
               >
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -2515,7 +2515,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
               class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
-                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
               >
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -3037,7 +3037,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
               class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
-                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
               >
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -3446,7 +3446,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
               class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
-                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
               >
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"

--- a/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
           </span>
         </div>
         <div
-          class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+          class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
         >
           <span
             class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -170,7 +170,7 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
           </span>
         </div>
         <div
-          class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+          class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
         >
           <span
             class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -282,7 +282,7 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
           </span>
         </div>
         <div
-          class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+          class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
         >
           <span
             class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -394,7 +394,7 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
           </span>
         </div>
         <div
-          class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+          class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
         >
           <span
             class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -506,7 +506,7 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
           </span>
         </div>
         <div
-          class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+          class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
         >
           <span
             class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -618,7 +618,7 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
           </span>
         </div>
         <div
-          class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+          class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
         >
           <span
             class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -730,7 +730,7 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
           </span>
         </div>
         <div
-          class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+          class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
         >
           <span
             class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -1202,7 +1202,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                   </span>
                                 </div>
                                 <div
-                                  class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                                  class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
                                 >
                                   <span
                                     class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -1314,7 +1314,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                   </span>
                                 </div>
                                 <div
-                                  class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                                  class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
                                 >
                                   <span
                                     class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -1426,7 +1426,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                   </span>
                                 </div>
                                 <div
-                                  class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                                  class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
                                 >
                                   <span
                                     class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -1538,7 +1538,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                   </span>
                                 </div>
                                 <div
-                                  class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                                  class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
                                 >
                                   <span
                                     class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -1650,7 +1650,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                   </span>
                                 </div>
                                 <div
-                                  class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                                  class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
                                 >
                                   <span
                                     class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -1762,7 +1762,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                   </span>
                                 </div>
                                 <div
-                                  class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                                  class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
                                 >
                                   <span
                                     class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -1874,7 +1874,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                   </span>
                                 </div>
                                 <div
-                                  class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                                  class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
                                 >
                                   <span
                                     class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"

--- a/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
@@ -1351,7 +1351,7 @@ exports[`With search parameters both search components are populated as expected
               class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
-                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
               >
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -1872,7 +1872,7 @@ exports[`With search parameters both search components are populated as expected
               class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
-                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
               >
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -2402,7 +2402,7 @@ exports[`With search parameters both search components are populated as expected
               class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
-                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
               >
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -2923,7 +2923,7 @@ exports[`With search parameters both search components are populated as expected
               class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
-                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
               >
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -3453,7 +3453,7 @@ exports[`With search parameters displays the default value for framework if the 
               class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
-                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
               >
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -3974,7 +3974,7 @@ exports[`With search parameters displays the default value for framework if the 
               class="selectedRevision_fubtarc MuiBox-root css-0"
             >
               <div
-                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
               >
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"

--- a/src/__tests__/Search/__snapshots__/SelectedRevision.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SelectedRevision.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`SelectedRevision should show the selected checked revisions once a resu
     class="selectedRevision_fubtarc MuiBox-root css-0"
   >
     <div
-      class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+      class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
     >
       <span
         class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"

--- a/src/components/CompareResults/OverTimeResultsView.tsx
+++ b/src/components/CompareResults/OverTimeResultsView.tsx
@@ -33,7 +33,7 @@ function ResultsView(props: ResultsViewProps) {
     }),
   };
 
-  const sectionStyles = SearchContainerStyles(themeMode, /* isHome */ false);
+  const sectionStyles = SearchContainerStyles(/* isHome */ false);
 
   useEffect(() => {
     document.title = title;

--- a/src/components/CompareResults/ResultsView.tsx
+++ b/src/components/CompareResults/ResultsView.tsx
@@ -41,7 +41,7 @@ function ResultsView(props: ResultsViewProps) {
     }),
   };
 
-  const sectionStyles = SearchContainerStyles(themeMode, /* isHome */ false);
+  const sectionStyles = SearchContainerStyles(/* isHome */ false);
 
   useEffect(() => {
     document.title = title;

--- a/src/components/Search/SearchContainer.tsx
+++ b/src/components/Search/SearchContainer.tsx
@@ -8,7 +8,6 @@ import CompareWithBase from './CompareWithBase';
 import type { LoaderReturnValue } from './loader';
 import SearchFormHeader from './SearchFormHeader';
 import { STUDENT_T } from '../../common/constants';
-import { useAppSelector } from '../../hooks/app';
 import { Strings } from '../../resources/Strings';
 import { SearchContainerStyles } from '../../styles';
 import type { TimeRange } from '../../types/types';
@@ -16,8 +15,7 @@ import type { TimeRange } from '../../types/types';
 const strings = Strings.components.searchDefault;
 
 function SearchContainer(props: SearchViewProps) {
-  const themeMode = useAppSelector((state) => state.theme.mode);
-  const styles = SearchContainerStyles(themeMode, /* isHome */ true);
+  const styles = SearchContainerStyles(/* isHome */ true);
   const [isBaseSearchExpanded, setIsBaseSearchExpanded] = useState(true);
   const { newRevInfo, newRepo, frameworkId } =
     useLoaderData<LoaderReturnValue>();

--- a/src/components/Shared/PageError.tsx
+++ b/src/components/Shared/PageError.tsx
@@ -24,7 +24,7 @@ export function PageError({ title }: PageErrorProps) {
     }),
   };
 
-  const sectionStyles = SearchContainerStyles(themeMode, /* isHome */ false);
+  const sectionStyles = SearchContainerStyles(/* isHome */ false);
 
   const error = useRouteError() as Error;
   console.error(error);

--- a/src/components/Shared/ToggleDarkModeButton.tsx
+++ b/src/components/Shared/ToggleDarkModeButton.tsx
@@ -31,9 +31,7 @@ function ToggleDarkMode() {
       margin: 0,
       $nest: {
         '.toggle-text': {
-          ...(theme === 'light'
-            ? FontsRaw.BodyDefault
-            : FontsRaw.BodyDefaultDark),
+          ...FontsRaw.BodyDefault,
           margin: 0,
         },
         '.toggle-switch': {

--- a/src/styles/CompareCards.ts
+++ b/src/styles/CompareCards.ts
@@ -122,12 +122,10 @@ export const CompareCardsStyles = (mode: string) => {
       width: '76%',
       $nest: {
         '.compare-card-title': {
-          ...(isTrueLight
-            ? FontsRaw.HeadingDefault
-            : FontsRaw.HeadingDefaultDark),
+          ...FontsRaw.HeadingDefault,
         },
         '.compare-card-tagline': {
-          ...(isTrueLight ? FontsRaw.BodyDefault : FontsRaw.BodyDefaultDark),
+          ...FontsRaw.BodyDefault,
           margin: '0px',
         },
       },
@@ -166,7 +164,7 @@ export const SearchStyles = (mode: string) => {
       marginBottom: `${Spacing.xSmall + 2}px`,
       $nest: {
         '.dropdown-select-label,.base_label': {
-          ...(isTrueLight ? FontsRaw.BodyDefault : FontsRaw.BodyDefaultDark),
+          ...FontsRaw.BodyDefault,
           fontWeight: '600',
           display: 'flex',
           alignItems: 'center',

--- a/src/styles/Fonts.ts
+++ b/src/styles/Fonts.ts
@@ -59,37 +59,12 @@ export const FontsRaw = {
     fontSize: FontSizeRaw.Normal.fontSize,
     fontFamily: 'SF Pro',
   },
-
-  //DARK MODE FONTS
-
-  HeadingDefaultDark: {
-    ...sharedFontStyles,
-    fontWeight: '600',
-    fontSize: '17px',
-    fontFamily: 'SF Pro',
-  },
-
-  HeadingXSDark: {
-    ...sharedFontStyles,
-    fontSize: '24px',
-    fontFamily: 'Metropolis',
-  },
-
-  BodyDefaultDark: {
-    ...sharedFontStyles,
-    fontWeight: '400',
-    fontSize: FontSizeRaw.Normal.fontSize,
-    fontFamily: 'SF Pro',
-  },
 };
 
 export const Fonts = {
   HeadingDefault: style(FontsRaw.HeadingDefault),
   HeadingXS: style(FontsRaw.HeadingXS),
   BodyDefault: style(FontsRaw.BodyDefault),
-  HeadingDefaultDark: style(FontsRaw.HeadingDefaultDark),
-  HeadingXSDark: style(FontsRaw.HeadingXSDark),
-  BodyDefaultDark: style(FontsRaw.BodyDefaultDark),
 };
 
 export const FontSize = {

--- a/src/styles/SearchContainerStyles.ts
+++ b/src/styles/SearchContainerStyles.ts
@@ -2,9 +2,7 @@ import { stylesheet } from 'typestyle';
 
 import { FontsRaw, Spacing } from '../styles';
 
-export const SearchContainerStyles = (mode: string, isHome: boolean) => {
-  const isTrueLight = mode == 'light';
-
+export const SearchContainerStyles = (isHome: boolean) => {
   const styles = stylesheet({
     container: {
       /*** maxWidth based on mozilla protocol large cards size; see https://protocol.mozilla.org/components/detail/card--large
@@ -18,7 +16,7 @@ export const SearchContainerStyles = (mode: string, isHome: boolean) => {
       flexDirection: 'column',
       $nest: {
         '.search-default-title': {
-          ...(isTrueLight ? FontsRaw.HeadingXS : FontsRaw.HeadingXSDark),
+          ...FontsRaw.HeadingXS,
           marginBottom: `${Spacing.xLarge + 10}px`,
           textAlign: 'center',
         },

--- a/src/styles/SelectedRevsStyle.ts
+++ b/src/styles/SelectedRevsStyle.ts
@@ -27,7 +27,7 @@ export const SelectRevsStyles = (mode: string) => {
           },
         },
         '.item-container': {
-          ...(isTrueLight ? FontsRaw.BodyDefault : FontsRaw.BodyDefaultDark),
+          ...FontsRaw.BodyDefault,
           backgroundColor: isTrueLight
             ? Colors.Background200
             : Colors.Background300Dark,


### PR DESCRIPTION
Changes introduced:
* `fonts.ts`: Remove the redundant Dark fonts.
* Updated files using the affected Dark fonts
* Updated snapshots by running `npm run fix-all`

Fixes [Bug-2022758](https://bugzilla.mozilla.org/show_bug.cgi?id=2022758)