### PR TITLE
 Bug 2026342 : Replace truncated subtest names with full name 

### DIFF
--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -398,9 +398,9 @@ describe('App', () => {
 
       // Verify that Mann-Whitney-U specific columns are rendered
       // (this indicates the testVersion defaulted to mann-whitney-u)
-      expect(screen.getByText("Cliff's Delta")).toBeInTheDocument();
-      expect(screen.getByText('Significance')).toBeInTheDocument();
-      expect(screen.getByText('CLES(%)')).toBeInTheDocument();
+      expect(screen.getByText('CD')).toBeInTheDocument();
+      expect(screen.getByText('Sig')).toBeInTheDocument();
+      expect(screen.getByText('CLES (%)')).toBeInTheDocument();
 
       // Verify the Stats Test Version dropdown shows Mann-Whitney-U as selected
       const testVersionDropdown = screen.getByRole('combobox', {

--- a/src/__tests__/CompareResults/ResultsTable.test.tsx
+++ b/src/__tests__/CompareResults/ResultsTable.test.tsx
@@ -716,9 +716,9 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
       '  rev: devilrabbit',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
     ]);
     expect(screen.getByRole('rowgroup')).toMatchSnapshot();
   });
@@ -742,12 +742,12 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await screen.findByText('a11yr');
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
-      '  - inexistant, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, Not significant, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
-      '  - Windows 10, -, , -, Significant, 100.00 %',
-      '  - Windows 10, -2.401 %, , -, Significant, 50.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - inexistant, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - Windows 10, -, , -, , 100.00 %',
+      '  - Windows 10, -2.401 %, , -, , 50.00 %',
     ]);
 
     expect(summarizeTableFiltersFromUrl()).toEqual({});
@@ -756,9 +756,9 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', /Windows/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, Not significant, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       platform: ['osx', 'linux', 'android', 'ios'],
@@ -769,12 +769,12 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', /Windows/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
-      '  - inexistant, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, Not significant, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
-      '  - Windows 10, -, , -, Significant, 100.00 %',
-      '  - Windows 10, -2.401 %, , -, Significant, 50.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - inexistant, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - Windows 10, -, , -, , 100.00 %',
+      '  - Windows 10, -2.401 %, , -, , 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({});
 
@@ -782,8 +782,8 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', /Linux/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       platform: ['osx', 'android', 'ios'],
@@ -792,9 +792,9 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', /Linux/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, Not significant, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       platform: ['osx', 'android', 'ios', 'linux'],
@@ -803,22 +803,22 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', 'Select all values');
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
-      '  - inexistant, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, Not significant, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
-      '  - Windows 10, -, , -, Significant, 100.00 %',
-      '  - Windows 10, -2.401 %, , -, Significant, 50.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - inexistant, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - Windows 10, -, , -, , 100.00 %',
+      '  - Windows 10, -2.401 %, , -, , 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({});
 
     await clickMenuItem(user, 'Platform', /macOS/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, Not significant, 45.00 %',
-      '  - Windows 10, -, , -, Significant, 100.00 %',
-      '  - Windows 10, -2.401 %, , -, Significant, 50.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
+      '  - Windows 10, -, , -, , 100.00 %',
+      '  - Windows 10, -2.401 %, , -, , 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       platform: ['windows', 'linux', 'android', 'ios'],
@@ -827,9 +827,9 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', /Android/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Linux 18.04, 1.849 %, Regression, -, Not significant, 45.00 %',
-      '  - Windows 10, -, , -, Significant, 100.00 %',
-      '  - Windows 10, -2.401 %, , -, Significant, 50.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
+      '  - Windows 10, -, , -, , 100.00 %',
+      '  - Windows 10, -2.401 %, , -, , 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       platform: ['windows', 'linux', 'ios'],
@@ -838,7 +838,7 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', /Select only.*Android/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, -, 25.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       platform: ['android'],
@@ -853,8 +853,10 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
     // Filter only "Significant"
-    const signifianceMenu = await screen.findAllByText(/Significance/);
-    await user.click(signifianceMenu[1]);
+    const signifianceMenu = await screen.findByRole('button', {
+      name: /Sig.*filter/,
+    });
+    await user.click(signifianceMenu);
     expect(signifianceMenu).toMatchSnapshot();
 
     // significant item 0 and Not significant item 1
@@ -875,10 +877,10 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await screen.findByText('a11yr');
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Linux 18.04, 1.849 %, Regression, -, Not significant, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
-      '  - Windows 10, -, , -, Significant, 100.00 %',
-      '  - Windows 10, -2.401 %, , -, Significant, 50.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - Windows 10, -, , -, , 100.00 %',
+      '  - Windows 10, -2.401 %, , -, , 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({});
 
@@ -886,8 +888,8 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Status', /No changes/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Linux 18.04, 1.849 %, Regression, -, Not significant, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       status: ['improvement', 'regression'],
@@ -896,7 +898,7 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Status', /Improvement/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Linux 18.04, 1.849 %, Regression, -, Not significant, 45.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       status: ['regression'],
@@ -906,9 +908,9 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Status', /Regression/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
-      '  - Windows 10, -, , -, Significant, 100.00 %',
-      '  - Windows 10, -2.401 %, , -, Significant, 50.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - Windows 10, -, , -, , 100.00 %',
+      '  - Windows 10, -2.401 %, , -, , 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       status: ['none', 'improvement'],
@@ -917,17 +919,17 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Status', /Regression/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Linux 18.04, 1.849 %, Regression, -, Not significant, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
-      '  - Windows 10, -, , -, Significant, 100.00 %',
-      '  - Windows 10, -2.401 %, , -, Significant, 50.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - Windows 10, -, , -, , 100.00 %',
+      '  - Windows 10, -2.401 %, , -, , 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({});
 
     await clickMenuItem(user, 'Status', /Select only.*Regression/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Linux 18.04, 1.849 %, Regression, -, Not significant, 45.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       status: ['regression'],
@@ -936,7 +938,7 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Status', /Select only.*Improvement/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       status: ['improvement'],
@@ -953,12 +955,12 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
 
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
     ]);
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     expect(await summarizeTableFiltersFromCheckboxes(user)).toEqual({
       'Platform(2)': ['macOS', 'Android'],
-      'Significance(2)': ['Significant', 'Not Significant'],
+      'Sig(2)': ['Significant', 'Not Significant-'],
       'Status(3)': ['No changes', 'Improvement', 'Regression'],
     });
 
@@ -982,33 +984,33 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
     // Sort by Cliff's Delta
-    const deltaButton = screen.getByRole('button', { name: /Cliff's Delta/ });
+    const deltaButton = screen.getByRole('button', { name: /CD/ });
     expect(deltaButton).toMatchSnapshot();
 
     // // Sort descending
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr aria.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - Linux 18.04, 1.849 %, Regression, 1.2, Not significant, 44.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 1.3, Not significant, 24.00 %',
-      '  - Windows 10, -, , 1.2, Significant, 99.00 %',
-      '  - Windows 10, -2.401 %, , 1.2, Significant, 49.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 1.2, -, 44.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 1.3, -, 24.00 %',
+      '  - Windows 10, -, , 1.2, , 99.00 %',
+      '  - Windows 10, -2.401 %, , 1.2, , 49.00 %',
       '  rev: tictactoe',
-      '  - Linux 18.04, 1.849 %, Regression, 2, Not significant, 43.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 2.1, Not significant, 23.00 %',
-      '  - Windows 10, -, , 2, Significant, 98.00 %',
-      '  - Windows 10, -2.401 %, , 2, Significant, 48.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 2, -, 43.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 2.1, -, 23.00 %',
+      '  - Windows 10, -, , 2, , 98.00 %',
+      '  - Windows 10, -2.401 %, , 2, , 48.00 %',
       'a11yr dhtml.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - Linux 18.04, 1.849 %, Regression, -, Not significant, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
-      '  - Windows 10, -, , -, Significant, 100.00 %',
-      '  - Windows 10, -2.401 %, , -, Significant, 50.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - Windows 10, -, , -, , 100.00 %',
+      '  - Windows 10, -2.401 %, , -, , 50.00 %',
       '  rev: tictactoe',
-      '  - Linux 18.04, 1.849 %, Regression, 0.8, Not significant, 44.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.9, Not significant, 24.00 %',
-      '  - Windows 10, -, , 0.8, Significant, 99.00 %',
-      '  - Windows 10, -2.401 %, , 0.8, Significant, 49.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 0.8, -, 44.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.9, -, 24.00 %',
+      '  - Windows 10, -, , 0.8, , 99.00 %',
+      '  - Windows 10, -2.401 %, , 0.8, , 49.00 %',
     ]);
     // It should have the "descending" SVG.
     expect(deltaButton).toMatchSnapshot();
@@ -1020,26 +1022,26 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr aria.html opt e10s fission stylo webrender',
       '  rev: tictactoe',
-      '  - macOS 10.15, 1.078 %, Improvement, 2.1, Not significant, 23.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 2, Not significant, 43.00 %',
-      '  - Windows 10, -2.401 %, , 2, Significant, 48.00 %',
-      '  - Windows 10, -, , 2, Significant, 98.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 2.1, -, 23.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 2, -, 43.00 %',
+      '  - Windows 10, -2.401 %, , 2, , 48.00 %',
+      '  - Windows 10, -, , 2, , 98.00 %',
       '  rev: spam',
-      '  - macOS 10.15, 1.078 %, Improvement, 1.3, Not significant, 24.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 1.2, Not significant, 44.00 %',
-      '  - Windows 10, -2.401 %, , 1.2, Significant, 49.00 %',
-      '  - Windows 10, -, , 1.2, Significant, 99.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 1.3, -, 24.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 1.2, -, 44.00 %',
+      '  - Windows 10, -2.401 %, , 1.2, , 49.00 %',
+      '  - Windows 10, -, , 1.2, , 99.00 %',
       'a11yr dhtml.html opt e10s fission stylo webrender',
       '  rev: tictactoe',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.9, Not significant, 24.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 0.8, Not significant, 44.00 %',
-      '  - Windows 10, -2.401 %, , 0.8, Significant, 49.00 %',
-      '  - Windows 10, -, , 0.8, Significant, 99.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.9, -, 24.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 0.8, -, 44.00 %',
+      '  - Windows 10, -2.401 %, , 0.8, , 49.00 %',
+      '  - Windows 10, -, , 0.8, , 99.00 %',
       '  rev: spam',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, Not significant, 45.00 %',
-      '  - Windows 10, -2.401 %, , -, Significant, 50.00 %',
-      '  - Windows 10, -, , -, Significant, 100.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
+      '  - Windows 10, -2.401 %, , -, , 50.00 %',
+      '  - Windows 10, -, , -, , 100.00 %',
     ]);
     // It should have the "ascending" SVG.
     expect(deltaButton).toMatchSnapshot();
@@ -1048,32 +1050,32 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
 
     // Sort by Significance descending
     const significanceButton = screen.getByRole('button', {
-      name: /Significance.*sort/,
+      name: /Sig.*sort/,
     });
     await user.click(significanceButton);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr aria.html opt e10s fission stylo webrender',
       '  rev: tictactoe',
-      '  - macOS 10.15, 1.078 %, Improvement, 2.1, Not significant, 23.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 2, Not significant, 43.00 %',
-      '  - Windows 10, -, , 2, Significant, 98.00 %',
-      '  - Windows 10, -2.401 %, , 2, Significant, 48.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 2.1, -, 23.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 2, -, 43.00 %',
+      '  - Windows 10, -, , 2, , 98.00 %',
+      '  - Windows 10, -2.401 %, , 2, , 48.00 %',
       '  rev: spam',
-      '  - macOS 10.15, 1.078 %, Improvement, 1.3, Not significant, 24.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 1.2, Not significant, 44.00 %',
-      '  - Windows 10, -, , 1.2, Significant, 99.00 %',
-      '  - Windows 10, -2.401 %, , 1.2, Significant, 49.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 1.3, -, 24.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 1.2, -, 44.00 %',
+      '  - Windows 10, -, , 1.2, , 99.00 %',
+      '  - Windows 10, -2.401 %, , 1.2, , 49.00 %',
       'a11yr dhtml.html opt e10s fission stylo webrender',
       '  rev: tictactoe',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.9, Not significant, 24.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 0.8, Not significant, 44.00 %',
-      '  - Windows 10, -, , 0.8, Significant, 99.00 %',
-      '  - Windows 10, -2.401 %, , 0.8, Significant, 49.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.9, -, 24.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 0.8, -, 44.00 %',
+      '  - Windows 10, -, , 0.8, , 99.00 %',
+      '  - Windows 10, -2.401 %, , 0.8, , 49.00 %',
       '  rev: spam',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, Not significant, 45.00 %',
-      '  - Windows 10, -, , -, Significant, 100.00 %',
-      '  - Windows 10, -2.401 %, , -, Significant, 50.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
+      '  - Windows 10, -, , -, , 100.00 %',
+      '  - Windows 10, -2.401 %, , -, , 50.00 %',
     ]);
     // It should have the "descending" SVG.
     expect(significanceButton).toMatchSnapshot();
@@ -1085,26 +1087,26 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - Windows 10, -2.401 %, , -, Significant, 50.00 %',
-      '  - Windows 10, -, , -, Significant, 100.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, Not significant, 45.00 %',
+      '  - Windows 10, -2.401 %, , -, , 50.00 %',
+      '  - Windows 10, -, , -, , 100.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
       '  rev: tictactoe',
-      '  - Windows 10, -2.401 %, , 0.8, Significant, 49.00 %',
-      '  - Windows 10, -, , 0.8, Significant, 99.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.9, Not significant, 24.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 0.8, Not significant, 44.00 %',
+      '  - Windows 10, -2.401 %, , 0.8, , 49.00 %',
+      '  - Windows 10, -, , 0.8, , 99.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.9, -, 24.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 0.8, -, 44.00 %',
       'a11yr aria.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - Windows 10, -2.401 %, , 1.2, Significant, 49.00 %',
-      '  - Windows 10, -, , 1.2, Significant, 99.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 1.3, Not significant, 24.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 1.2, Not significant, 44.00 %',
+      '  - Windows 10, -2.401 %, , 1.2, , 49.00 %',
+      '  - Windows 10, -, , 1.2, , 99.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 1.3, -, 24.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 1.2, -, 44.00 %',
       '  rev: tictactoe',
-      '  - Windows 10, -2.401 %, , 2, Significant, 48.00 %',
-      '  - Windows 10, -, , 2, Significant, 98.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 2.1, Not significant, 23.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 2, Not significant, 43.00 %',
+      '  - Windows 10, -2.401 %, , 2, , 48.00 %',
+      '  - Windows 10, -, , 2, , 98.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 2.1, -, 23.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 2, -, 43.00 %',
     ]);
     // It should have the "descending" SVG.
     expect(significanceButton).toMatchSnapshot();
@@ -1113,32 +1115,32 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
 
     // Sort by Effect Size (%) descending
     const effectSizeButton = screen.getByRole('button', {
-      name: /CLES\(%\).*sort/,
+      name: /CLES \(%\).*sort/,
     });
     await user.click(effectSizeButton);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - Windows 10, -, , -, Significant, 100.00 %',
-      '  - Windows 10, -2.401 %, , -, Significant, 50.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, Not significant, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
+      '  - Windows 10, -, , -, , 100.00 %',
+      '  - Windows 10, -2.401 %, , -, , 50.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
       '  rev: tictactoe',
-      '  - Windows 10, -, , 0.8, Significant, 99.00 %',
-      '  - Windows 10, -2.401 %, , 0.8, Significant, 49.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 0.8, Not significant, 44.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.9, Not significant, 24.00 %',
+      '  - Windows 10, -, , 0.8, , 99.00 %',
+      '  - Windows 10, -2.401 %, , 0.8, , 49.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 0.8, -, 44.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.9, -, 24.00 %',
       'a11yr aria.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - Windows 10, -, , 1.2, Significant, 99.00 %',
-      '  - Windows 10, -2.401 %, , 1.2, Significant, 49.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 1.2, Not significant, 44.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 1.3, Not significant, 24.00 %',
+      '  - Windows 10, -, , 1.2, , 99.00 %',
+      '  - Windows 10, -2.401 %, , 1.2, , 49.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 1.2, -, 44.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 1.3, -, 24.00 %',
       '  rev: tictactoe',
-      '  - Windows 10, -, , 2, Significant, 98.00 %',
-      '  - Windows 10, -2.401 %, , 2, Significant, 48.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 2, Not significant, 43.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 2.1, Not significant, 23.00 %',
+      '  - Windows 10, -, , 2, , 98.00 %',
+      '  - Windows 10, -2.401 %, , 2, , 48.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 2, -, 43.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 2.1, -, 23.00 %',
     ]);
 
     expect(effectSizeButton).toMatchSnapshot();
@@ -1150,26 +1152,26 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr aria.html opt e10s fission stylo webrender',
       '  rev: tictactoe',
-      '  - macOS 10.15, 1.078 %, Improvement, 2.1, Not significant, 23.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 2, Not significant, 43.00 %',
-      '  - Windows 10, -2.401 %, , 2, Significant, 48.00 %',
-      '  - Windows 10, -, , 2, Significant, 98.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 2.1, -, 23.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 2, -, 43.00 %',
+      '  - Windows 10, -2.401 %, , 2, , 48.00 %',
+      '  - Windows 10, -, , 2, , 98.00 %',
       '  rev: spam',
-      '  - macOS 10.15, 1.078 %, Improvement, 1.3, Not significant, 24.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 1.2, Not significant, 44.00 %',
-      '  - Windows 10, -2.401 %, , 1.2, Significant, 49.00 %',
-      '  - Windows 10, -, , 1.2, Significant, 99.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 1.3, -, 24.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 1.2, -, 44.00 %',
+      '  - Windows 10, -2.401 %, , 1.2, , 49.00 %',
+      '  - Windows 10, -, , 1.2, , 99.00 %',
       'a11yr dhtml.html opt e10s fission stylo webrender',
       '  rev: tictactoe',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.9, Not significant, 24.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 0.8, Not significant, 44.00 %',
-      '  - Windows 10, -2.401 %, , 0.8, Significant, 49.00 %',
-      '  - Windows 10, -, , 0.8, Significant, 99.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.9, -, 24.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 0.8, -, 44.00 %',
+      '  - Windows 10, -2.401 %, , 0.8, , 49.00 %',
+      '  - Windows 10, -, , 0.8, , 99.00 %',
       '  rev: spam',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, Not significant, 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, Not significant, 45.00 %',
-      '  - Windows 10, -2.401 %, , -, Significant, 50.00 %',
-      '  - Windows 10, -, , -, Significant, 100.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
+      '  - Windows 10, -2.401 %, , -, , 50.00 %',
+      '  - Windows 10, -, , -, , 100.00 %',
     ]);
     expect(effectSizeButton).toMatchSnapshot();
     // It should be persisted in the URL
@@ -1177,7 +1179,7 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
 
     // Sort by MD(%) descending
     const medianDiffButton = screen.getByRole('button', {
-      name: /MD\(%\).*sort/,
+      name: /MD \(%\).*sort/,
     });
     await user.click(medianDiffButton);
     expect(summarizeVisibleRows('mann-whitney-u')).toMatchSnapshot();

--- a/src/__tests__/CompareResults/SubtestsResultsView.test.tsx
+++ b/src/__tests__/CompareResults/SubtestsResultsView.test.tsx
@@ -508,25 +508,25 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       await setupForSorting();
       // Initial view (alphabetical ordered, even if "sort by subtests" isn't specified
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
-        'browser.html: 0.963 %, -0.04, Not significant, 15.00%',
-        'dhtml.html: 1.135 %, 0.02, Significant, 60.00%',
-        'improvement.html: 0.963 %, -0.05, Significant, 50.00%',
-        'regression.html: 1.135 %, 0.12, Significant, 25.00%',
+        'browser.html: 0.963 %, -0.04, -, 15.00%',
+        'dhtml.html: 1.135 %, 0.02, , 60.00%',
+        'improvement.html: 0.963 %, -0.05, , 50.00%',
+        'regression.html: 1.135 %, 0.12, , 25.00%',
         'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
       ]);
 
       // Sort by Delta
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-      const deltaButton = screen.getByRole('button', { name: /Delta/ });
+      const deltaButton = screen.getByRole('button', { name: /CD/ });
       expect(deltaButton).toMatchSnapshot();
       expect(window.location.search).not.toContain('sort=');
       // Sort descending
       await user.click(deltaButton);
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
-        'regression.html: 1.135 %, 0.12, Significant, 25.00%',
-        'improvement.html: 0.963 %, -0.05, Significant, 50.00%',
-        'browser.html: 0.963 %, -0.04, Not significant, 15.00%',
-        'dhtml.html: 1.135 %, 0.02, Significant, 60.00%',
+        'regression.html: 1.135 %, 0.12, , 25.00%',
+        'improvement.html: 0.963 %, -0.05, , 50.00%',
+        'browser.html: 0.963 %, -0.04, -, 15.00%',
+        'dhtml.html: 1.135 %, 0.02, , 60.00%',
         'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
       ]);
 
@@ -539,10 +539,10 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       await user.click(deltaButton);
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
         'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
-        'dhtml.html: 1.135 %, 0.02, Significant, 60.00%',
-        'browser.html: 0.963 %, -0.04, Not significant, 15.00%',
-        'improvement.html: 0.963 %, -0.05, Significant, 50.00%',
-        'regression.html: 1.135 %, 0.12, Significant, 25.00%',
+        'dhtml.html: 1.135 %, 0.02, , 60.00%',
+        'browser.html: 0.963 %, -0.04, -, 15.00%',
+        'improvement.html: 0.963 %, -0.05, , 50.00%',
+        'regression.html: 1.135 %, 0.12, , 25.00%',
       ]);
       // It should have the "ascending" SVG.
       expect(deltaButton).toMatchSnapshot();
@@ -551,15 +551,15 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
 
       // Sort by Significance descending
       const significanceButton = screen.getByRole('button', {
-        name: /Significance.*sort/,
+        name: /Sig.*sort/,
       });
       await user.click(significanceButton);
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
-        'browser.html: 0.963 %, -0.04, Not significant, 15.00%',
+        'browser.html: 0.963 %, -0.04, -, 15.00%',
         'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
-        'dhtml.html: 1.135 %, 0.02, Significant, 60.00%',
-        'regression.html: 1.135 %, 0.12, Significant, 25.00%',
-        'improvement.html: 0.963 %, -0.05, Significant, 50.00%',
+        'dhtml.html: 1.135 %, 0.02, , 60.00%',
+        'regression.html: 1.135 %, 0.12, , 25.00%',
+        'improvement.html: 0.963 %, -0.05, , 50.00%',
       ]);
       // It should have the "no sort" SVG.
       expect(deltaButton).toMatchSnapshot();
@@ -571,25 +571,25 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       // Sort by Significance ascending
       await user.click(significanceButton);
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
-        'improvement.html: 0.963 %, -0.05, Significant, 50.00%',
-        'regression.html: 1.135 %, 0.12, Significant, 25.00%',
-        'dhtml.html: 1.135 %, 0.02, Significant, 60.00%',
+        'improvement.html: 0.963 %, -0.05, , 50.00%',
+        'regression.html: 1.135 %, 0.12, , 25.00%',
+        'dhtml.html: 1.135 %, 0.02, , 60.00%',
         'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
-        'browser.html: 0.963 %, -0.04, Not significant, 15.00%',
+        'browser.html: 0.963 %, -0.04, -, 15.00%',
       ]);
       expectParameterToHaveValue('sort', 'significance|asc');
 
       // Sort by Effect Size descending
       const effectButton = screen.getByRole('button', {
-        name: /CLES\(%\).*sort/,
+        name: /CLES \(%\).*sort/,
       });
       await user.click(effectButton);
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
-        'dhtml.html: 1.135 %, 0.02, Significant, 60.00%',
-        'improvement.html: 0.963 %, -0.05, Significant, 50.00%',
+        'dhtml.html: 1.135 %, 0.02, , 60.00%',
+        'improvement.html: 0.963 %, -0.05, , 50.00%',
         'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
-        'regression.html: 1.135 %, 0.12, Significant, 25.00%',
-        'browser.html: 0.963 %, -0.04, Not significant, 15.00%',
+        'regression.html: 1.135 %, 0.12, , 25.00%',
+        'browser.html: 0.963 %, -0.04, -, 15.00%',
       ]);
 
       // It should have the "descending" SVG.
@@ -600,11 +600,11 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       // Sort by Effect Size ascending
       await user.click(effectButton);
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
-        'browser.html: 0.963 %, -0.04, Not significant, 15.00%',
-        'regression.html: 1.135 %, 0.12, Significant, 25.00%',
+        'browser.html: 0.963 %, -0.04, -, 15.00%',
+        'regression.html: 1.135 %, 0.12, , 25.00%',
         'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
-        'improvement.html: 0.963 %, -0.05, Significant, 50.00%',
-        'dhtml.html: 1.135 %, 0.02, Significant, 60.00%',
+        'improvement.html: 0.963 %, -0.05, , 50.00%',
+        'dhtml.html: 1.135 %, 0.02, , 60.00%',
       ]);
       expectParameterToHaveValue('sort', 'effects|asc');
     });
@@ -614,40 +614,40 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       await screen.findByText('dhtml.html');
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
         'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
-        'dhtml.html: 1.135 %, 0.02, Significant, 60.00%',
-        'browser.html: 0.963 %, -0.04, Not significant, 15.00%',
-        'improvement.html: 0.963 %, -0.05, Significant, 50.00%',
-        'regression.html: 1.135 %, 0.12, Significant, 25.00%',
+        'dhtml.html: 1.135 %, 0.02, , 60.00%',
+        'browser.html: 0.963 %, -0.04, -, 15.00%',
+        'improvement.html: 0.963 %, -0.05, , 50.00%',
+        'regression.html: 1.135 %, 0.12, , 25.00%',
       ]);
       // It should have the "ascending" SVG.
-      expect(screen.getByRole('button', { name: /Delta/ })).toMatchSnapshot();
+      expect(screen.getByRole('button', { name: /CD/ })).toMatchSnapshot();
     });
 
     it('initializes the sort from the URL at load time for an implicit descending sort', async () => {
       await setupForSorting({ extraParameters: 'sort=delta' });
       await screen.findByText('dhtml.html');
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
-        'regression.html: 1.135 %, 0.12, Significant, 25.00%',
-        'improvement.html: 0.963 %, -0.05, Significant, 50.00%',
-        'browser.html: 0.963 %, -0.04, Not significant, 15.00%',
-        'dhtml.html: 1.135 %, 0.02, Significant, 60.00%',
+        'regression.html: 1.135 %, 0.12, , 25.00%',
+        'improvement.html: 0.963 %, -0.05, , 50.00%',
+        'browser.html: 0.963 %, -0.04, -, 15.00%',
+        'dhtml.html: 1.135 %, 0.02, , 60.00%',
         'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
       ]);
       // It should have the "descending" SVG.
-      expect(screen.getByRole('button', { name: /Delta/ })).toMatchSnapshot();
+      expect(screen.getByRole('button', { name: /CD/ })).toMatchSnapshot();
     });
 
     it('initializes the sort from the URL at load time for a descending sort', async () => {
       await setupForSorting({ extraParameters: 'sort=delta|desc' });
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
-        'regression.html: 1.135 %, 0.12, Significant, 25.00%',
-        'improvement.html: 0.963 %, -0.05, Significant, 50.00%',
-        'browser.html: 0.963 %, -0.04, Not significant, 15.00%',
-        'dhtml.html: 1.135 %, 0.02, Significant, 60.00%',
+        'regression.html: 1.135 %, 0.12, , 25.00%',
+        'improvement.html: 0.963 %, -0.05, , 50.00%',
+        'browser.html: 0.963 %, -0.04, -, 15.00%',
+        'dhtml.html: 1.135 %, 0.02, , 60.00%',
         'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
       ]);
       // It should have the "descending" SVG.
-      expect(screen.getByRole('button', { name: /Delta/ })).toMatchSnapshot();
+      expect(screen.getByRole('button', { name: /CD/ })).toMatchSnapshot();
     });
   });
 });

--- a/src/__tests__/CompareResults/SubtestsRevisionRow.test.tsx
+++ b/src/__tests__/CompareResults/SubtestsRevisionRow.test.tsx
@@ -190,11 +190,11 @@ describe('SubtestsRevisionRow Component', () => {
     );
 
     const roles = await screen.findAllByRole('cell');
-    const effects = roles[8]?.childNodes[0];
+    const effects = roles[7]?.childNodes[0];
     expect(effects).toHaveTextContent('60.00%');
 
-    const significance = roles[7]?.childNodes[0];
-    expect(significance).toHaveTextContent('Significant');
+    const significanceCell = roles[8];
+    expect(significanceCell?.querySelector('svg')).not.toBeNull();
 
     const cliffs_delta = roles[6]?.childNodes[1];
     expect(cliffs_delta).toHaveTextContent('0.02');

--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -311,7 +311,7 @@ exports[`Results View The table should match snapshot and other elements should 
       </div>
     </div>
     <div
-      class="fjksmi8 f1l733lh"
+      class="fdtnfac f1l733lh"
       data-testid="table-header"
       role="row"
     >
@@ -387,7 +387,7 @@ exports[`Results View The table should match snapshot and other elements should 
           data-mui-internal-clone-element="true"
         >
           <button
-            aria-label="MD(%) (Click to sort by this column)"
+            aria-label="MD (%) (Click to sort by this column)"
             class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"
@@ -403,10 +403,10 @@ exports[`Results View The table should match snapshot and other elements should 
                 d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
               />
               <title>
-                Not sorted by MD(%)
+                Not sorted by MD (%)
               </title>
             </svg>
-            MD(%)
+            MD (%)
           </button>
         </span>
       </div>
@@ -453,7 +453,7 @@ exports[`Results View The table should match snapshot and other elements should 
           data-mui-internal-clone-element="true"
         >
           <button
-            aria-label="Cliff's Delta (Click to sort by this column)"
+            aria-label="CD (Click to sort by this column)"
             class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"
@@ -469,10 +469,42 @@ exports[`Results View The table should match snapshot and other elements should 
                 d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
               />
               <title>
-                Not sorted by Cliff's Delta
+                Not sorted by CD
               </title>
             </svg>
-            Cliff's Delta
+            CD
+          </button>
+        </span>
+      </div>
+      <div
+        class="cell effects-header"
+        role="columnheader"
+      >
+        <span
+          class="MuiBox-root css-1tkq7a4"
+          data-mui-internal-clone-element="true"
+        >
+          <button
+            aria-label="CLES (%) (Click to sort by this column)"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-10d4m26-MuiSvgIcon-root"
+              data-testid="SwapVertIcon"
+              focusable="false"
+              role="img"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
+              />
+              <title>
+                Not sorted by CLES (%)
+              </title>
+            </svg>
+            CLES (%)
           </button>
         </span>
       </div>
@@ -485,7 +517,7 @@ exports[`Results View The table should match snapshot and other elements should 
           role="group"
         >
           <button
-            aria-label="Significance (Click to sort by this column)"
+            aria-label="Sig (Click to sort by this column)"
             class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButtonGroup-firstButton css-17eldkb-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"
@@ -501,19 +533,19 @@ exports[`Results View The table should match snapshot and other elements should 
                 d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
               />
               <title>
-                Not sorted by Significance
+                Not sorted by Sig
               </title>
             </svg>
           </button>
           <button
             aria-haspopup="true"
-            aria-label="Significance (Click to filter values)"
+            aria-label="Sig (Click to filter values)"
             class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-lastButton css-l81dbu-MuiButtonBase-root-MuiButton-root"
             data-mui-internal-clone-element="true"
             tabindex="0"
             type="button"
           >
-            Significance
+            Sig
             <div
               aria-label="2 items selected"
               class="MuiBox-root css-18uhbjh"
@@ -535,38 +567,6 @@ exports[`Results View The table should match snapshot and other elements should 
             </svg>
           </button>
         </div>
-      </div>
-      <div
-        class="cell effects-header"
-        role="columnheader"
-      >
-        <span
-          class="MuiBox-root css-1tkq7a4"
-          data-mui-internal-clone-element="true"
-        >
-          <button
-            aria-label="CLES(%) (Click to sort by this column)"
-            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
-            tabindex="0"
-            type="button"
-          >
-            <svg
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-10d4m26-MuiSvgIcon-root"
-              data-testid="SwapVertIcon"
-              focusable="false"
-              role="img"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
-              />
-              <title>
-                Not sorted by CLES(%)
-              </title>
-            </svg>
-            CLES(%)
-          </button>
-        </span>
       </div>
       <div
         class="cell trials-header"
@@ -701,7 +701,7 @@ exports[`Results View The table should match snapshot and other elements should 
               class="fw0pvlu"
             >
               <div
-                class="revisionRow fh8ovok f1dlt78d MuiBox-root css-6a7wpt"
+                class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
                 role="row"
               >
                 <div
@@ -774,13 +774,13 @@ exports[`Results View The table should match snapshot and other elements should 
                   -
                 </div>
                 <div
-                  class="significance cell"
+                  class="effects cell"
                   role="cell"
                 >
                   -
                 </div>
                 <div
-                  class="effects cell"
+                  class="significance cell"
                   role="cell"
                 >
                   -
@@ -899,7 +899,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow fh8ovok f1dlt78d MuiBox-root css-6a7wpt"
+                class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
                 role="row"
               >
                 <div
@@ -973,13 +973,13 @@ exports[`Results View The table should match snapshot and other elements should 
                   -
                 </div>
                 <div
-                  class="significance cell"
+                  class="effects cell"
                   role="cell"
                 >
                   -
                 </div>
                 <div
-                  class="effects cell"
+                  class="significance cell"
                   role="cell"
                 >
                   -
@@ -1098,7 +1098,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow fh8ovok f1dlt78d MuiBox-root css-6a7wpt"
+                class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
                 role="row"
               >
                 <div
@@ -1172,13 +1172,13 @@ exports[`Results View The table should match snapshot and other elements should 
                   -
                 </div>
                 <div
-                  class="significance cell"
+                  class="effects cell"
                   role="cell"
                 >
                   -
                 </div>
                 <div
-                  class="effects cell"
+                  class="significance cell"
                   role="cell"
                 >
                   -
@@ -1297,7 +1297,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow fh8ovok f1dlt78d MuiBox-root css-6a7wpt"
+                class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
                 role="row"
               >
                 <div
@@ -1371,13 +1371,13 @@ exports[`Results View The table should match snapshot and other elements should 
                   -
                 </div>
                 <div
-                  class="significance cell"
+                  class="effects cell"
                   role="cell"
                 >
                   -
                 </div>
                 <div
-                  class="effects cell"
+                  class="significance cell"
                   role="cell"
                 >
                   -

--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -701,7 +701,7 @@ exports[`Results View The table should match snapshot and other elements should 
               class="fw0pvlu"
             >
               <div
-                class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
+                class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
                 role="row"
               >
                 <div
@@ -899,7 +899,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
+                class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
                 role="row"
               >
                 <div
@@ -1098,7 +1098,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
+                class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
                 role="row"
               >
                 <div
@@ -1297,7 +1297,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
+                class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
                 role="row"
               >
                 <div

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -1204,7 +1204,7 @@ exports[`Results Table Should match snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="fjksmi8 f1l733lh"
+                  class="fdtnfac f1l733lh"
                   data-testid="table-header"
                   role="row"
                 >
@@ -1280,7 +1280,7 @@ exports[`Results Table Should match snapshot 1`] = `
                       data-mui-internal-clone-element="true"
                     >
                       <button
-                        aria-label="MD(%) (Click to sort by this column)"
+                        aria-label="MD (%) (Click to sort by this column)"
                         class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
                         tabindex="0"
                         type="button"
@@ -1296,10 +1296,10 @@ exports[`Results Table Should match snapshot 1`] = `
                             d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
                           />
                           <title>
-                            Not sorted by MD(%)
+                            Not sorted by MD (%)
                           </title>
                         </svg>
-                        MD(%)
+                        MD (%)
                       </button>
                     </span>
                   </div>
@@ -1346,7 +1346,7 @@ exports[`Results Table Should match snapshot 1`] = `
                       data-mui-internal-clone-element="true"
                     >
                       <button
-                        aria-label="Cliff's Delta (Click to sort by this column)"
+                        aria-label="CD (Click to sort by this column)"
                         class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
                         tabindex="0"
                         type="button"
@@ -1362,10 +1362,42 @@ exports[`Results Table Should match snapshot 1`] = `
                             d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
                           />
                           <title>
-                            Not sorted by Cliff's Delta
+                            Not sorted by CD
                           </title>
                         </svg>
-                        Cliff's Delta
+                        CD
+                      </button>
+                    </span>
+                  </div>
+                  <div
+                    class="cell effects-header"
+                    role="columnheader"
+                  >
+                    <span
+                      class="MuiBox-root css-1tkq7a4"
+                      data-mui-internal-clone-element="true"
+                    >
+                      <button
+                        aria-label="CLES (%) (Click to sort by this column)"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-10d4m26-MuiSvgIcon-root"
+                          data-testid="SwapVertIcon"
+                          focusable="false"
+                          role="img"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
+                          />
+                          <title>
+                            Not sorted by CLES (%)
+                          </title>
+                        </svg>
+                        CLES (%)
                       </button>
                     </span>
                   </div>
@@ -1378,7 +1410,7 @@ exports[`Results Table Should match snapshot 1`] = `
                       role="group"
                     >
                       <button
-                        aria-label="Significance (Click to sort by this column)"
+                        aria-label="Sig (Click to sort by this column)"
                         class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButtonGroup-firstButton css-17eldkb-MuiButtonBase-root-MuiButton-root"
                         tabindex="0"
                         type="button"
@@ -1394,19 +1426,19 @@ exports[`Results Table Should match snapshot 1`] = `
                             d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
                           />
                           <title>
-                            Not sorted by Significance
+                            Not sorted by Sig
                           </title>
                         </svg>
                       </button>
                       <button
                         aria-haspopup="true"
-                        aria-label="Significance (Click to filter values)"
+                        aria-label="Sig (Click to filter values)"
                         class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-lastButton css-l81dbu-MuiButtonBase-root-MuiButton-root"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
                       >
-                        Significance
+                        Sig
                         <div
                           aria-label="2 items selected"
                           class="MuiBox-root css-18uhbjh"
@@ -1428,38 +1460,6 @@ exports[`Results Table Should match snapshot 1`] = `
                         </svg>
                       </button>
                     </div>
-                  </div>
-                  <div
-                    class="cell effects-header"
-                    role="columnheader"
-                  >
-                    <span
-                      class="MuiBox-root css-1tkq7a4"
-                      data-mui-internal-clone-element="true"
-                    >
-                      <button
-                        aria-label="CLES(%) (Click to sort by this column)"
-                        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
-                        tabindex="0"
-                        type="button"
-                      >
-                        <svg
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-10d4m26-MuiSvgIcon-root"
-                          data-testid="SwapVertIcon"
-                          focusable="false"
-                          role="img"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
-                          />
-                          <title>
-                            Not sorted by CLES(%)
-                          </title>
-                        </svg>
-                        CLES(%)
-                      </button>
-                    </span>
                   </div>
                   <div
                     class="cell trials-header"
@@ -1594,7 +1594,7 @@ exports[`Results Table Should match snapshot 1`] = `
                           class="fw0pvlu"
                         >
                           <div
-                            class="revisionRow fh8ovok f1dlt78d MuiBox-root css-6a7wpt"
+                            class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
                             role="row"
                           >
                             <div
@@ -1667,13 +1667,13 @@ exports[`Results Table Should match snapshot 1`] = `
                               -
                             </div>
                             <div
-                              class="significance cell"
+                              class="effects cell"
                               role="cell"
                             >
                               -
                             </div>
                             <div
-                              class="effects cell"
+                              class="significance cell"
                               role="cell"
                             >
                               -
@@ -1792,7 +1792,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </div>
                           </div>
                           <div
-                            class="revisionRow fh8ovok f1dlt78d MuiBox-root css-6a7wpt"
+                            class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
                             role="row"
                           >
                             <div
@@ -1866,13 +1866,13 @@ exports[`Results Table Should match snapshot 1`] = `
                               -
                             </div>
                             <div
-                              class="significance cell"
+                              class="effects cell"
                               role="cell"
                             >
                               -
                             </div>
                             <div
-                              class="effects cell"
+                              class="significance cell"
                               role="cell"
                             >
                               -
@@ -1991,7 +1991,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </div>
                           </div>
                           <div
-                            class="revisionRow fh8ovok f1dlt78d MuiBox-root css-6a7wpt"
+                            class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
                             role="row"
                           >
                             <div
@@ -2065,13 +2065,13 @@ exports[`Results Table Should match snapshot 1`] = `
                               -
                             </div>
                             <div
-                              class="significance cell"
+                              class="effects cell"
                               role="cell"
                             >
                               -
                             </div>
                             <div
-                              class="effects cell"
+                              class="significance cell"
                               role="cell"
                             >
                               -
@@ -2271,7 +2271,7 @@ exports[`Results Table Should match snapshot 1`] = `
                           class="fw0pvlu"
                         >
                           <div
-                            class="revisionRow fh8ovok f1dlt78d MuiBox-root css-6a7wpt"
+                            class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
                             role="row"
                           >
                             <div
@@ -2345,13 +2345,13 @@ exports[`Results Table Should match snapshot 1`] = `
                               -
                             </div>
                             <div
-                              class="significance cell"
+                              class="effects cell"
                               role="cell"
                             >
                               -
                             </div>
                             <div
-                              class="effects cell"
+                              class="significance cell"
                               role="cell"
                             >
                               -
@@ -3960,7 +3960,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                   </div>
                 </div>
                 <div
-                  class="fjksmi8 f1l733lh"
+                  class="fdtnfac f1l733lh"
                   data-testid="table-header"
                   role="row"
                 >
@@ -4036,7 +4036,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                       data-mui-internal-clone-element="true"
                     >
                       <button
-                        aria-label="MD(%) (Click to sort by this column)"
+                        aria-label="MD (%) (Click to sort by this column)"
                         class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
                         tabindex="0"
                         type="button"
@@ -4052,10 +4052,10 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                             d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
                           />
                           <title>
-                            Not sorted by MD(%)
+                            Not sorted by MD (%)
                           </title>
                         </svg>
-                        MD(%)
+                        MD (%)
                       </button>
                     </span>
                   </div>
@@ -4102,7 +4102,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                       data-mui-internal-clone-element="true"
                     >
                       <button
-                        aria-label="Cliff's Delta (Click to sort by this column)"
+                        aria-label="CD (Click to sort by this column)"
                         class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
                         tabindex="0"
                         type="button"
@@ -4118,10 +4118,42 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                             d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
                           />
                           <title>
-                            Not sorted by Cliff's Delta
+                            Not sorted by CD
                           </title>
                         </svg>
-                        Cliff's Delta
+                        CD
+                      </button>
+                    </span>
+                  </div>
+                  <div
+                    class="cell effects-header"
+                    role="columnheader"
+                  >
+                    <span
+                      class="MuiBox-root css-1tkq7a4"
+                      data-mui-internal-clone-element="true"
+                    >
+                      <button
+                        aria-label="CLES (%) (Click to sort by this column)"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-10d4m26-MuiSvgIcon-root"
+                          data-testid="SwapVertIcon"
+                          focusable="false"
+                          role="img"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
+                          />
+                          <title>
+                            Not sorted by CLES (%)
+                          </title>
+                        </svg>
+                        CLES (%)
                       </button>
                     </span>
                   </div>
@@ -4134,7 +4166,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                       role="group"
                     >
                       <button
-                        aria-label="Significance (Click to sort by this column)"
+                        aria-label="Sig (Click to sort by this column)"
                         class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButtonGroup-firstButton css-17eldkb-MuiButtonBase-root-MuiButton-root"
                         tabindex="0"
                         type="button"
@@ -4150,19 +4182,19 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                             d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
                           />
                           <title>
-                            Not sorted by Significance
+                            Not sorted by Sig
                           </title>
                         </svg>
                       </button>
                       <button
                         aria-haspopup="true"
-                        aria-label="Significance (Click to filter values)"
+                        aria-label="Sig (Click to filter values)"
                         class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-lastButton css-l81dbu-MuiButtonBase-root-MuiButton-root"
                         data-mui-internal-clone-element="true"
                         tabindex="0"
                         type="button"
                       >
-                        Significance
+                        Sig
                         <div
                           aria-label="2 items selected"
                           class="MuiBox-root css-18uhbjh"
@@ -4184,38 +4216,6 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                         </svg>
                       </button>
                     </div>
-                  </div>
-                  <div
-                    class="cell effects-header"
-                    role="columnheader"
-                  >
-                    <span
-                      class="MuiBox-root css-1tkq7a4"
-                      data-mui-internal-clone-element="true"
-                    >
-                      <button
-                        aria-label="CLES(%) (Click to sort by this column)"
-                        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
-                        tabindex="0"
-                        type="button"
-                      >
-                        <svg
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-10d4m26-MuiSvgIcon-root"
-                          data-testid="SwapVertIcon"
-                          focusable="false"
-                          role="img"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
-                          />
-                          <title>
-                            Not sorted by CLES(%)
-                          </title>
-                        </svg>
-                        CLES(%)
-                      </button>
-                    </span>
                   </div>
                   <div
                     class="cell trials-header"
@@ -4350,7 +4350,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                           class="fw0pvlu"
                         >
                           <div
-                            class="revisionRow fh8ovok f1dlt78d MuiBox-root css-6a7wpt"
+                            class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
                             role="row"
                           >
                             <div
@@ -4436,16 +4436,16 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                               -
                             </div>
                             <div
-                              class="significance cell"
-                              role="cell"
-                            >
-                              Not significant
-                            </div>
-                            <div
                               class="effects cell"
                               role="cell"
                             >
                               45.00 %
+                            </div>
+                            <div
+                              class="significance cell"
+                              role="cell"
+                            >
+                              -
                             </div>
                             <div
                               class="total-runs cell"
@@ -4561,7 +4561,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                             </div>
                           </div>
                           <div
-                            class="revisionRow fh8ovok f1dlt78d MuiBox-root css-6a7wpt"
+                            class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
                             role="row"
                           >
                             <div
@@ -4648,16 +4648,16 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                               0.1
                             </div>
                             <div
-                              class="significance cell"
-                              role="cell"
-                            >
-                              Not significant
-                            </div>
-                            <div
                               class="effects cell"
                               role="cell"
                             >
                               25.00 %
+                            </div>
+                            <div
+                              class="significance cell"
+                              role="cell"
+                            >
+                              -
                             </div>
                             <div
                               class="total-runs cell"
@@ -4773,7 +4773,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                             </div>
                           </div>
                           <div
-                            class="revisionRow fh8ovok f1dlt78d MuiBox-root css-6a7wpt"
+                            class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
                             role="row"
                           >
                             <div
@@ -4847,16 +4847,29 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                               -
                             </div>
                             <div
-                              class="significance cell"
-                              role="cell"
-                            >
-                              Significant
-                            </div>
-                            <div
                               class="effects cell"
                               role="cell"
                             >
                               50.00 %
+                            </div>
+                            <div
+                              class="significance cell"
+                              role="cell"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                                data-testid="KeyboardDoubleArrowUpIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
+                                />
+                                <path
+                                  d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
+                                />
+                              </svg>
                             </div>
                             <div
                               class="total-runs cell"
@@ -5053,7 +5066,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                           class="fw0pvlu"
                         >
                           <div
-                            class="revisionRow fh8ovok f1dlt78d MuiBox-root css-6a7wpt"
+                            class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
                             role="row"
                           >
                             <div
@@ -5123,16 +5136,29 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                               -
                             </div>
                             <div
-                              class="significance cell"
-                              role="cell"
-                            >
-                              Significant
-                            </div>
-                            <div
                               class="effects cell"
                               role="cell"
                             >
                               100.00 %
+                            </div>
+                            <div
+                              class="significance cell"
+                              role="cell"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                                data-testid="KeyboardDoubleArrowUpIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
+                                />
+                                <path
+                                  d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
+                                />
+                              </svg>
                             </div>
                             <div
                               class="total-runs cell"
@@ -5264,7 +5290,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
 
 exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion can sort params from the URL on mann-whitney-u test_version 1`] = `
 <button
-  aria-label="Cliff's Delta (Click to sort by this column)"
+  aria-label="CD (Click to sort by this column)"
   class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
@@ -5280,16 +5306,16 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
       d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
     />
     <title>
-      Not sorted by Cliff's Delta
+      Not sorted by CD
     </title>
   </svg>
-  Cliff's Delta
+  CD
 </button>
 `;
 
 exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion can sort params from the URL on mann-whitney-u test_version 2`] = `
 <button
-  aria-label="Cliff's Delta (Click to sort by this column)"
+  aria-label="CD (Click to sort by this column)"
   class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
@@ -5305,16 +5331,16 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
       d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
     />
     <title>
-      Not sorted by Cliff's Delta
+      Not sorted by CD
     </title>
   </svg>
-  Cliff's Delta
+  CD
 </button>
 `;
 
 exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion can sort params from the URL on mann-whitney-u test_version 3`] = `
 <button
-  aria-label="Cliff's Delta (Currently sorted by this column. Click to change)"
+  aria-label="CD (Currently sorted by this column. Click to change)"
   class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation Mui-focusVisible MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
@@ -5330,10 +5356,10 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
       d="M11 6.83 9.41 8.41 8 7l4-4 4 4-1.41 1.41L13 6.83V21h-2z"
     />
     <title>
-      Sorted by Cliff's Delta in descending order
+      Sorted by CD in descending order
     </title>
   </svg>
-  Cliff's Delta
+  CD
   <span
     class="MuiTouchRipple-root css-r3djoj-MuiTouchRipple-root"
   >
@@ -5359,7 +5385,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
 
 exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion can sort params from the URL on mann-whitney-u test_version 4`] = `
 <button
-  aria-label="Significance (Currently sorted by this column. Click to change)"
+  aria-label="Sig (Currently sorted by this column. Click to change)"
   class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation Mui-focusVisible MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButtonGroup-firstButton css-17eldkb-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
@@ -5375,7 +5401,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
       d="M11 6.83 9.41 8.41 8 7l4-4 4 4-1.41 1.41L13 6.83V21h-2z"
     />
     <title>
-      Sorted by Significance in descending order
+      Sorted by Sig in descending order
     </title>
   </svg>
   <span
@@ -5403,7 +5429,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
 
 exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion can sort params from the URL on mann-whitney-u test_version 5`] = `
 <button
-  aria-label="Significance (Currently sorted by this column. Click to change)"
+  aria-label="Sig (Currently sorted by this column. Click to change)"
   class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation Mui-focusVisible MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButtonGroup-firstButton css-17eldkb-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
@@ -5419,7 +5445,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
       d="M11 6.83 9.41 8.41 8 7l4-4 4 4-1.41 1.41L13 6.83V21h-2z"
     />
     <title>
-      Sorted by Significance in ascending order
+      Sorted by Sig in ascending order
     </title>
   </svg>
   <span
@@ -5455,7 +5481,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
 
 exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion can sort params from the URL on mann-whitney-u test_version 6`] = `
 <button
-  aria-label="CLES(%) (Currently sorted by this column. Click to change)"
+  aria-label="CLES (%) (Currently sorted by this column. Click to change)"
   class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation Mui-focusVisible MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
@@ -5471,10 +5497,10 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
       d="M11 6.83 9.41 8.41 8 7l4-4 4 4-1.41 1.41L13 6.83V21h-2z"
     />
     <title>
-      Sorted by CLES(%) in descending order
+      Sorted by CLES (%) in descending order
     </title>
   </svg>
-  CLES(%)
+  CLES (%)
   <span
     class="MuiTouchRipple-root css-r3djoj-MuiTouchRipple-root"
   >
@@ -5500,7 +5526,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
 
 exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion can sort params from the URL on mann-whitney-u test_version 7`] = `
 <button
-  aria-label="CLES(%) (Currently sorted by this column. Click to change)"
+  aria-label="CLES (%) (Currently sorted by this column. Click to change)"
   class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation Mui-focusVisible MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
@@ -5516,10 +5542,10 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
       d="M11 6.83 9.41 8.41 8 7l4-4 4 4-1.41 1.41L13 6.83V21h-2z"
     />
     <title>
-      Sorted by CLES(%) in ascending order
+      Sorted by CLES (%) in ascending order
     </title>
   </svg>
-  CLES(%)
+  CLES (%)
   <span
     class="MuiTouchRipple-root css-r3djoj-MuiTouchRipple-root"
   >
@@ -5555,32 +5581,32 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
 [
   "a11yr dhtml.html opt e10s fission stylo webrender",
   "  rev: spam",
-  "  - Linux 18.04, 1.849 %, Regression, -, Not significant, 45.00 %",
-  "  - macOS 10.15, 1.078 %, Improvement, 0.1, Not significant, 25.00 %",
-  "  - Windows 10, -, , -, Significant, 100.00 %",
-  "  - Windows 10, -2.401 %, , -, Significant, 50.00 %",
+  "  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %",
+  "  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %",
+  "  - Windows 10, -, , -, , 100.00 %",
+  "  - Windows 10, -2.401 %, , -, , 50.00 %",
   "  rev: tictactoe",
-  "  - Linux 18.04, 1.849 %, Regression, 0.8, Not significant, 44.00 %",
-  "  - macOS 10.15, 1.078 %, Improvement, 0.9, Not significant, 24.00 %",
-  "  - Windows 10, -, , 0.8, Significant, 99.00 %",
-  "  - Windows 10, -2.401 %, , 0.8, Significant, 49.00 %",
+  "  - Linux 18.04, 1.849 %, Regression, 0.8, -, 44.00 %",
+  "  - macOS 10.15, 1.078 %, Improvement, 0.9, -, 24.00 %",
+  "  - Windows 10, -, , 0.8, , 99.00 %",
+  "  - Windows 10, -2.401 %, , 0.8, , 49.00 %",
   "a11yr aria.html opt e10s fission stylo webrender",
   "  rev: spam",
-  "  - Linux 18.04, 1.849 %, Regression, 1.2, Not significant, 44.00 %",
-  "  - macOS 10.15, 1.078 %, Improvement, 1.3, Not significant, 24.00 %",
-  "  - Windows 10, -, , 1.2, Significant, 99.00 %",
-  "  - Windows 10, -2.401 %, , 1.2, Significant, 49.00 %",
+  "  - Linux 18.04, 1.849 %, Regression, 1.2, -, 44.00 %",
+  "  - macOS 10.15, 1.078 %, Improvement, 1.3, -, 24.00 %",
+  "  - Windows 10, -, , 1.2, , 99.00 %",
+  "  - Windows 10, -2.401 %, , 1.2, , 49.00 %",
   "  rev: tictactoe",
-  "  - Linux 18.04, 1.849 %, Regression, 2, Not significant, 43.00 %",
-  "  - macOS 10.15, 1.078 %, Improvement, 2.1, Not significant, 23.00 %",
-  "  - Windows 10, -, , 2, Significant, 98.00 %",
-  "  - Windows 10, -2.401 %, , 2, Significant, 48.00 %",
+  "  - Linux 18.04, 1.849 %, Regression, 2, -, 43.00 %",
+  "  - macOS 10.15, 1.078 %, Improvement, 2.1, -, 23.00 %",
+  "  - Windows 10, -, , 2, , 98.00 %",
+  "  - Windows 10, -2.401 %, , 2, , 48.00 %",
 ]
 `;
 
 exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion can sort params from the URL on mann-whitney-u test_version 9`] = `
 <button
-  aria-label="MD(%) (Currently sorted by this column. Click to change)"
+  aria-label="MD (%) (Currently sorted by this column. Click to change)"
   class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation Mui-focusVisible MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
@@ -5596,10 +5622,10 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
       d="M11 6.83 9.41 8.41 8 7l4-4 4 4-1.41 1.41L13 6.83V21h-2z"
     />
     <title>
-      Sorted by MD(%) in descending order
+      Sorted by MD (%) in descending order
     </title>
   </svg>
-  MD(%)
+  MD (%)
   <span
     class="MuiTouchRipple-root css-r3djoj-MuiTouchRipple-root"
   >
@@ -5627,32 +5653,32 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
 [
   "a11yr dhtml.html opt e10s fission stylo webrender",
   "  rev: spam",
-  "  - Windows 10, -2.401 %, , -, Significant, 50.00 %",
-  "  - Windows 10, -, , -, Significant, 100.00 %",
-  "  - macOS 10.15, 1.078 %, Improvement, 0.1, Not significant, 25.00 %",
-  "  - Linux 18.04, 1.849 %, Regression, -, Not significant, 45.00 %",
+  "  - Windows 10, -2.401 %, , -, , 50.00 %",
+  "  - Windows 10, -, , -, , 100.00 %",
+  "  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %",
+  "  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %",
   "  rev: tictactoe",
-  "  - Windows 10, -2.401 %, , 0.8, Significant, 49.00 %",
-  "  - Windows 10, -, , 0.8, Significant, 99.00 %",
-  "  - macOS 10.15, 1.078 %, Improvement, 0.9, Not significant, 24.00 %",
-  "  - Linux 18.04, 1.849 %, Regression, 0.8, Not significant, 44.00 %",
+  "  - Windows 10, -2.401 %, , 0.8, , 49.00 %",
+  "  - Windows 10, -, , 0.8, , 99.00 %",
+  "  - macOS 10.15, 1.078 %, Improvement, 0.9, -, 24.00 %",
+  "  - Linux 18.04, 1.849 %, Regression, 0.8, -, 44.00 %",
   "a11yr aria.html opt e10s fission stylo webrender",
   "  rev: spam",
-  "  - Windows 10, -2.401 %, , 1.2, Significant, 49.00 %",
-  "  - Windows 10, -, , 1.2, Significant, 99.00 %",
-  "  - macOS 10.15, 1.078 %, Improvement, 1.3, Not significant, 24.00 %",
-  "  - Linux 18.04, 1.849 %, Regression, 1.2, Not significant, 44.00 %",
+  "  - Windows 10, -2.401 %, , 1.2, , 49.00 %",
+  "  - Windows 10, -, , 1.2, , 99.00 %",
+  "  - macOS 10.15, 1.078 %, Improvement, 1.3, -, 24.00 %",
+  "  - Linux 18.04, 1.849 %, Regression, 1.2, -, 44.00 %",
   "  rev: tictactoe",
-  "  - Windows 10, -2.401 %, , 2, Significant, 48.00 %",
-  "  - Windows 10, -, , 2, Significant, 98.00 %",
-  "  - macOS 10.15, 1.078 %, Improvement, 2.1, Not significant, 23.00 %",
-  "  - Linux 18.04, 1.849 %, Regression, 2, Not significant, 43.00 %",
+  "  - Windows 10, -2.401 %, , 2, , 48.00 %",
+  "  - Windows 10, -, , 2, , 98.00 %",
+  "  - macOS 10.15, 1.078 %, Improvement, 2.1, -, 23.00 %",
+  "  - Linux 18.04, 1.849 %, Regression, 2, -, 43.00 %",
 ]
 `;
 
 exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion can sort params from the URL on mann-whitney-u test_version 11`] = `
 <button
-  aria-label="MD(%) (Currently sorted by this column. Click to change)"
+  aria-label="MD (%) (Currently sorted by this column. Click to change)"
   class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation Mui-focusVisible MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
@@ -5668,10 +5694,10 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
       d="M11 6.83 9.41 8.41 8 7l4-4 4 4-1.41 1.41L13 6.83V21h-2z"
     />
     <title>
-      Sorted by MD(%) in ascending order
+      Sorted by MD (%) in ascending order
     </title>
   </svg>
-  MD(%)
+  MD (%)
   <span
     class="MuiTouchRipple-root css-r3djoj-MuiTouchRipple-root"
   >
@@ -5704,61 +5730,56 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
 `;
 
 exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion should filter on the Significance column 1`] = `
-[
-  <title>
-    Not sorted by Significance
-  </title>,
-  <button
-    aria-controls="significance"
-    aria-haspopup="true"
-    aria-label="Significance (Click to filter values)"
-    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-lastButton css-l81dbu-MuiButtonBase-root-MuiButton-root"
-    data-mui-internal-clone-element="true"
-    tabindex="0"
-    type="button"
+<button
+  aria-controls="significance"
+  aria-haspopup="true"
+  aria-label="Sig (Click to filter values)"
+  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-lastButton css-l81dbu-MuiButtonBase-root-MuiButton-root"
+  data-mui-internal-clone-element="true"
+  tabindex="0"
+  type="button"
+>
+  Sig
+  <div
+    aria-label="2 items selected"
+    class="MuiBox-root css-18uhbjh"
   >
-    Significance
-    <div
-      aria-label="2 items selected"
-      class="MuiBox-root css-18uhbjh"
-    >
-      (
-      2
-      )
-    </div>
-    <svg
-      aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-120he73-MuiSvgIcon-root"
-      data-testid="KeyboardArrowDownIcon"
-      focusable="false"
-      viewBox="0 0 24 24"
-    >
-      <path
-        d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6z"
-      />
-    </svg>
+    (
+    2
+    )
+  </div>
+  <svg
+    aria-hidden="true"
+    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-120he73-MuiSvgIcon-root"
+    data-testid="KeyboardArrowDownIcon"
+    focusable="false"
+    viewBox="0 0 24 24"
+  >
+    <path
+      d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6z"
+    />
+  </svg>
+  <span
+    class="MuiTouchRipple-root css-r3djoj-MuiTouchRipple-root"
+  >
     <span
-      class="MuiTouchRipple-root css-r3djoj-MuiTouchRipple-root"
+      class="css-y4cjyz-MuiTouchRipple-ripple MuiTouchRipple-ripple MuiTouchRipple-rippleVisible"
+      style="width: 2.8284271247461903px; height: 2.8284271247461903px; top: -1.4142135623730951px; left: -1.4142135623730951px;"
     >
       <span
-        class="css-y4cjyz-MuiTouchRipple-ripple MuiTouchRipple-ripple MuiTouchRipple-rippleVisible"
-        style="width: 2.8284271247461903px; height: 2.8284271247461903px; top: -1.4142135623730951px; left: -1.4142135623730951px;"
-      >
-        <span
-          class="MuiTouchRipple-child MuiTouchRipple-childLeaving"
-        />
-      </span>
-      <span
-        class="css-y4cjyz-MuiTouchRipple-ripple MuiTouchRipple-ripple MuiTouchRipple-rippleVisible MuiTouchRipple-ripplePulsate"
-        style="width: 1px; height: 1px; top: -0.5px; left: -0.5px;"
-      >
-        <span
-          class="MuiTouchRipple-child MuiTouchRipple-childLeaving MuiTouchRipple-childPulsate"
-        />
-      </span>
+        class="MuiTouchRipple-child MuiTouchRipple-childLeaving"
+      />
     </span>
-  </button>,
-]
+    <span
+      class="css-y4cjyz-MuiTouchRipple-ripple MuiTouchRipple-ripple MuiTouchRipple-rippleVisible MuiTouchRipple-ripplePulsate"
+      style="width: 1px; height: 1px; top: -0.5px; left: -0.5px;"
+    >
+      <span
+        class="MuiTouchRipple-child MuiTouchRipple-childLeaving MuiTouchRipple-childPulsate"
+      />
+    </span>
+  </span>
+</button>
 `;
 
 exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion should render different blocks when rendering several revisions 1`] = `
@@ -5854,7 +5875,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
       </span>
     </div>
     <div
-      class="revisionRow fh8ovok f1dlt78d MuiBox-root css-6a7wpt"
+      class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
       role="row"
     >
       <div
@@ -5941,16 +5962,16 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
         0.1
       </div>
       <div
-        class="significance cell"
-        role="cell"
-      >
-        Not significant
-      </div>
-      <div
         class="effects cell"
         role="cell"
       >
         25.00 %
+      </div>
+      <div
+        class="significance cell"
+        role="cell"
+      >
+        -
       </div>
       <div
         class="total-runs cell"
@@ -6105,7 +6126,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
       </span>
     </div>
     <div
-      class="revisionRow fh8ovok f1dlt78d MuiBox-root css-6a7wpt"
+      class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
       role="row"
     >
       <div
@@ -6192,16 +6213,16 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
         0.1
       </div>
       <div
-        class="significance cell"
-        role="cell"
-      >
-        Not significant
-      </div>
-      <div
         class="effects cell"
         role="cell"
       >
         25.00 %
+      </div>
+      <div
+        class="significance cell"
+        role="cell"
+      >
+        -
       </div>
       <div
         class="total-runs cell"
@@ -6413,7 +6434,7 @@ exports[`Results Table should render different blocks when rendering several rev
       </span>
     </div>
     <div
-      class="revisionRow fh8ovok f1dlt78d MuiBox-root css-oluxz7"
+      class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1auw4i3"
       role="row"
     >
       <div
@@ -6659,7 +6680,7 @@ exports[`Results Table should render different blocks when rendering several rev
       </span>
     </div>
     <div
-      class="revisionRow fh8ovok f1dlt78d MuiBox-root css-oluxz7"
+      class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1auw4i3"
       role="row"
     >
       <div

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -1594,7 +1594,7 @@ exports[`Results Table Should match snapshot 1`] = `
                           class="fw0pvlu"
                         >
                           <div
-                            class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
+                            class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
                             role="row"
                           >
                             <div
@@ -1792,7 +1792,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </div>
                           </div>
                           <div
-                            class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
+                            class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
                             role="row"
                           >
                             <div
@@ -1991,7 +1991,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </div>
                           </div>
                           <div
-                            class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
+                            class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
                             role="row"
                           >
                             <div
@@ -2271,7 +2271,7 @@ exports[`Results Table Should match snapshot 1`] = `
                           class="fw0pvlu"
                         >
                           <div
-                            class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
+                            class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
                             role="row"
                           >
                             <div
@@ -4350,7 +4350,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                           class="fw0pvlu"
                         >
                           <div
-                            class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
+                            class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
                             role="row"
                           >
                             <div
@@ -4561,7 +4561,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                             </div>
                           </div>
                           <div
-                            class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
+                            class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
                             role="row"
                           >
                             <div
@@ -4773,7 +4773,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                             </div>
                           </div>
                           <div
-                            class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
+                            class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
                             role="row"
                           >
                             <div
@@ -5066,7 +5066,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                           class="fw0pvlu"
                         >
                           <div
-                            class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
+                            class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
                             role="row"
                           >
                             <div
@@ -5875,7 +5875,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
       </span>
     </div>
     <div
-      class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
+      class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
       role="row"
     >
       <div
@@ -6126,7 +6126,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
       </span>
     </div>
     <div
-      class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
+      class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
       role="row"
     >
       <div
@@ -6434,7 +6434,7 @@ exports[`Results Table should render different blocks when rendering several rev
       </span>
     </div>
     <div
-      class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1auw4i3"
+      class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1auw4i3"
       role="row"
     >
       <div
@@ -6680,7 +6680,7 @@ exports[`Results Table should render different blocks when rendering several rev
       </span>
     </div>
     <div
-      class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1auw4i3"
+      class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1auw4i3"
       role="row"
     >
       <div

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -1160,7 +1160,7 @@ exports[`Results View The table should match snapshot and other elements should 
       </div>
     </div>
     <div
-      class="fjksmi8 f1l733lh"
+      class="fdtnfac f1l733lh"
       data-testid="table-header"
       role="row"
     >
@@ -1236,7 +1236,7 @@ exports[`Results View The table should match snapshot and other elements should 
           data-mui-internal-clone-element="true"
         >
           <button
-            aria-label="MD(%) (Click to sort by this column)"
+            aria-label="MD (%) (Click to sort by this column)"
             class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"
@@ -1252,10 +1252,10 @@ exports[`Results View The table should match snapshot and other elements should 
                 d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
               />
               <title>
-                Not sorted by MD(%)
+                Not sorted by MD (%)
               </title>
             </svg>
-            MD(%)
+            MD (%)
           </button>
         </span>
       </div>
@@ -1302,7 +1302,7 @@ exports[`Results View The table should match snapshot and other elements should 
           data-mui-internal-clone-element="true"
         >
           <button
-            aria-label="Cliff's Delta (Click to sort by this column)"
+            aria-label="CD (Click to sort by this column)"
             class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"
@@ -1318,10 +1318,42 @@ exports[`Results View The table should match snapshot and other elements should 
                 d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
               />
               <title>
-                Not sorted by Cliff's Delta
+                Not sorted by CD
               </title>
             </svg>
-            Cliff's Delta
+            CD
+          </button>
+        </span>
+      </div>
+      <div
+        class="cell effects-header"
+        role="columnheader"
+      >
+        <span
+          class="MuiBox-root css-1tkq7a4"
+          data-mui-internal-clone-element="true"
+        >
+          <button
+            aria-label="CLES (%) (Click to sort by this column)"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-10d4m26-MuiSvgIcon-root"
+              data-testid="SwapVertIcon"
+              focusable="false"
+              role="img"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
+              />
+              <title>
+                Not sorted by CLES (%)
+              </title>
+            </svg>
+            CLES (%)
           </button>
         </span>
       </div>
@@ -1334,7 +1366,7 @@ exports[`Results View The table should match snapshot and other elements should 
           role="group"
         >
           <button
-            aria-label="Significance (Click to sort by this column)"
+            aria-label="Sig (Click to sort by this column)"
             class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButtonGroup-firstButton css-17eldkb-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"
@@ -1350,19 +1382,19 @@ exports[`Results View The table should match snapshot and other elements should 
                 d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
               />
               <title>
-                Not sorted by Significance
+                Not sorted by Sig
               </title>
             </svg>
           </button>
           <button
             aria-haspopup="true"
-            aria-label="Significance (Click to filter values)"
+            aria-label="Sig (Click to filter values)"
             class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-lastButton css-l81dbu-MuiButtonBase-root-MuiButton-root"
             data-mui-internal-clone-element="true"
             tabindex="0"
             type="button"
           >
-            Significance
+            Sig
             <div
               aria-label="2 items selected"
               class="MuiBox-root css-18uhbjh"
@@ -1384,38 +1416,6 @@ exports[`Results View The table should match snapshot and other elements should 
             </svg>
           </button>
         </div>
-      </div>
-      <div
-        class="cell effects-header"
-        role="columnheader"
-      >
-        <span
-          class="MuiBox-root css-1tkq7a4"
-          data-mui-internal-clone-element="true"
-        >
-          <button
-            aria-label="CLES(%) (Click to sort by this column)"
-            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
-            tabindex="0"
-            type="button"
-          >
-            <svg
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-10d4m26-MuiSvgIcon-root"
-              data-testid="SwapVertIcon"
-              focusable="false"
-              role="img"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
-              />
-              <title>
-                Not sorted by CLES(%)
-              </title>
-            </svg>
-            CLES(%)
-          </button>
-        </span>
       </div>
       <div
         class="cell trials-header"
@@ -1550,7 +1550,7 @@ exports[`Results View The table should match snapshot and other elements should 
               class="fw0pvlu"
             >
               <div
-                class="revisionRow fh8ovok f1dlt78d MuiBox-root css-6a7wpt"
+                class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
                 role="row"
               >
                 <div
@@ -1623,13 +1623,13 @@ exports[`Results View The table should match snapshot and other elements should 
                   -
                 </div>
                 <div
-                  class="significance cell"
+                  class="effects cell"
                   role="cell"
                 >
                   -
                 </div>
                 <div
-                  class="effects cell"
+                  class="significance cell"
                   role="cell"
                 >
                   -
@@ -1748,7 +1748,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow fh8ovok f1dlt78d MuiBox-root css-6a7wpt"
+                class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
                 role="row"
               >
                 <div
@@ -1822,13 +1822,13 @@ exports[`Results View The table should match snapshot and other elements should 
                   -
                 </div>
                 <div
-                  class="significance cell"
+                  class="effects cell"
                   role="cell"
                 >
                   -
                 </div>
                 <div
-                  class="effects cell"
+                  class="significance cell"
                   role="cell"
                 >
                   -
@@ -1947,7 +1947,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow fh8ovok f1dlt78d MuiBox-root css-6a7wpt"
+                class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
                 role="row"
               >
                 <div
@@ -2021,13 +2021,13 @@ exports[`Results View The table should match snapshot and other elements should 
                   -
                 </div>
                 <div
-                  class="significance cell"
+                  class="effects cell"
                   role="cell"
                 >
                   -
                 </div>
                 <div
-                  class="effects cell"
+                  class="significance cell"
                   role="cell"
                 >
                   -
@@ -2146,7 +2146,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow fh8ovok f1dlt78d MuiBox-root css-6a7wpt"
+                class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
                 role="row"
               >
                 <div
@@ -2220,13 +2220,13 @@ exports[`Results View The table should match snapshot and other elements should 
                   -
                 </div>
                 <div
-                  class="significance cell"
+                  class="effects cell"
                   role="cell"
                 >
                   -
                 </div>
                 <div
-                  class="effects cell"
+                  class="significance cell"
                   role="cell"
                 >
                   -

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -1550,7 +1550,7 @@ exports[`Results View The table should match snapshot and other elements should 
               class="fw0pvlu"
             >
               <div
-                class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
+                class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
                 role="row"
               >
                 <div
@@ -1748,7 +1748,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
+                class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
                 role="row"
               >
                 <div
@@ -1947,7 +1947,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
+                class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
                 role="row"
               >
                 <div
@@ -2146,7 +2146,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow fh8ovok f1dlt78d MuiBox-root css-1woqe0l"
+                class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
                 role="row"
               >
                 <div

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion table sorting can sort the table and persist the information to the URL of mann-whitney-u values 1`] = `
 <button
-  aria-label="Cliff's Delta (Click to sort by this column)"
+  aria-label="CD (Click to sort by this column)"
   class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
@@ -18,16 +18,16 @@ exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion tabl
       d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
     />
     <title>
-      Not sorted by Cliff's Delta
+      Not sorted by CD
     </title>
   </svg>
-  Cliff's Delta
+  CD
 </button>
 `;
 
 exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion table sorting can sort the table and persist the information to the URL of mann-whitney-u values 2`] = `
 <button
-  aria-label="Cliff's Delta (Currently sorted by this column. Click to change)"
+  aria-label="CD (Currently sorted by this column. Click to change)"
   class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation Mui-focusVisible MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
@@ -43,10 +43,10 @@ exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion tabl
       d="M11 6.83 9.41 8.41 8 7l4-4 4 4-1.41 1.41L13 6.83V21h-2z"
     />
     <title>
-      Sorted by Cliff's Delta in descending order
+      Sorted by CD in descending order
     </title>
   </svg>
-  Cliff's Delta
+  CD
   <span
     class="MuiTouchRipple-root css-r3djoj-MuiTouchRipple-root"
   >
@@ -72,7 +72,7 @@ exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion tabl
 
 exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion table sorting can sort the table and persist the information to the URL of mann-whitney-u values 3`] = `
 <button
-  aria-label="Cliff's Delta (Currently sorted by this column. Click to change)"
+  aria-label="CD (Currently sorted by this column. Click to change)"
   class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation Mui-focusVisible MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
@@ -88,10 +88,10 @@ exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion tabl
       d="M11 6.83 9.41 8.41 8 7l4-4 4 4-1.41 1.41L13 6.83V21h-2z"
     />
     <title>
-      Sorted by Cliff's Delta in ascending order
+      Sorted by CD in ascending order
     </title>
   </svg>
-  Cliff's Delta
+  CD
   <span
     class="MuiTouchRipple-root css-r3djoj-MuiTouchRipple-root"
   >
@@ -125,7 +125,7 @@ exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion tabl
 
 exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion table sorting can sort the table and persist the information to the URL of mann-whitney-u values 4`] = `
 <button
-  aria-label="Cliff's Delta (Click to sort by this column)"
+  aria-label="CD (Click to sort by this column)"
   class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
@@ -141,10 +141,10 @@ exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion tabl
       d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
     />
     <title>
-      Not sorted by Cliff's Delta
+      Not sorted by CD
     </title>
   </svg>
-  Cliff's Delta
+  CD
   <span
     class="MuiTouchRipple-root css-r3djoj-MuiTouchRipple-root"
   >
@@ -178,7 +178,7 @@ exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion tabl
 
 exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion table sorting can sort the table and persist the information to the URL of mann-whitney-u values 5`] = `
 <button
-  aria-label="Significance (Currently sorted by this column. Click to change)"
+  aria-label="Sig (Currently sorted by this column. Click to change)"
   class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation Mui-focusVisible MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButtonGroup-firstButton css-17eldkb-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
@@ -194,7 +194,7 @@ exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion tabl
       d="M11 6.83 9.41 8.41 8 7l4-4 4 4-1.41 1.41L13 6.83V21h-2z"
     />
     <title>
-      Sorted by Significance in descending order
+      Sorted by Sig in descending order
     </title>
   </svg>
   <span
@@ -222,7 +222,7 @@ exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion tabl
 
 exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion table sorting can sort the table and persist the information to the URL of mann-whitney-u values 6`] = `
 <button
-  aria-label="CLES(%) (Currently sorted by this column. Click to change)"
+  aria-label="CLES (%) (Currently sorted by this column. Click to change)"
   class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation Mui-focusVisible MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
@@ -238,10 +238,10 @@ exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion tabl
       d="M11 6.83 9.41 8.41 8 7l4-4 4 4-1.41 1.41L13 6.83V21h-2z"
     />
     <title>
-      Sorted by CLES(%) in descending order
+      Sorted by CLES (%) in descending order
     </title>
   </svg>
-  CLES(%)
+  CLES (%)
   <span
     class="MuiTouchRipple-root css-r3djoj-MuiTouchRipple-root"
   >
@@ -267,7 +267,7 @@ exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion tabl
 
 exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion table sorting initializes the sort from the URL at load time for a descending sort 1`] = `
 <button
-  aria-label="Cliff's Delta (Currently sorted by this column. Click to change)"
+  aria-label="CD (Currently sorted by this column. Click to change)"
   class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
@@ -283,16 +283,16 @@ exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion tabl
       d="M11 6.83 9.41 8.41 8 7l4-4 4 4-1.41 1.41L13 6.83V21h-2z"
     />
     <title>
-      Sorted by Cliff's Delta in descending order
+      Sorted by CD in descending order
     </title>
   </svg>
-  Cliff's Delta
+  CD
 </button>
 `;
 
 exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion table sorting initializes the sort from the URL at load time for an ascending sort 1`] = `
 <button
-  aria-label="Cliff's Delta (Currently sorted by this column. Click to change)"
+  aria-label="CD (Currently sorted by this column. Click to change)"
   class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
@@ -308,16 +308,16 @@ exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion tabl
       d="M11 6.83 9.41 8.41 8 7l4-4 4 4-1.41 1.41L13 6.83V21h-2z"
     />
     <title>
-      Sorted by Cliff's Delta in ascending order
+      Sorted by CD in ascending order
     </title>
   </svg>
-  Cliff's Delta
+  CD
 </button>
 `;
 
 exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion table sorting initializes the sort from the URL at load time for an implicit descending sort 1`] = `
 <button
-  aria-label="Cliff's Delta (Currently sorted by this column. Click to change)"
+  aria-label="CD (Currently sorted by this column. Click to change)"
   class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
   tabindex="0"
   type="button"
@@ -333,10 +333,10 @@ exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion tabl
       d="M11 6.83 9.41 8.41 8 7l4-4 4 4-1.41 1.41L13 6.83V21h-2z"
     />
     <title>
-      Sorted by Cliff's Delta in descending order
+      Sorted by CD in descending order
     </title>
   </svg>
-  Cliff's Delta
+  CD
 </button>
 `;
 
@@ -838,7 +838,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
               role="table"
             >
               <div
-                class="f5chj1k f1l733lh"
+                class="f1itjsvw f1l733lh"
                 data-testid="table-header"
                 role="row"
               >
@@ -907,7 +907,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                     data-mui-internal-clone-element="true"
                   >
                     <button
-                      aria-label="MD(%) (Click to sort by this column)"
+                      aria-label="MD (%) (Click to sort by this column)"
                       class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
                       tabindex="0"
                       type="button"
@@ -923,10 +923,10 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                           d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
                         />
                         <title>
-                          Not sorted by MD(%)
+                          Not sorted by MD (%)
                         </title>
                       </svg>
-                      MD(%)
+                      MD (%)
                     </button>
                   </span>
                 </div>
@@ -973,7 +973,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                     data-mui-internal-clone-element="true"
                   >
                     <button
-                      aria-label="Cliff's Delta (Click to sort by this column)"
+                      aria-label="CD (Click to sort by this column)"
                       class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
                       tabindex="0"
                       type="button"
@@ -989,10 +989,42 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                           d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
                         />
                         <title>
-                          Not sorted by Cliff's Delta
+                          Not sorted by CD
                         </title>
                       </svg>
-                      Cliff's Delta
+                      CD
+                    </button>
+                  </span>
+                </div>
+                <div
+                  class="cell effects-header"
+                  role="columnheader"
+                >
+                  <span
+                    class="MuiBox-root css-1tkq7a4"
+                    data-mui-internal-clone-element="true"
+                  >
+                    <button
+                      aria-label="CLES (%) (Click to sort by this column)"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-10d4m26-MuiSvgIcon-root"
+                        data-testid="SwapVertIcon"
+                        focusable="false"
+                        role="img"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
+                        />
+                        <title>
+                          Not sorted by CLES (%)
+                        </title>
+                      </svg>
+                      CLES (%)
                     </button>
                   </span>
                 </div>
@@ -1005,7 +1037,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                     role="group"
                   >
                     <button
-                      aria-label="Significance (Click to sort by this column)"
+                      aria-label="Sig (Click to sort by this column)"
                       class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButtonGroup-firstButton css-17eldkb-MuiButtonBase-root-MuiButton-root"
                       tabindex="0"
                       type="button"
@@ -1021,19 +1053,19 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                           d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
                         />
                         <title>
-                          Not sorted by Significance
+                          Not sorted by Sig
                         </title>
                       </svg>
                     </button>
                     <button
                       aria-haspopup="true"
-                      aria-label="Significance (Click to filter values)"
+                      aria-label="Sig (Click to filter values)"
                       class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-lastButton css-l81dbu-MuiButtonBase-root-MuiButton-root"
                       data-mui-internal-clone-element="true"
                       tabindex="0"
                       type="button"
                     >
-                      Significance
+                      Sig
                       <div
                         aria-label="2 items selected"
                         class="MuiBox-root css-18uhbjh"
@@ -1057,38 +1089,6 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   </div>
                 </div>
                 <div
-                  class="cell effects-header"
-                  role="columnheader"
-                >
-                  <span
-                    class="MuiBox-root css-1tkq7a4"
-                    data-mui-internal-clone-element="true"
-                  >
-                    <button
-                      aria-label="CLES(%) (Click to sort by this column)"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
-                      tabindex="0"
-                      type="button"
-                    >
-                      <svg
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-10d4m26-MuiSvgIcon-root"
-                        data-testid="SwapVertIcon"
-                        focusable="false"
-                        role="img"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
-                        />
-                        <title>
-                          Not sorted by CLES(%)
-                        </title>
-                      </svg>
-                      CLES(%)
-                    </button>
-                  </span>
-                </div>
-                <div
                   class="cell trials-header"
                   role="columnheader"
                 >
@@ -1110,7 +1110,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 />
               </div>
               <div
-                class="revisionRow fbf0zkr f161t6v MuiBox-root css-82nxkj"
+                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -1180,16 +1180,16 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   -
                 </div>
                 <div
-                  class="significance cell"
-                  role="cell"
-                >
-                  -
-                </div>
-                <div
                   class="effects cell"
                   role="cell"
                 >
                   0.00% 
+                </div>
+                <div
+                  class="significance cell"
+                  role="cell"
+                >
+                  -
                 </div>
                 <div
                   class="total-runs cell"
@@ -1272,7 +1272,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow fbf0zkr f161t6v MuiBox-root css-82nxkj"
+                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -1328,16 +1328,16 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   -
                 </div>
                 <div
-                  class="significance cell"
-                  role="cell"
-                >
-                  -
-                </div>
-                <div
                   class="effects cell"
                   role="cell"
                 >
                   0.00% 
+                </div>
+                <div
+                  class="significance cell"
+                  role="cell"
+                >
+                  -
                 </div>
                 <div
                   class="total-runs cell"
@@ -1420,7 +1420,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow fbf0zkr f161t6v MuiBox-root css-82nxkj"
+                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -1476,16 +1476,16 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   -
                 </div>
                 <div
-                  class="significance cell"
-                  role="cell"
-                >
-                  -
-                </div>
-                <div
                   class="effects cell"
                   role="cell"
                 >
                   0.00% 
+                </div>
+                <div
+                  class="significance cell"
+                  role="cell"
+                >
+                  -
                 </div>
                 <div
                   class="total-runs cell"
@@ -1568,7 +1568,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow fbf0zkr f161t6v MuiBox-root css-82nxkj"
+                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -1624,16 +1624,16 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   -
                 </div>
                 <div
-                  class="significance cell"
-                  role="cell"
-                >
-                  -
-                </div>
-                <div
                   class="effects cell"
                   role="cell"
                 >
                   0.00% 
+                </div>
+                <div
+                  class="significance cell"
+                  role="cell"
+                >
+                  -
                 </div>
                 <div
                   class="total-runs cell"
@@ -1716,7 +1716,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow fbf0zkr f161t6v MuiBox-root css-82nxkj"
+                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -1772,16 +1772,16 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   -
                 </div>
                 <div
-                  class="significance cell"
-                  role="cell"
-                >
-                  -
-                </div>
-                <div
                   class="effects cell"
                   role="cell"
                 >
                   0.00% 
+                </div>
+                <div
+                  class="significance cell"
+                  role="cell"
+                >
+                  -
                 </div>
                 <div
                   class="total-runs cell"
@@ -2747,7 +2747,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
               role="table"
             >
               <div
-                class="f5chj1k f1l733lh"
+                class="f1itjsvw f1l733lh"
                 data-testid="table-header"
                 role="row"
               >
@@ -2816,7 +2816,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                     data-mui-internal-clone-element="true"
                   >
                     <button
-                      aria-label="MD(%) (Click to sort by this column)"
+                      aria-label="MD (%) (Click to sort by this column)"
                       class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
                       tabindex="0"
                       type="button"
@@ -2832,10 +2832,10 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                           d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
                         />
                         <title>
-                          Not sorted by MD(%)
+                          Not sorted by MD (%)
                         </title>
                       </svg>
-                      MD(%)
+                      MD (%)
                     </button>
                   </span>
                 </div>
@@ -2882,7 +2882,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                     data-mui-internal-clone-element="true"
                   >
                     <button
-                      aria-label="Cliff's Delta (Click to sort by this column)"
+                      aria-label="CD (Click to sort by this column)"
                       class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
                       tabindex="0"
                       type="button"
@@ -2898,10 +2898,42 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                           d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
                         />
                         <title>
-                          Not sorted by Cliff's Delta
+                          Not sorted by CD
                         </title>
                       </svg>
-                      Cliff's Delta
+                      CD
+                    </button>
+                  </span>
+                </div>
+                <div
+                  class="cell effects-header"
+                  role="columnheader"
+                >
+                  <span
+                    class="MuiBox-root css-1tkq7a4"
+                    data-mui-internal-clone-element="true"
+                  >
+                    <button
+                      aria-label="CLES (%) (Click to sort by this column)"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-10d4m26-MuiSvgIcon-root"
+                        data-testid="SwapVertIcon"
+                        focusable="false"
+                        role="img"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
+                        />
+                        <title>
+                          Not sorted by CLES (%)
+                        </title>
+                      </svg>
+                      CLES (%)
                     </button>
                   </span>
                 </div>
@@ -2914,7 +2946,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                     role="group"
                   >
                     <button
-                      aria-label="Significance (Click to sort by this column)"
+                      aria-label="Sig (Click to sort by this column)"
                       class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButtonGroup-firstButton css-17eldkb-MuiButtonBase-root-MuiButton-root"
                       tabindex="0"
                       type="button"
@@ -2930,19 +2962,19 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                           d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
                         />
                         <title>
-                          Not sorted by Significance
+                          Not sorted by Sig
                         </title>
                       </svg>
                     </button>
                     <button
                       aria-haspopup="true"
-                      aria-label="Significance (Click to filter values)"
+                      aria-label="Sig (Click to filter values)"
                       class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-lastButton css-l81dbu-MuiButtonBase-root-MuiButton-root"
                       data-mui-internal-clone-element="true"
                       tabindex="0"
                       type="button"
                     >
-                      Significance
+                      Sig
                       <div
                         aria-label="2 items selected"
                         class="MuiBox-root css-18uhbjh"
@@ -2966,38 +2998,6 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   </div>
                 </div>
                 <div
-                  class="cell effects-header"
-                  role="columnheader"
-                >
-                  <span
-                    class="MuiBox-root css-1tkq7a4"
-                    data-mui-internal-clone-element="true"
-                  >
-                    <button
-                      aria-label="CLES(%) (Click to sort by this column)"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
-                      tabindex="0"
-                      type="button"
-                    >
-                      <svg
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-10d4m26-MuiSvgIcon-root"
-                        data-testid="SwapVertIcon"
-                        focusable="false"
-                        role="img"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
-                        />
-                        <title>
-                          Not sorted by CLES(%)
-                        </title>
-                      </svg>
-                      CLES(%)
-                    </button>
-                  </span>
-                </div>
-                <div
                   class="cell trials-header"
                   role="columnheader"
                 >
@@ -3019,7 +3019,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 />
               </div>
               <div
-                class="revisionRow fbf0zkr f161t6v MuiBox-root css-82nxkj"
+                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -3091,16 +3091,16 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   -0.04
                 </div>
                 <div
-                  class="significance cell"
-                  role="cell"
-                >
-                  Not significant
-                </div>
-                <div
                   class="effects cell"
                   role="cell"
                 >
                   15.00% 
+                </div>
+                <div
+                  class="significance cell"
+                  role="cell"
+                >
+                  -
                 </div>
                 <div
                   class="total-runs cell"
@@ -3183,7 +3183,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow fbf0zkr f161t6v MuiBox-root css-82nxkj"
+                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -3254,16 +3254,29 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   0.02
                 </div>
                 <div
-                  class="significance cell"
-                  role="cell"
-                >
-                  Significant
-                </div>
-                <div
                   class="effects cell"
                   role="cell"
                 >
                   60.00% 
+                </div>
+                <div
+                  class="significance cell"
+                  role="cell"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                    data-testid="KeyboardDoubleArrowUpIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
+                    />
+                    <path
+                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
+                    />
+                  </svg>
                 </div>
                 <div
                   class="total-runs cell"
@@ -3346,7 +3359,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow fbf0zkr f161t6v MuiBox-root css-82nxkj"
+                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -3404,16 +3417,29 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   -0.05
                 </div>
                 <div
-                  class="significance cell"
-                  role="cell"
-                >
-                  Significant
-                </div>
-                <div
                   class="effects cell"
                   role="cell"
                 >
                   50.00% 
+                </div>
+                <div
+                  class="significance cell"
+                  role="cell"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                    data-testid="KeyboardDoubleArrowUpIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
+                    />
+                    <path
+                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
+                    />
+                  </svg>
                 </div>
                 <div
                   class="total-runs cell"
@@ -3496,7 +3522,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow fbf0zkr f161t6v MuiBox-root css-82nxkj"
+                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -3554,16 +3580,29 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   0.12
                 </div>
                 <div
-                  class="significance cell"
-                  role="cell"
-                >
-                  Significant
-                </div>
-                <div
                   class="effects cell"
                   role="cell"
                 >
                   25.00% 
+                </div>
+                <div
+                  class="significance cell"
+                  role="cell"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                    data-testid="KeyboardDoubleArrowUpIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
+                    />
+                    <path
+                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
+                    />
+                  </svg>
                 </div>
                 <div
                   class="total-runs cell"
@@ -3646,7 +3685,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow fbf0zkr f161t6v MuiBox-root css-82nxkj"
+                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -3717,16 +3756,16 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   0.01
                 </div>
                 <div
-                  class="significance cell"
-                  role="cell"
-                >
-                  -
-                </div>
-                <div
                   class="effects cell"
                   role="cell"
                 >
                   45.00% 
+                </div>
+                <div
+                  class="significance cell"
+                  role="cell"
+                >
+                  -
                 </div>
                 <div
                   class="total-runs cell"
@@ -4308,7 +4347,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
               role="table"
             >
               <div
-                class="f5chj1k f1l733lh"
+                class="f1itjsvw f1l733lh"
                 data-testid="table-header"
                 role="row"
               >
@@ -4377,7 +4416,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                     data-mui-internal-clone-element="true"
                   >
                     <button
-                      aria-label="MD(%) (Click to sort by this column)"
+                      aria-label="MD (%) (Click to sort by this column)"
                       class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
                       tabindex="0"
                       type="button"
@@ -4393,10 +4432,10 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                           d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
                         />
                         <title>
-                          Not sorted by MD(%)
+                          Not sorted by MD (%)
                         </title>
                       </svg>
-                      MD(%)
+                      MD (%)
                     </button>
                   </span>
                 </div>
@@ -4443,7 +4482,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                     data-mui-internal-clone-element="true"
                   >
                     <button
-                      aria-label="Cliff's Delta (Click to sort by this column)"
+                      aria-label="CD (Click to sort by this column)"
                       class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
                       tabindex="0"
                       type="button"
@@ -4459,10 +4498,42 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                           d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
                         />
                         <title>
-                          Not sorted by Cliff's Delta
+                          Not sorted by CD
                         </title>
                       </svg>
-                      Cliff's Delta
+                      CD
+                    </button>
+                  </span>
+                </div>
+                <div
+                  class="cell effects-header"
+                  role="columnheader"
+                >
+                  <span
+                    class="MuiBox-root css-1tkq7a4"
+                    data-mui-internal-clone-element="true"
+                  >
+                    <button
+                      aria-label="CLES (%) (Click to sort by this column)"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-10d4m26-MuiSvgIcon-root"
+                        data-testid="SwapVertIcon"
+                        focusable="false"
+                        role="img"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
+                        />
+                        <title>
+                          Not sorted by CLES (%)
+                        </title>
+                      </svg>
+                      CLES (%)
                     </button>
                   </span>
                 </div>
@@ -4475,7 +4546,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                     role="group"
                   >
                     <button
-                      aria-label="Significance (Click to sort by this column)"
+                      aria-label="Sig (Click to sort by this column)"
                       class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButtonGroup-firstButton css-17eldkb-MuiButtonBase-root-MuiButton-root"
                       tabindex="0"
                       type="button"
@@ -4491,19 +4562,19 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                           d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
                         />
                         <title>
-                          Not sorted by Significance
+                          Not sorted by Sig
                         </title>
                       </svg>
                     </button>
                     <button
                       aria-haspopup="true"
-                      aria-label="Significance (Click to filter values)"
+                      aria-label="Sig (Click to filter values)"
                       class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-lastButton css-l81dbu-MuiButtonBase-root-MuiButton-root"
                       data-mui-internal-clone-element="true"
                       tabindex="0"
                       type="button"
                     >
-                      Significance
+                      Sig
                       <div
                         aria-label="2 items selected"
                         class="MuiBox-root css-18uhbjh"
@@ -4527,38 +4598,6 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   </div>
                 </div>
                 <div
-                  class="cell effects-header"
-                  role="columnheader"
-                >
-                  <span
-                    class="MuiBox-root css-1tkq7a4"
-                    data-mui-internal-clone-element="true"
-                  >
-                    <button
-                      aria-label="CLES(%) (Click to sort by this column)"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
-                      tabindex="0"
-                      type="button"
-                    >
-                      <svg
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-10d4m26-MuiSvgIcon-root"
-                        data-testid="SwapVertIcon"
-                        focusable="false"
-                        role="img"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
-                        />
-                        <title>
-                          Not sorted by CLES(%)
-                        </title>
-                      </svg>
-                      CLES(%)
-                    </button>
-                  </span>
-                </div>
-                <div
                   class="cell trials-header"
                   role="columnheader"
                 >
@@ -4580,7 +4619,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 />
               </div>
               <div
-                class="revisionRow fbf0zkr f161t6v MuiBox-root css-82nxkj"
+                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -4652,16 +4691,16 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   -0.04
                 </div>
                 <div
-                  class="significance cell"
-                  role="cell"
-                >
-                  Not significant
-                </div>
-                <div
                   class="effects cell"
                   role="cell"
                 >
                   15.00% 
+                </div>
+                <div
+                  class="significance cell"
+                  role="cell"
+                >
+                  -
                 </div>
                 <div
                   class="total-runs cell"
@@ -4744,7 +4783,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow fbf0zkr f161t6v MuiBox-root css-82nxkj"
+                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -4815,16 +4854,29 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   0.02
                 </div>
                 <div
-                  class="significance cell"
-                  role="cell"
-                >
-                  Significant
-                </div>
-                <div
                   class="effects cell"
                   role="cell"
                 >
                   60.00% 
+                </div>
+                <div
+                  class="significance cell"
+                  role="cell"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                    data-testid="KeyboardDoubleArrowUpIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
+                    />
+                    <path
+                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
+                    />
+                  </svg>
                 </div>
                 <div
                   class="total-runs cell"
@@ -4907,7 +4959,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow fbf0zkr f161t6v MuiBox-root css-82nxkj"
+                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -4965,16 +5017,29 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   -0.05
                 </div>
                 <div
-                  class="significance cell"
-                  role="cell"
-                >
-                  Significant
-                </div>
-                <div
                   class="effects cell"
                   role="cell"
                 >
                   50.00% 
+                </div>
+                <div
+                  class="significance cell"
+                  role="cell"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                    data-testid="KeyboardDoubleArrowUpIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
+                    />
+                    <path
+                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
+                    />
+                  </svg>
                 </div>
                 <div
                   class="total-runs cell"
@@ -5057,7 +5122,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow fbf0zkr f161t6v MuiBox-root css-82nxkj"
+                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -5115,16 +5180,29 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   0.12
                 </div>
                 <div
-                  class="significance cell"
-                  role="cell"
-                >
-                  Significant
-                </div>
-                <div
                   class="effects cell"
                   role="cell"
                 >
                   25.00% 
+                </div>
+                <div
+                  class="significance cell"
+                  role="cell"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                    data-testid="KeyboardDoubleArrowUpIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
+                    />
+                    <path
+                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
+                    />
+                  </svg>
                 </div>
                 <div
                   class="total-runs cell"
@@ -5207,7 +5285,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow fbf0zkr f161t6v MuiBox-root css-82nxkj"
+                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -5278,16 +5356,16 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   0.01
                 </div>
                 <div
-                  class="significance cell"
-                  role="cell"
-                >
-                  -
-                </div>
-                <div
                   class="effects cell"
                   role="cell"
                 >
                   45.00% 
+                </div>
+                <div
+                  class="significance cell"
+                  role="cell"
+                >
+                  -
                 </div>
                 <div
                   class="total-runs cell"
@@ -5869,7 +5947,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
               role="table"
             >
               <div
-                class="f5chj1k f1l733lh"
+                class="f1itjsvw f1l733lh"
                 data-testid="table-header"
                 role="row"
               >
@@ -5938,7 +6016,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                     data-mui-internal-clone-element="true"
                   >
                     <button
-                      aria-label="MD(%) (Click to sort by this column)"
+                      aria-label="MD (%) (Click to sort by this column)"
                       class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
                       tabindex="0"
                       type="button"
@@ -5954,10 +6032,10 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                           d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
                         />
                         <title>
-                          Not sorted by MD(%)
+                          Not sorted by MD (%)
                         </title>
                       </svg>
-                      MD(%)
+                      MD (%)
                     </button>
                   </span>
                 </div>
@@ -6004,7 +6082,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                     data-mui-internal-clone-element="true"
                   >
                     <button
-                      aria-label="Cliff's Delta (Click to sort by this column)"
+                      aria-label="CD (Click to sort by this column)"
                       class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
                       tabindex="0"
                       type="button"
@@ -6020,10 +6098,42 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                           d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
                         />
                         <title>
-                          Not sorted by Cliff's Delta
+                          Not sorted by CD
                         </title>
                       </svg>
-                      Cliff's Delta
+                      CD
+                    </button>
+                  </span>
+                </div>
+                <div
+                  class="cell effects-header"
+                  role="columnheader"
+                >
+                  <span
+                    class="MuiBox-root css-1tkq7a4"
+                    data-mui-internal-clone-element="true"
+                  >
+                    <button
+                      aria-label="CLES (%) (Click to sort by this column)"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-10d4m26-MuiSvgIcon-root"
+                        data-testid="SwapVertIcon"
+                        focusable="false"
+                        role="img"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
+                        />
+                        <title>
+                          Not sorted by CLES (%)
+                        </title>
+                      </svg>
+                      CLES (%)
                     </button>
                   </span>
                 </div>
@@ -6036,7 +6146,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                     role="group"
                   >
                     <button
-                      aria-label="Significance (Click to sort by this column)"
+                      aria-label="Sig (Click to sort by this column)"
                       class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButtonGroup-firstButton css-17eldkb-MuiButtonBase-root-MuiButton-root"
                       tabindex="0"
                       type="button"
@@ -6052,19 +6162,19 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                           d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
                         />
                         <title>
-                          Not sorted by Significance
+                          Not sorted by Sig
                         </title>
                       </svg>
                     </button>
                     <button
                       aria-haspopup="true"
-                      aria-label="Significance (Click to filter values)"
+                      aria-label="Sig (Click to filter values)"
                       class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-lastButton css-l81dbu-MuiButtonBase-root-MuiButton-root"
                       data-mui-internal-clone-element="true"
                       tabindex="0"
                       type="button"
                     >
-                      Significance
+                      Sig
                       <div
                         aria-label="2 items selected"
                         class="MuiBox-root css-18uhbjh"
@@ -6088,38 +6198,6 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   </div>
                 </div>
                 <div
-                  class="cell effects-header"
-                  role="columnheader"
-                >
-                  <span
-                    class="MuiBox-root css-1tkq7a4"
-                    data-mui-internal-clone-element="true"
-                  >
-                    <button
-                      aria-label="CLES(%) (Click to sort by this column)"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
-                      tabindex="0"
-                      type="button"
-                    >
-                      <svg
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-10d4m26-MuiSvgIcon-root"
-                        data-testid="SwapVertIcon"
-                        focusable="false"
-                        role="img"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
-                        />
-                        <title>
-                          Not sorted by CLES(%)
-                        </title>
-                      </svg>
-                      CLES(%)
-                    </button>
-                  </span>
-                </div>
-                <div
                   class="cell trials-header"
                   role="columnheader"
                 >
@@ -6141,7 +6219,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                 />
               </div>
               <div
-                class="revisionRow fbf0zkr f161t6v MuiBox-root css-82nxkj"
+                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -6213,16 +6291,16 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   -0.04
                 </div>
                 <div
-                  class="significance cell"
-                  role="cell"
-                >
-                  Not significant
-                </div>
-                <div
                   class="effects cell"
                   role="cell"
                 >
                   15.00% 
+                </div>
+                <div
+                  class="significance cell"
+                  role="cell"
+                >
+                  -
                 </div>
                 <div
                   class="total-runs cell"
@@ -6305,7 +6383,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                 </div>
               </div>
               <div
-                class="revisionRow fbf0zkr f161t6v MuiBox-root css-82nxkj"
+                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -6376,16 +6454,29 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   0.02
                 </div>
                 <div
-                  class="significance cell"
-                  role="cell"
-                >
-                  Significant
-                </div>
-                <div
                   class="effects cell"
                   role="cell"
                 >
                   60.00% 
+                </div>
+                <div
+                  class="significance cell"
+                  role="cell"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                    data-testid="KeyboardDoubleArrowUpIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
+                    />
+                    <path
+                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
+                    />
+                  </svg>
                 </div>
                 <div
                   class="total-runs cell"
@@ -6468,7 +6559,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                 </div>
               </div>
               <div
-                class="revisionRow fbf0zkr f161t6v MuiBox-root css-82nxkj"
+                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -6526,16 +6617,29 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   -0.05
                 </div>
                 <div
-                  class="significance cell"
-                  role="cell"
-                >
-                  Significant
-                </div>
-                <div
                   class="effects cell"
                   role="cell"
                 >
                   50.00% 
+                </div>
+                <div
+                  class="significance cell"
+                  role="cell"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                    data-testid="KeyboardDoubleArrowUpIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
+                    />
+                    <path
+                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
+                    />
+                  </svg>
                 </div>
                 <div
                   class="total-runs cell"
@@ -6618,7 +6722,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                 </div>
               </div>
               <div
-                class="revisionRow fbf0zkr f161t6v MuiBox-root css-82nxkj"
+                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -6676,16 +6780,29 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   0.12
                 </div>
                 <div
-                  class="significance cell"
-                  role="cell"
-                >
-                  Significant
-                </div>
-                <div
                   class="effects cell"
                   role="cell"
                 >
                   25.00% 
+                </div>
+                <div
+                  class="significance cell"
+                  role="cell"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                    data-testid="KeyboardDoubleArrowUpIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
+                    />
+                    <path
+                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
+                    />
+                  </svg>
                 </div>
                 <div
                   class="total-runs cell"
@@ -6768,7 +6885,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                 </div>
               </div>
               <div
-                class="revisionRow fbf0zkr f161t6v MuiBox-root css-82nxkj"
+                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -6839,16 +6956,16 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   0.01
                 </div>
                 <div
-                  class="significance cell"
-                  role="cell"
-                >
-                  -
-                </div>
-                <div
                   class="effects cell"
                   role="cell"
                 >
                   45.00% 
+                </div>
+                <div
+                  class="significance cell"
+                  role="cell"
+                >
+                  -
                 </div>
                 <div
                   class="total-runs cell"
@@ -7430,7 +7547,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
               role="table"
             >
               <div
-                class="f5chj1k f1l733lh"
+                class="f1itjsvw f1l733lh"
                 data-testid="table-header"
                 role="row"
               >
@@ -7499,7 +7616,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                     data-mui-internal-clone-element="true"
                   >
                     <button
-                      aria-label="MD(%) (Click to sort by this column)"
+                      aria-label="MD (%) (Click to sort by this column)"
                       class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
                       tabindex="0"
                       type="button"
@@ -7515,10 +7632,10 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                           d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
                         />
                         <title>
-                          Not sorted by MD(%)
+                          Not sorted by MD (%)
                         </title>
                       </svg>
-                      MD(%)
+                      MD (%)
                     </button>
                   </span>
                 </div>
@@ -7565,7 +7682,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                     data-mui-internal-clone-element="true"
                   >
                     <button
-                      aria-label="Cliff's Delta (Click to sort by this column)"
+                      aria-label="CD (Click to sort by this column)"
                       class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
                       tabindex="0"
                       type="button"
@@ -7581,10 +7698,42 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                           d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
                         />
                         <title>
-                          Not sorted by Cliff's Delta
+                          Not sorted by CD
                         </title>
                       </svg>
-                      Cliff's Delta
+                      CD
+                    </button>
+                  </span>
+                </div>
+                <div
+                  class="cell effects-header"
+                  role="columnheader"
+                >
+                  <span
+                    class="MuiBox-root css-1tkq7a4"
+                    data-mui-internal-clone-element="true"
+                  >
+                    <button
+                      aria-label="CLES (%) (Click to sort by this column)"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-10d4m26-MuiSvgIcon-root"
+                        data-testid="SwapVertIcon"
+                        focusable="false"
+                        role="img"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
+                        />
+                        <title>
+                          Not sorted by CLES (%)
+                        </title>
+                      </svg>
+                      CLES (%)
                     </button>
                   </span>
                 </div>
@@ -7597,7 +7746,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                     role="group"
                   >
                     <button
-                      aria-label="Significance (Click to sort by this column)"
+                      aria-label="Sig (Click to sort by this column)"
                       class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButtonGroup-firstButton css-17eldkb-MuiButtonBase-root-MuiButton-root"
                       tabindex="0"
                       type="button"
@@ -7613,19 +7762,19 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                           d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
                         />
                         <title>
-                          Not sorted by Significance
+                          Not sorted by Sig
                         </title>
                       </svg>
                     </button>
                     <button
                       aria-haspopup="true"
-                      aria-label="Significance (Click to filter values)"
+                      aria-label="Sig (Click to filter values)"
                       class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedTableHeaderButton MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButtonGroup-lastButton css-l81dbu-MuiButtonBase-root-MuiButton-root"
                       data-mui-internal-clone-element="true"
                       tabindex="0"
                       type="button"
                     >
-                      Significance
+                      Sig
                       <div
                         aria-label="2 items selected"
                         class="MuiBox-root css-18uhbjh"
@@ -7649,38 +7798,6 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   </div>
                 </div>
                 <div
-                  class="cell effects-header"
-                  role="columnheader"
-                >
-                  <span
-                    class="MuiBox-root css-1tkq7a4"
-                    data-mui-internal-clone-element="true"
-                  >
-                    <button
-                      aria-label="CLES(%) (Click to sort by this column)"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation MuiButton-root MuiButton-contained MuiButton-containedTableHeaderButton MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorTableHeaderButton MuiButton-disableElevation css-7upxw3-MuiButtonBase-root-MuiButton-root"
-                      tabindex="0"
-                      type="button"
-                    >
-                      <svg
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-10d4m26-MuiSvgIcon-root"
-                        data-testid="SwapVertIcon"
-                        focusable="false"
-                        role="img"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99zM9 3 5 6.99h3V14h2V6.99h3z"
-                        />
-                        <title>
-                          Not sorted by CLES(%)
-                        </title>
-                      </svg>
-                      CLES(%)
-                    </button>
-                  </span>
-                </div>
-                <div
                   class="cell trials-header"
                   role="columnheader"
                 >
@@ -7702,7 +7819,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 />
               </div>
               <div
-                class="revisionRow fbf0zkr f161t6v MuiBox-root css-82nxkj"
+                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -7772,16 +7889,16 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   -
                 </div>
                 <div
-                  class="significance cell"
-                  role="cell"
-                >
-                  -
-                </div>
-                <div
                   class="effects cell"
                   role="cell"
                 >
                   0.00% 
+                </div>
+                <div
+                  class="significance cell"
+                  role="cell"
+                >
+                  -
                 </div>
                 <div
                   class="total-runs cell"
@@ -7864,7 +7981,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow fbf0zkr f161t6v MuiBox-root css-82nxkj"
+                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -7920,16 +8037,16 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   -
                 </div>
                 <div
-                  class="significance cell"
-                  role="cell"
-                >
-                  -
-                </div>
-                <div
                   class="effects cell"
                   role="cell"
                 >
                   0.00% 
+                </div>
+                <div
+                  class="significance cell"
+                  role="cell"
+                >
+                  -
                 </div>
                 <div
                   class="total-runs cell"
@@ -8012,7 +8129,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow fbf0zkr f161t6v MuiBox-root css-82nxkj"
+                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -8068,16 +8185,16 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   -
                 </div>
                 <div
-                  class="significance cell"
-                  role="cell"
-                >
-                  -
-                </div>
-                <div
                   class="effects cell"
                   role="cell"
                 >
                   0.00% 
+                </div>
+                <div
+                  class="significance cell"
+                  role="cell"
+                >
+                  -
                 </div>
                 <div
                   class="total-runs cell"
@@ -8160,7 +8277,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow fbf0zkr f161t6v MuiBox-root css-82nxkj"
+                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -8216,16 +8333,16 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   -
                 </div>
                 <div
-                  class="significance cell"
-                  role="cell"
-                >
-                  -
-                </div>
-                <div
                   class="effects cell"
                   role="cell"
                 >
                   0.00% 
+                </div>
+                <div
+                  class="significance cell"
+                  role="cell"
+                >
+                  -
                 </div>
                 <div
                   class="total-runs cell"
@@ -8308,7 +8425,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow fbf0zkr f161t6v MuiBox-root css-82nxkj"
+                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -8364,16 +8481,16 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   -
                 </div>
                 <div
-                  class="significance cell"
-                  role="cell"
-                >
-                  -
-                </div>
-                <div
                   class="effects cell"
                   role="cell"
                 >
                   0.00% 
+                </div>
+                <div
+                  class="significance cell"
+                  role="cell"
+                >
+                  -
                 </div>
                 <div
                   class="total-runs cell"

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsRevisionRow.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsRevisionRow.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`SubtestsRevisionRow Component renders browser name when base and new ap
 <body>
   <div>
     <div
-      class="revisionRow fbf0zkr f161t6v MuiBox-root css-1uflkrc"
+      class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-1uflkrc"
       role="row"
     >
       <div
@@ -183,7 +183,7 @@ exports[`SubtestsRevisionRow Component renders doesnt render browser name when b
 <body>
   <div>
     <div
-      class="revisionRow fbf0zkr f161t6v MuiBox-root css-1uflkrc"
+      class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-1uflkrc"
       role="row"
     >
       <div
@@ -337,7 +337,7 @@ exports[`SubtestsRevisionRow Component renders the component with correct data 1
 <body>
   <div>
     <div
-      class="revisionRow fbf0zkr f161t6v MuiBox-root css-1uflkrc"
+      class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-1uflkrc"
       role="row"
     >
       <div

--- a/src/common/testVersions/mannWhitney.tsx
+++ b/src/common/testVersions/mannWhitney.tsx
@@ -1,3 +1,4 @@
+import KeyboardDoubleArrowUpIcon from '@mui/icons-material/KeyboardDoubleArrowUp';
 import ThumbDownIcon from '@mui/icons-material/ThumbDown';
 import ThumbUpIcon from '@mui/icons-material/ThumbUp';
 import WarningIcon from '@mui/icons-material/Warning';
@@ -130,15 +131,15 @@ export const mannWhitneyStrategy = {
       {
         name: 'Base',
         key: 'base',
-        gridWidth: '.75fr',
+        gridWidth: '1fr',
         tooltip: tooltipBaseMean,
       },
       { key: 'comparisonSign', gridWidth: '0.25fr' },
-      { name: 'New', key: 'new', gridWidth: '.75fr', tooltip: tooltipNewMean },
+      { name: 'New', key: 'new', gridWidth: '1fr', tooltip: tooltipNewMean },
       {
-        name: 'MD(%)',
+        name: 'MD (%)',
         key: 'median-diff',
-        gridWidth: '.75fr',
+        gridWidth: '1fr',
         sortFunction(
           resultA: MannWhitneyResultsItem,
           resultB: MannWhitneyResultsItem,
@@ -160,7 +161,7 @@ export const mannWhitneyStrategy = {
         name: 'Status',
         filter: true,
         key: 'status',
-        gridWidth: '1.25fr',
+        gridWidth: '1.5fr',
         possibleValues: [
           { label: 'No changes', key: 'none' },
           { label: 'Improvement', key: 'improvement' },
@@ -182,9 +183,9 @@ export const mannWhitneyStrategy = {
         tooltip: tooltipStatusMannWhitney,
       },
       {
-        name: "Cliff's Delta",
+        name: 'CD',
         key: 'delta',
-        gridWidth: '1.25fr',
+        gridWidth: '1fr',
         sortFunction(
           resultA: MannWhitneyResultsItem,
           resultB: MannWhitneyResultsItem,
@@ -196,35 +197,7 @@ export const mannWhitneyStrategy = {
         tooltip: tooltipCliffsDelta,
       },
       {
-        name: 'Significance',
-        key: 'significance',
-        filter: true,
-        gridWidth: '1.5fr',
-        tooltip: tooltipSignificance,
-        possibleValues: [
-          { label: 'Significant', key: 'significant' },
-          { label: 'Not Significant', key: 'not significant' },
-        ],
-        matchesFunction(result: MannWhitneyResultsItem, valueKey: string) {
-          const label = this.possibleValues.find(
-            ({ key }) => key === valueKey?.toLowerCase(),
-          )?.label;
-          return (
-            result.mann_whitney_test?.interpretation === label?.toLowerCase()
-          );
-        },
-        sortFunction(
-          resultA: MannWhitneyResultsItem,
-          resultB: MannWhitneyResultsItem,
-        ) {
-          return (
-            Math.abs(resultA.mann_whitney_test?.pvalue ?? 0) -
-            Math.abs(resultB.mann_whitney_test?.pvalue ?? 0)
-          );
-        },
-      },
-      {
-        name: 'CLES(%)',
+        name: 'CLES (%)',
         key: 'effects',
         gridWidth: '1.25fr',
         sortFunction(
@@ -238,6 +211,38 @@ export const mannWhitneyStrategy = {
         },
         tooltip: tooltipEffectSize,
       },
+      {
+        name: 'Sig',
+        key: 'significance',
+        filter: true,
+        gridWidth: '1.25fr',
+        tooltip: tooltipSignificance,
+        possibleValues: [
+          {
+            label: 'Significant',
+            key: 'significant',
+            icon: <KeyboardDoubleArrowUpIcon fontSize='small' />,
+          },
+          {
+            label: 'Not Significant',
+            key: 'not significant',
+            icon: <div>-</div>,
+          },
+        ],
+        matchesFunction(result: MannWhitneyResultsItem, valueKey: string) {
+          return result.mann_whitney_test?.interpretation === valueKey;
+        },
+        sortFunction(
+          resultA: MannWhitneyResultsItem,
+          resultB: MannWhitneyResultsItem,
+        ) {
+          return (
+            Math.abs(resultA.mann_whitney_test?.pvalue ?? 0) -
+            Math.abs(resultB.mann_whitney_test?.pvalue ?? 0)
+          );
+        },
+      },
+
       {
         name: 'Total Trials',
         key: 'trials',
@@ -269,9 +274,6 @@ export const mannWhitneyStrategy = {
       base_app: baseApp,
       new_app: newApp,
     } = result as MannWhitneyResultsItem;
-    const mann_whitney_interpretation = mann_whitney_test?.interpretation
-      ? capitalize(mann_whitney_test.interpretation)
-      : '-';
     const clesVal = ((cles?.cles ?? 0) * 100).toFixed(2);
     const baseAvgValue =
       (result as MannWhitneyResultsItem).base_standard_stats?.mean ?? 0;
@@ -355,11 +357,16 @@ export const mannWhitneyStrategy = {
           {' '}
           {cliffs_delta || '-'}
         </div>
-        <div className='significance cell' role='cell'>
-          {mann_whitney_interpretation}
-        </div>
+
         <div className='effects cell' role='cell'>
           {clesVal ? `${clesVal}% ` : '-'}
+        </div>
+        <div className='significance cell' role='cell'>
+          {mann_whitney_test?.interpretation === 'significant' ? (
+            <KeyboardDoubleArrowUpIcon fontSize='small' />
+          ) : (
+            '-'
+          )}
         </div>
       </>
     );
@@ -480,13 +487,15 @@ export const mannWhitneyStrategy = {
         <div className='delta cell' role='cell'>
           {cliffs_delta || '-'}
         </div>
-        <div className='significance cell' role='cell'>
-          {mann_whitney_test?.interpretation
-            ? capitalize(mann_whitney_test.interpretation)
-            : '-'}
-        </div>
         <div className='effects cell' role='cell'>
           {clesValue}
+        </div>
+        <div className='significance cell' role='cell'>
+          {mann_whitney_test?.interpretation === 'significant' ? (
+            <KeyboardDoubleArrowUpIcon fontSize='small' />
+          ) : (
+            '-'
+          )}
         </div>
       </>
     );

--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -14,7 +14,10 @@ import useRawSearchParams from '../../hooks/useRawSearchParams';
 import useTableFilters from '../../hooks/useTableFilters';
 import useTableSort from '../../hooks/useTableSort';
 import { Framework, TestVersion } from '../../types/types';
-import { getColumnsConfiguration } from '../../utils/rowTemplateColumns';
+import {
+  getColumnsConfiguration,
+  toGridTemplateColumns,
+} from '../../utils/rowTemplateColumns';
 
 type CombinedLoaderReturnValue = LoaderReturnValue | OverTimeLoaderReturnValue;
 export default function ResultsTable() {
@@ -76,9 +79,7 @@ export default function ResultsTable() {
     setSearchParams(searchParams);
   };
 
-  const rowGridTemplateColumns = columnsConfig
-    .map((config) => config.gridWidth)
-    .join(' ');
+  const rowGridTemplateColumns = toGridTemplateColumns(columnsConfig);
 
   return (
     <Box data-testid='results-table' role='table' sx={{ paddingBottom: 3 }}>

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -67,7 +67,6 @@ const revisionRow = style({
     '.significance': {
       gap: '10px',
       justifyContent: 'center',
-      paddingInlineStart: '15%',
     },
     '.expand-button-container': {
       justifyContent: 'right',

--- a/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
@@ -33,18 +33,12 @@ const revisionRow = style({
     },
     '.significance': {
       gap: '10px',
-      justifyContent: 'left',
+      justifyContent: 'center',
     },
     '.subtests': {
       borderRadius: '4px 0 0 4px',
       paddingLeft: Spacing.Medium, // Synchronize with its header
       justifyContent: 'left',
-      whiteSpace: 'nowrap',
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-    },
-    '.subtests-mannwhitney': {
-      maxWidth: '150px',
     },
 
     '.status': {
@@ -98,7 +92,6 @@ const typography = style({
   fontStyle: 'normal',
   fontWeight: 400,
   fontSize: '16px',
-  whiteSpace: 'nowrap',
   lineHeight: '1.5',
 });
 

--- a/src/components/CompareResults/TableHeader.tsx
+++ b/src/components/CompareResults/TableHeader.tsx
@@ -26,6 +26,7 @@ import type {
   CompareResultsTableColumn,
   CompareMannWhitneyResultsTableConfig,
 } from '../../types/types';
+import { toGridTemplateColumns } from '../../utils/gridTemplateColumns';
 
 function SortDirectionIcon({
   columnName,
@@ -180,7 +181,23 @@ function FilterableColumnHeader({
                   sx={{ padding: 0 }}
                 />
               </ListItemIcon>
-              <ListItemText primary={possibleValue.label} />
+              <ListItemText
+                primary={
+                  possibleValue.icon ? (
+                    <span
+                      style={{
+                        display: 'inline-flex',
+                        gap: '8px',
+                      }}
+                    >
+                      {possibleValue.label}
+                      {possibleValue.icon}
+                    </span>
+                  ) : (
+                    possibleValue.label
+                  )
+                }
+              />
             </MenuItem>
           );
         })}
@@ -283,9 +300,7 @@ function TableHeader({
     tableHeader: style({
       display: 'grid',
       // Should be kept in sync with the gridTemplateColumns from RevisionRow
-      gridTemplateColumns: columnsConfiguration
-        .map((config) => config.gridWidth)
-        .join(' '),
+      gridTemplateColumns: toGridTemplateColumns(columnsConfiguration),
       background:
         themeMode == 'light' ? Colors.Background100 : Colors.Background300Dark,
       borderRadius: '4px',

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -25,7 +25,7 @@ interface FilterableColumnMixin {
   // Always true for filterable columns.
   filter: true;
   // All values this column might have.
-  possibleValues: Array<{ label: string; key: string }>;
+  possibleValues: Array<{ label: string; key: string; icon?: React.ReactNode }>;
   // This function returns whether this result matches the value for this column.
   matchesFunction: (
     this: FilterableColumnMixin,
@@ -39,7 +39,7 @@ interface FilterableMannWhitneyColumnMixin {
   // Always true for filterable columns.
   filter: true;
   // All values this column might have.
-  possibleValues: Array<{ label: string; key: string }>;
+  possibleValues: Array<{ label: string; key: string; icon?: React.ReactNode }>;
   // This function returns whether this result matches the value for this column.
   matchesFunction: (
     this: FilterableMannWhitneyColumnMixin,
@@ -118,7 +118,7 @@ interface FilterableColumnGenericMixin<
   // Always true for filterable columns.
   filter: true;
   // All values this column might have.
-  possibleValues: Array<{ label: string; key: string }>;
+  possibleValues: Array<{ label: string; key: string; icon?: React.ReactNode }>;
   // Returns whether the given result row matches the selected filter value for
   // this column. "this" is typed so the function can access other column
   // properties (e.g. possibleValues) if needed.

--- a/src/utils/gridTemplateColumns.ts
+++ b/src/utils/gridTemplateColumns.ts
@@ -1,0 +1,11 @@
+// Builds a CSS grid-template-columns string from a columns config.
+// Uses minmax(0, Xfr) for fr tracks so that min-content of individual cells
+// (e.g. header button groups vs icon-only cells) cannot expand a track beyond
+// its fr allocation across separate grid instances.
+export function toGridTemplateColumns(config: { gridWidth: string }[]): string {
+  return config
+    .map(({ gridWidth }) =>
+      gridWidth.endsWith('fr') ? `minmax(0, ${gridWidth})` : gridWidth,
+    )
+    .join(' ');
+}

--- a/src/utils/rowTemplateColumns.ts
+++ b/src/utils/rowTemplateColumns.ts
@@ -12,3 +12,5 @@ export const getColumnsConfiguration = (
   isSubtestTable: boolean,
   testVersion: TestVersion,
 ): TableConfig => getColumnsForVersion(testVersion, isSubtestTable);
+
+export { toGridTemplateColumns } from './gridTemplateColumns';


### PR DESCRIPTION
Fix for [Bug 2026342.](https://bugzilla.mozilla.org/show_bug.cgi?id=2026342)
https://mozilla-hub.atlassian.net/browse/PCF-725 

In order to show the full name of the subtests for Mann-Whitney-U, the `Significance` column (now called `Sig`) was reduced in size, `Significant` text replaced with up arrow icon, `Not Significant` replaced with -,  and the col switched places with the CLES column for better reading. This change required changing the size of the other columns as shown in `src/common/testVersions/mannWhitney.tsx`. Also to make more space, reduced `Cliff's Delta` to `CD`.

Furthermore, I noticed the header width didn't match the width of the cells, so an extra util was added to make sure the min-content of the cells didn't expand a track beyond its fr allocation. This creates a cleaner more aligned table.

### Before: [Main Link](https://main--mozilla-perfcompare.netlify.app/subtests-compare-results?baseRev=ba78e2fc6ec552aede3949ea7106caad274e9501&baseRepo=try&newRev=d4ddbab3d47e8a2c65c672eb10e1f53826d5d38b&newRepo=try&framework=13&baseParentSignature=5296731&newParentSignature=5296731&test_version=mann-whitney-u&sort=significance%7Casc)

<img width="1386" height="854" alt="Screenshot 2026-04-03 at 10 25 09 AM" src="https://github.com/user-attachments/assets/0c8b590f-55f4-4326-b47e-b5b1a254a44e" />


### After:[ Deploy Link](https://deploy-preview-1023--mozilla-perfcompare.netlify.app/subtests-compare-results?baseRev=ba78e2fc6ec552aede3949ea7106caad274e9501&baseRepo=try&newRev=d4ddbab3d47e8a2c65c672eb10e1f53826d5d38b&newRepo=try&framework=13&baseParentSignature=5296731&newParentSignature=5296731&test_version=mann-whitney-u&sort=significance%7Casc)

<img width="1394" height="774" alt="Screenshot 2026-04-03 at 10 25 38 AM" src="https://github.com/user-attachments/assets/afc89b58-3526-4694-a12d-ca0b321e7290" />


Lastly, the tests were updated to reflect the name changes. 