### PR TITLE
Bug-1986319: Allow auto selection of full hash matches

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -333,6 +333,7 @@ exports[`Results Table Should match snapshot 1`] = `
                               id="search-base-input"
                               placeholder="Search by revision ID or author email"
                               type="text"
+                              value=""
                             />
                             <fieldset
                               aria-hidden="true"
@@ -618,6 +619,7 @@ exports[`Results Table Should match snapshot 1`] = `
                               id="search-new-input"
                               placeholder="Search by revision ID or author email"
                               type="text"
+                              value=""
                             />
                             <fieldset
                               aria-hidden="true"
@@ -3089,6 +3091,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                               id="search-base-input"
                               placeholder="Search by revision ID or author email"
                               type="text"
+                              value=""
                             />
                             <fieldset
                               aria-hidden="true"
@@ -3374,6 +3377,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                               id="search-new-input"
                               placeholder="Search by revision ID or author email"
                               type="text"
+                              value=""
                             />
                             <fieldset
                               aria-hidden="true"

--- a/src/__tests__/Search/SearchInputAndResults.test.tsx
+++ b/src/__tests__/Search/SearchInputAndResults.test.tsx
@@ -1,0 +1,126 @@
+import fetchMock from '@fetch-mock/jest';
+import userEvent from '@testing-library/user-event';
+
+import SearchInputAndResults from '../../components/Search/SearchInputAndResults';
+import getTestData from '../utils/fixtures';
+import { screen, render } from '../utils/test-utils';
+
+describe('SearchInputAndResults - Auto-select full hash', () => {
+  const mockOnToggle = jest.fn();
+  const { testData } = getTestData();
+  const fullHash = testData[7].revision;
+
+  beforeEach(() => {
+    mockOnToggle.mockClear();
+  });
+
+  it('should auto-select when pasting a full hash for base revision', async () => {
+    fetchMock.get(
+      `glob:https://treeherder.mozilla.org/api/project/try/push/*`,
+      { results: testData },
+    );
+
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    render(
+      <SearchInputAndResults
+        compact={false}
+        inputPlaceholder='Search base'
+        displayedRevisions={[]}
+        searchType='base'
+        repository='try'
+        onSearchResultsToggle={mockOnToggle}
+        listItemComponent='radio'
+      />,
+    );
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, fullHash);
+
+    // Assert auto-select happened
+    expect(mockOnToggle).toHaveBeenCalledWith(testData[7]);
+    expect(input).toHaveValue(''); // Input cleared
+  });
+
+  it('should auto-select when pasting a full hash for new revision (not already selected)', async () => {
+    fetchMock.get(
+      `glob:https://treeherder.mozilla.org/api/project/try/push/*`,
+      { results: testData },
+    );
+
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    render(
+      <SearchInputAndResults
+        compact={false}
+        inputPlaceholder='Search new'
+        displayedRevisions={[]} // Not selected yet
+        searchType='new'
+        repository='try'
+        onSearchResultsToggle={mockOnToggle}
+        listItemComponent='checkbox'
+      />,
+    );
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, fullHash);
+
+    expect(mockOnToggle).toHaveBeenCalledWith(testData[7]);
+    expect(input).toHaveValue('');
+  });
+
+  it('should not auto-select if full hash is already selected for new revision', async () => {
+    fetchMock.get(
+      `glob:https://treeherder.mozilla.org/api/project/try/push/*`,
+      { results: testData },
+    );
+
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    render(
+      <SearchInputAndResults
+        compact={false}
+        inputPlaceholder='Search new'
+        displayedRevisions={[testData[7]]} // Already selected
+        searchType='new'
+        repository='try'
+        onSearchResultsToggle={mockOnToggle}
+        listItemComponent='checkbox'
+      />,
+    );
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, fullHash);
+
+    expect(mockOnToggle).not.toHaveBeenCalled(); // No toggle
+    expect(input).toHaveValue(''); // Still cleared
+  });
+
+  it('should show dropdown for partial hash (no auto-select)', async () => {
+    fetchMock.get(
+      `glob:https://treeherder.mozilla.org/api/project/try/push/*`,
+      { results: testData },
+    );
+
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    render(
+      <SearchInputAndResults
+        compact={false}
+        inputPlaceholder='Search base'
+        displayedRevisions={[]}
+        searchType='base'
+        repository='try'
+        onSearchResultsToggle={mockOnToggle}
+        listItemComponent='radio'
+      />,
+    );
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, 'coconut'); // Partial hash
+
+    expect(mockOnToggle).not.toHaveBeenCalled();
+    // Dropdown should appear with results
+    await screen.findByText(/no arms left/); // From testData
+  });
+});

--- a/src/__tests__/Search/SearchInputAndResults.test.tsx
+++ b/src/__tests__/Search/SearchInputAndResults.test.tsx
@@ -5,10 +5,11 @@ import SearchInputAndResults from '../../components/Search/SearchInputAndResults
 import getTestData from '../utils/fixtures';
 import { screen, render } from '../utils/test-utils';
 
-describe('SearchInputAndResults - Auto-select full hash', () => {
+describe('SearchInputAndResults - Auto-select revision hash', () => {
   const mockOnToggle = jest.fn();
   const { testData } = getTestData();
   const fullHash = testData[7].revision;
+  const partialHash = fullHash.substring(0, 12);
 
   beforeEach(() => {
     mockOnToggle.mockClear();
@@ -42,7 +43,35 @@ describe('SearchInputAndResults - Auto-select full hash', () => {
     expect(input).toHaveValue(''); // Input cleared
   });
 
-  it('should auto-select when pasting a full hash for new revision (not already selected)', async () => {
+  it('should auto-select when pasting a partial hash (>= 7 chars) for base revision', async () => {
+    fetchMock.get(
+      `glob:https://treeherder.mozilla.org/api/project/try/push/*`,
+      { results: testData },
+    );
+
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    render(
+      <SearchInputAndResults
+        compact={false}
+        inputPlaceholder='Search base'
+        displayedRevisions={[]}
+        searchType='base'
+        repository='try'
+        onSearchResultsToggle={mockOnToggle}
+        listItemComponent='radio'
+      />,
+    );
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, partialHash);
+
+    // Assert auto-select happened
+    expect(mockOnToggle).toHaveBeenCalledWith(testData[7]);
+    expect(input).toHaveValue(''); // Input cleared
+  });
+
+  it('should auto-select when pasting a revision hash for new revision (not already selected)', async () => {
     fetchMock.get(
       `glob:https://treeherder.mozilla.org/api/project/try/push/*`,
       { results: testData },
@@ -69,7 +98,7 @@ describe('SearchInputAndResults - Auto-select full hash', () => {
     expect(input).toHaveValue('');
   });
 
-  it('should not auto-select if full hash is already selected for new revision', async () => {
+  it('should not auto-select if revision hash is already selected for new revision', async () => {
     fetchMock.get(
       `glob:https://treeherder.mozilla.org/api/project/try/push/*`,
       { results: testData },
@@ -96,7 +125,7 @@ describe('SearchInputAndResults - Auto-select full hash', () => {
     expect(input).toHaveValue(''); // Still cleared
   });
 
-  it('should show dropdown for partial hash (no auto-select)', async () => {
+  it('should show dropdown for non-hash search terms (no auto-select)', async () => {
     fetchMock.get(
       `glob:https://treeherder.mozilla.org/api/project/try/push/*`,
       { results: testData },
@@ -117,7 +146,7 @@ describe('SearchInputAndResults - Auto-select full hash', () => {
     );
 
     const input = screen.getByRole('textbox');
-    await user.type(input, 'coconut'); // Partial hash
+    await user.type(input, 'coconut'); // Not a hex hash
 
     expect(mockOnToggle).not.toHaveBeenCalled();
     // Dropdown should appear with results

--- a/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareOverTime.test.tsx.snap
@@ -273,6 +273,7 @@ exports[`Compare Over Time renders correctly in Search View: Initial state for t
                   id="search-new-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"
@@ -1167,6 +1168,7 @@ exports[`Compare Over Time should have an edit mode in Results View: After click
                   id="search-new-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"
@@ -1957,6 +1959,7 @@ exports[`Compare Over Time should remove the checked revision once X button is c
                   id="search-new-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"
@@ -2855,6 +2858,7 @@ exports[`Compare Over Time should update base repo, revisions and time-range aft
                   id="search-new-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"

--- a/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
@@ -141,6 +141,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
                   id="search-base-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"
@@ -446,6 +447,7 @@ exports[`Compare With Base renders correctly when there are no results: Initial 
                   id="search-new-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"
@@ -941,6 +943,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                   id="search-base-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"
@@ -1246,6 +1249,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                   id="search-new-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"
@@ -1455,6 +1459,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                   id="search-base-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"
@@ -1760,6 +1765,7 @@ exports[`Compare With Base should have an edit mode in Results View: After click
                   id="search-new-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"
@@ -2133,6 +2139,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
                   id="search-base-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"
@@ -2438,6 +2445,7 @@ exports[`Compare With Base should have an edit mode in Results View: Initial sta
                   id="search-new-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"
@@ -2815,6 +2823,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
                   id="search-base-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"
@@ -2960,6 +2969,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
                   id="search-new-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"
@@ -3369,6 +3379,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
                   id="search-base-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"
@@ -3674,6 +3685,7 @@ exports[`Compare With Base should have an edit mode in Results View: after remov
                   id="search-new-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"
@@ -4077,6 +4089,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                                 id="search-base-input"
                                 placeholder="Search by revision ID or author email"
                                 type="text"
+                                value=""
                               />
                               <fieldset
                                 aria-hidden="true"
@@ -4222,6 +4235,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                                 id="search-new-input"
                                 placeholder="Search by revision ID or author email"
                                 type="text"
+                                value=""
                               />
                               <fieldset
                                 aria-hidden="true"
@@ -4646,6 +4660,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                                 id="search-new-input"
                                 placeholder="Search by revision ID or author email"
                                 type="text"
+                                value=""
                               />
                               <fieldset
                                 aria-hidden="true"

--- a/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
@@ -4788,7 +4788,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
 exports[`Compare With Base updates the framework and url when a new one is selected: after awsy is selected 1`] = `
 <ul
   class="MuiList-root MuiList-padding MuiMenu-list css-1toxriw-MuiList-root-MuiMenu-list"
-  id="_r_5n_"
+  id="_r_5o_"
   role="listbox"
   tabindex="-1"
 >

--- a/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
@@ -4788,7 +4788,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
 exports[`Compare With Base updates the framework and url when a new one is selected: after awsy is selected 1`] = `
 <ul
   class="MuiList-root MuiList-padding MuiMenu-list css-1toxriw-MuiList-root-MuiMenu-list"
-  id="_r_5o_"
+  id="_r_5p_"
   role="listbox"
   tabindex="-1"
 >

--- a/src/__tests__/Search/__snapshots__/SearchContainer.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchContainer.test.tsx.snap
@@ -162,6 +162,7 @@ exports[`Search Containter should match snapshot 1`] = `
                               id="search-base-input"
                               placeholder="Search by revision ID or author email"
                               type="text"
+                              value=""
                             />
                             <fieldset
                               aria-hidden="true"
@@ -307,6 +308,7 @@ exports[`Search Containter should match snapshot 1`] = `
                               id="search-new-input"
                               placeholder="Search by revision ID or author email"
                               type="text"
+                              value=""
                             />
                             <fieldset
                               aria-hidden="true"
@@ -731,6 +733,7 @@ exports[`Search Containter should match snapshot 1`] = `
                               id="search-new-input"
                               placeholder="Search by revision ID or author email"
                               type="text"
+                              value=""
                             />
                             <fieldset
                               aria-hidden="true"

--- a/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
@@ -1126,6 +1126,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                 id="search-base-input"
                                 placeholder="Search by revision ID or author email"
                                 type="text"
+                                value=""
                               />
                               <fieldset
                                 aria-hidden="true"
@@ -2065,6 +2066,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                 id="search-new-input"
                                 placeholder="Search by revision ID or author email"
                                 type="text"
+                                value=""
                               />
                               <fieldset
                                 aria-hidden="true"
@@ -2489,6 +2491,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                 id="search-new-input"
                                 placeholder="Search by revision ID or author email"
                                 type="text"
+                                value=""
                               />
                               <fieldset
                                 aria-hidden="true"

--- a/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
@@ -793,6 +793,118 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
         </div>
       </li>
     </div>
+    <div
+      class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters fl1awgk css-1pl5w90-MuiButtonBase-root-MuiListItemButton-root"
+      role="button"
+      tabindex="0"
+    >
+      <li
+        class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-19f6boz-MuiListItem-root"
+      >
+        <div
+          class="MuiListItemIcon-root search-revision-item-icon search-revision css-cokf1l-MuiListItemIcon-root"
+        >
+          <span
+            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-edgeStart MuiRadio-root MuiRadio-colorPrimary search-revision-item-checkbox css-1y6o4l4-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+            data-testid="checkbox-7"
+          >
+            <input
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
+              tabindex="-1"
+              type="radio"
+            />
+            <span
+              class="css-9oxshb-MuiRadioButtonIcon-root"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-kemhjw-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                data-testid="RadioButtonUncheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-993gxc-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                data-testid="RadioButtonCheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+        <div
+          class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+        >
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 revision-hash css-10r6x9a-MuiTypography-root"
+            >
+              d670460b4b4a
+            </span>
+            <div
+              class="info-caption"
+            >
+              <div
+                class="info-caption-item item-author"
+              >
+                 
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-54rgmy-MuiSvgIcon-root"
+                  data-testid="MailOutlineOutlinedIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2m0 14H4V8l8 5 8-5zm-8-7L4 6h16z"
+                  />
+                </svg>
+                 
+                johncleese@python.com
+              </div>
+              <div
+                class="info-caption-item item-time"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall time-icon css-54rgmy-MuiSvgIcon-root"
+                  data-testid="AccessTimeOutlinedIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2M12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8m.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"
+                  />
+                </svg>
+                <div
+                  aria-label="Jul 22, 51, 17:46 UTC"
+                  class=""
+                  data-mui-internal-clone-element="true"
+                >
+                  Jul 22, 51, 17:46 UTC
+                </div>
+              </div>
+            </div>
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-1us1al8-MuiTypography-root"
+          >
+            Full 40 char hash created with echo 'test content' | git hash-object --stdin 
+          </span>
+        </div>
+      </li>
+    </div>
   </ul>
 </div>
 `;
@@ -1934,6 +2046,118 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                     class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-1us1al8-MuiTypography-root"
                                   >
                                     Commit message with no newline at the end 
+                                  </span>
+                                </div>
+                              </li>
+                            </div>
+                            <div
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters fl1awgk css-1pl5w90-MuiButtonBase-root-MuiListItemButton-root"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <li
+                                class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-19f6boz-MuiListItem-root"
+                              >
+                                <div
+                                  class="MuiListItemIcon-root search-revision-item-icon search-revision css-cokf1l-MuiListItemIcon-root"
+                                >
+                                  <span
+                                    class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-edgeStart MuiRadio-root MuiRadio-colorPrimary search-revision-item-checkbox css-1y6o4l4-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+                                    data-testid="checkbox-7"
+                                  >
+                                    <input
+                                      class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
+                                      tabindex="-1"
+                                      type="radio"
+                                    />
+                                    <span
+                                      class="css-9oxshb-MuiRadioButtonIcon-root"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-kemhjw-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                                        data-testid="RadioButtonUncheckedIcon"
+                                        focusable="false"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <path
+                                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                                        />
+                                      </svg>
+                                      <svg
+                                        aria-hidden="true"
+                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-993gxc-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                                        data-testid="RadioButtonCheckedIcon"
+                                        focusable="false"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <path
+                                          d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                </div>
+                                <div
+                                  class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                                >
+                                  <span
+                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
+                                  >
+                                    <span
+                                      class="MuiTypography-root MuiTypography-body2 revision-hash css-10r6x9a-MuiTypography-root"
+                                    >
+                                      d670460b4b4a
+                                    </span>
+                                    <div
+                                      class="info-caption"
+                                    >
+                                      <div
+                                        class="info-caption-item item-author"
+                                      >
+                                         
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-54rgmy-MuiSvgIcon-root"
+                                          data-testid="MailOutlineOutlinedIcon"
+                                          focusable="false"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <path
+                                            d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2m0 14H4V8l8 5 8-5zm-8-7L4 6h16z"
+                                          />
+                                        </svg>
+                                         
+                                        johncleese@python.com
+                                      </div>
+                                      <div
+                                        class="info-caption-item item-time"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall time-icon css-54rgmy-MuiSvgIcon-root"
+                                          data-testid="AccessTimeOutlinedIcon"
+                                          focusable="false"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <path
+                                            d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2M12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8m.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"
+                                          />
+                                        </svg>
+                                        <div
+                                          aria-label="Jul 22, 51, 17:46 UTC"
+                                          class=""
+                                          data-mui-internal-clone-element="true"
+                                        >
+                                          Jul 22, 51, 17:46 UTC
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </span>
+                                  <span
+                                    class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-1us1al8-MuiTypography-root"
+                                  >
+                                    Full 40 char hash created with echo 'test content' | git hash-object --stdin 
                                   </span>
                                 </div>
                               </li>

--- a/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
@@ -842,7 +842,7 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
           </span>
         </div>
         <div
-          class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+          class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
         >
           <span
             class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -900,7 +900,119 @@ exports[`SearchResultsList Should apply dark and light mode styles when theme bu
           <span
             class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-1us1al8-MuiTypography-root"
           >
-            Full 40 char hash created with echo 'test content' | git hash-object --stdin 
+            Full 40 char hash for auto-selection testing (supports complete or partial match) 
+          </span>
+        </div>
+      </li>
+    </div>
+    <div
+      class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters fl1awgk css-1pl5w90-MuiButtonBase-root-MuiListItemButton-root"
+      role="button"
+      tabindex="0"
+    >
+      <li
+        class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-19f6boz-MuiListItem-root"
+      >
+        <div
+          class="MuiListItemIcon-root search-revision-item-icon search-revision css-cokf1l-MuiListItemIcon-root"
+        >
+          <span
+            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-edgeStart MuiRadio-root MuiRadio-colorPrimary search-revision-item-checkbox css-1y6o4l4-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+            data-testid="checkbox-8"
+          >
+            <input
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
+              tabindex="-1"
+              type="radio"
+            />
+            <span
+              class="css-9oxshb-MuiRadioButtonIcon-root"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-kemhjw-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                data-testid="RadioButtonUncheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-993gxc-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                data-testid="RadioButtonCheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                />
+              </svg>
+            </span>
+          </span>
+        </div>
+        <div
+          class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
+        >
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 revision-hash css-10r6x9a-MuiTypography-root"
+            >
+              ABCDEF012345
+            </span>
+            <div
+              class="info-caption"
+            >
+              <div
+                class="info-caption-item item-author"
+              >
+                 
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-54rgmy-MuiSvgIcon-root"
+                  data-testid="MailOutlineOutlinedIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2m0 14H4V8l8 5 8-5zm-8-7L4 6h16z"
+                  />
+                </svg>
+                 
+                tester@mozilla.com
+              </div>
+              <div
+                class="info-caption-item item-time"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall time-icon css-54rgmy-MuiSvgIcon-root"
+                  data-testid="AccessTimeOutlinedIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2M12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8m.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"
+                  />
+                </svg>
+                <div
+                  aria-label="Apr 13, 22, 00:16 UTC"
+                  class=""
+                  data-mui-internal-clone-element="true"
+                >
+                  Apr 13, 22, 00:16 UTC
+                </div>
+              </div>
+            </div>
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-1us1al8-MuiTypography-root"
+          >
+            Mixed case hash for auto-selection testing (supports complete or partial match) 
           </span>
         </div>
       </li>
@@ -2099,7 +2211,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                   </span>
                                 </div>
                                 <div
-                                  class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-11r84w7-MuiListItemText-root"
+                                  class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
                                 >
                                   <span
                                     class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
@@ -2157,7 +2269,119 @@ exports[`SearchResultsList should match snapshot 1`] = `
                                   <span
                                     class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-1us1al8-MuiTypography-root"
                                   >
-                                    Full 40 char hash created with echo 'test content' | git hash-object --stdin 
+                                    Full 40 char hash for auto-selection testing (supports complete or partial match) 
+                                  </span>
+                                </div>
+                              </li>
+                            </div>
+                            <div
+                              class="MuiButtonBase-root MuiListItemButton-root MuiListItemButton-gutters MuiListItemButton-root MuiListItemButton-gutters fl1awgk css-1pl5w90-MuiButtonBase-root-MuiListItemButton-root"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <li
+                                class="MuiListItem-root MuiListItem-gutters search-revision-item search-revision css-19f6boz-MuiListItem-root"
+                              >
+                                <div
+                                  class="MuiListItemIcon-root search-revision-item-icon search-revision css-cokf1l-MuiListItemIcon-root"
+                                >
+                                  <span
+                                    class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-edgeStart MuiRadio-root MuiRadio-colorPrimary search-revision-item-checkbox css-1y6o4l4-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+                                    data-testid="checkbox-8"
+                                  >
+                                    <input
+                                      class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
+                                      tabindex="-1"
+                                      type="radio"
+                                    />
+                                    <span
+                                      class="css-9oxshb-MuiRadioButtonIcon-root"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-kemhjw-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                                        data-testid="RadioButtonUncheckedIcon"
+                                        focusable="false"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <path
+                                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                                        />
+                                      </svg>
+                                      <svg
+                                        aria-hidden="true"
+                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-993gxc-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                                        data-testid="RadioButtonCheckedIcon"
+                                        focusable="false"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <path
+                                          d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                </div>
+                                <div
+                                  class="MuiListItemText-root MuiListItemText-multiline search-revision-item-text css-14ln1j6-MuiListItemText-root"
+                                >
+                                  <span
+                                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap MuiListItemText-primary css-ym6a33-MuiTypography-root"
+                                  >
+                                    <span
+                                      class="MuiTypography-root MuiTypography-body2 revision-hash css-10r6x9a-MuiTypography-root"
+                                    >
+                                      ABCDEF012345
+                                    </span>
+                                    <div
+                                      class="info-caption"
+                                    >
+                                      <div
+                                        class="info-caption-item item-author"
+                                      >
+                                         
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mail-icon css-54rgmy-MuiSvgIcon-root"
+                                          data-testid="MailOutlineOutlinedIcon"
+                                          focusable="false"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <path
+                                            d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2m0 14H4V8l8 5 8-5zm-8-7L4 6h16z"
+                                          />
+                                        </svg>
+                                         
+                                        tester@mozilla.com
+                                      </div>
+                                      <div
+                                        class="info-caption-item item-time"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall time-icon css-54rgmy-MuiSvgIcon-root"
+                                          data-testid="AccessTimeOutlinedIcon"
+                                          focusable="false"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <path
+                                            d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2M12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8m.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"
+                                          />
+                                        </svg>
+                                        <div
+                                          aria-label="Apr 13, 22, 00:16 UTC"
+                                          class=""
+                                          data-mui-internal-clone-element="true"
+                                        >
+                                          Apr 13, 22, 00:16 UTC
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </span>
+                                  <span
+                                    class="MuiTypography-root MuiTypography-body2 MuiTypography-noWrap MuiListItemText-secondary css-1us1al8-MuiTypography-root"
+                                  >
+                                    Mixed case hash for auto-selection testing (supports complete or partial match) 
                                   </span>
                                 </div>
                               </li>

--- a/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
@@ -329,6 +329,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                                 id="search-base-input"
                                 placeholder="Search by revision ID or author email"
                                 type="text"
+                                value=""
                               />
                               <fieldset
                                 aria-hidden="true"
@@ -474,6 +475,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                                 id="search-new-input"
                                 placeholder="Search by revision ID or author email"
                                 type="text"
+                                value=""
                               />
                               <fieldset
                                 aria-hidden="true"
@@ -898,6 +900,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                                 id="search-new-input"
                                 placeholder="Search by revision ID or author email"
                                 type="text"
+                                value=""
                               />
                               <fieldset
                                 aria-hidden="true"
@@ -1295,6 +1298,7 @@ exports[`With search parameters both search components are populated as expected
                   id="search-new-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"
@@ -1670,6 +1674,7 @@ exports[`With search parameters both search components are populated as expected
                   id="search-base-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"
@@ -1815,6 +1820,7 @@ exports[`With search parameters both search components are populated as expected
                   id="search-new-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"
@@ -2346,6 +2352,7 @@ exports[`With search parameters both search components are populated as expected
                   id="search-new-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"
@@ -2721,6 +2728,7 @@ exports[`With search parameters both search components are populated as expected
                   id="search-base-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"
@@ -2866,6 +2874,7 @@ exports[`With search parameters both search components are populated as expected
                   id="search-new-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"
@@ -3397,6 +3406,7 @@ exports[`With search parameters displays the default value for framework if the 
                   id="search-new-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"
@@ -3772,6 +3782,7 @@ exports[`With search parameters displays the default value for framework if the 
                   id="search-base-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"
@@ -3917,6 +3928,7 @@ exports[`With search parameters displays the default value for framework if the 
                   id="search-new-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"
@@ -4448,6 +4460,7 @@ exports[`With search parameters displays the default values if some values are b
                   id="search-new-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"
@@ -4683,6 +4696,7 @@ exports[`With search parameters displays the default values if some values are b
                   id="search-base-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"
@@ -4828,6 +4842,7 @@ exports[`With search parameters displays the default values if some values are b
                   id="search-new-input"
                   placeholder="Search by revision ID or author email"
                   type="text"
+                  value=""
                 />
                 <fieldset
                   aria-hidden="true"

--- a/src/__tests__/utils/fixtures.ts
+++ b/src/__tests__/utils/fixtures.ts
@@ -147,6 +147,24 @@ const getTestData = () => {
       push_timestamp: 1649808000,
       repository_id: 77,
     },
+    {
+      id: 8,
+      revision: 'd670460b4b4aece5915caf5c68d12f560a9fe3e4',
+      author: 'johncleese@python.com',
+      revisions: [
+        {
+          result_set_id: 0,
+          repository_id: 4,
+          revision: 'd670460b4b4aece5915caf5c68d12f560a9fe3e4',
+          author: 'johncleese@python.com',
+          comments:
+            "Full 40 char hash created with echo 'test content' | git hash-object --stdin\n",
+        },
+      ],
+      revision_count: 1,
+      push_timestamp: -582099200,
+      repository_id: 4,
+    },
   ];
 
   const testCompareData: CompareResultsItem[] = [

--- a/src/__tests__/utils/fixtures.ts
+++ b/src/__tests__/utils/fixtures.ts
@@ -158,7 +158,7 @@ const getTestData = () => {
           revision: 'd670460b4b4aece5915caf5c68d12f560a9fe3e4',
           author: 'johncleese@python.com',
           comments:
-            "Full 40 char hash created with echo 'test content' | git hash-object --stdin\n",
+            'Full 40 char hash for auto-selection testing (supports complete or partial match)\n',
         },
       ],
       revision_count: 1,

--- a/src/components/Search/SearchInput.tsx
+++ b/src/components/Search/SearchInput.tsx
@@ -9,6 +9,7 @@ import { InputStylesRaw } from '../../styles';
 import { InputType } from '../../types/state';
 
 interface SearchInputProps {
+  value?: string;
   onFocus: () => unknown;
   inputPlaceholder: string;
   compact: boolean;
@@ -18,6 +19,7 @@ interface SearchInputProps {
 }
 
 function SearchInput({
+  value,
   onFocus,
   compact,
   inputPlaceholder,
@@ -48,6 +50,7 @@ function SearchInput({
   return (
     <FormControl className={styles.container} fullWidth>
       <TextField
+        value={value}
         error={Boolean(searchError)}
         helperText={searchError}
         placeholder={inputPlaceholder}

--- a/src/components/Search/SearchInputAndResults.tsx
+++ b/src/components/Search/SearchInputAndResults.tsx
@@ -34,6 +34,8 @@ export default function SearchInputAndResults({
   );
   const [searchError, setSearchError] = useState(null as null | string);
 
+  const [inputValue, setInputValue] = useState('');
+
   // The last used searchTerm is kept in a ref, so that it's possible to use it
   // in an effect when the repository prop changes. It's not stored in a state
   // because it's not used for rendering DOM.
@@ -66,8 +68,15 @@ export default function SearchInputAndResults({
     }
   }, []);
 
+  // Helper to check if the search term matches a full 40 character revision hash
+  const isFullRevisionHash = (searchTerm: string) =>
+    /^[a-f0-9]{40}$/i.test(searchTerm.trim());
+
   const searchRecentRevisions = useCallback(
-    async (searchTerm: string) => {
+    async (
+      searchTerm: string,
+      { autoSelect }: { autoSelect: boolean } = { autoSelect: false },
+    ) => {
       // If the URL has a parameter useFulltextSearch, use it to determine the search type.
       const urlParams = new URLSearchParams(window.location.search);
       const useFulltextSearch = urlParams.has('useFulltextSearch');
@@ -116,6 +125,29 @@ export default function SearchInputAndResults({
 
       try {
         const results = await fetchRecentRevisions(searchParameters);
+
+        if (autoSelect && isFullRevisionHash(searchTerm)) {
+          const completeHashMatch = results.find(
+            (rev) => rev.revision.toLowerCase() === searchTerm.toLowerCase(),
+          );
+          if (completeHashMatch) {
+            if (searchType === 'new') {
+              const alreadySelected = displayedRevisions.some(
+                (rev) => rev.id === completeHashMatch.id,
+              );
+              if (alreadySelected) {
+                setDisplayDropdown(false);
+                setInputValue('');
+                return;
+              }
+            }
+            setDisplayDropdown(false);
+            setInputValue('');
+            onSearchResultsToggle(completeHashMatch);
+            return;
+          }
+        }
+
         if (thisRequestId !== requestsCounterRef.current) return;
         // The user edited the text since the request started.
         // Let's ignore the result then.
@@ -137,7 +169,7 @@ export default function SearchInputAndResults({
         setRecentRevisions(null);
       }
     },
-    [repository],
+    [repository, onSearchResultsToggle, searchType, displayedRevisions],
   );
 
   const debouncedSearchRecentRevisions = useCallback(
@@ -147,9 +179,14 @@ export default function SearchInputAndResults({
 
   const onValueChange = (searchTerm: string) => {
     // Reset various states
+    setInputValue(searchTerm);
     setSearchError(null);
     setRecentRevisions(null);
-    debouncedSearchRecentRevisions(searchTerm);
+    if (isFullRevisionHash(searchTerm)) {
+      void searchRecentRevisions(searchTerm, { autoSelect: true });
+    } else {
+      debouncedSearchRecentRevisions(searchTerm);
+    }
   };
 
   // At load time and everytime the repository information changes, the recent
@@ -176,12 +213,13 @@ export default function SearchInputAndResults({
   return (
     <Box ref={containerRef}>
       <SearchInput
+        value={inputValue}
         onFocus={() => setDisplayDropdown(true)}
         compact={compact}
         inputPlaceholder={inputPlaceholder}
         searchType={searchType}
         searchError={searchError}
-        onChange={onValueChange}
+        onChange={(value) => onValueChange(value)}
       />
 
       {recentRevisions && displayDropdown && (

--- a/src/components/Search/SearchInputAndResults.tsx
+++ b/src/components/Search/SearchInputAndResults.tsx
@@ -68,9 +68,9 @@ export default function SearchInputAndResults({
     }
   }, []);
 
-  // Helper to check if the search term matches a full 40 character revision hash
-  const isFullRevisionHash = (searchTerm: string) =>
-    /^[a-f0-9]{40}$/i.test(searchTerm.trim());
+  // Helper to check if the search term matches a revision hash (full or short)
+  const isRevisionHash = (searchTerm: string) =>
+    /^[a-f0-9]{7,40}$/i.test(searchTerm.trim());
 
   const searchRecentRevisions = useCallback(
     async (
@@ -126,24 +126,20 @@ export default function SearchInputAndResults({
       try {
         const results = await fetchRecentRevisions(searchParameters);
 
-        if (autoSelect && isFullRevisionHash(searchTerm)) {
-          const completeHashMatch = results.find(
-            (rev) => rev.revision.toLowerCase() === searchTerm.toLowerCase(),
+        if (autoSelect && isRevisionHash(searchTerm)) {
+          const revisionMatch = results.find((rev) =>
+            rev.revision.toLowerCase().startsWith(searchTerm.toLowerCase()),
           );
-          if (completeHashMatch) {
+          if (revisionMatch) {
             if (searchType === 'new') {
               const alreadySelected = displayedRevisions.some(
-                (rev) => rev.id === completeHashMatch.id,
+                (rev) => rev.id === revisionMatch.id,
               );
               if (alreadySelected) {
-                setDisplayDropdown(false);
-                setInputValue('');
                 return;
               }
             }
-            setDisplayDropdown(false);
-            setInputValue('');
-            onSearchResultsToggle(completeHashMatch);
+            onSearchResultsToggle(revisionMatch);
             return;
           }
         }
@@ -182,7 +178,7 @@ export default function SearchInputAndResults({
     setInputValue(searchTerm);
     setSearchError(null);
     setRecentRevisions(null);
-    if (isFullRevisionHash(searchTerm)) {
+    if (isRevisionHash(searchTerm)) {
       void searchRecentRevisions(searchTerm, { autoSelect: true });
     } else {
       debouncedSearchRecentRevisions(searchTerm);
@@ -214,7 +210,12 @@ export default function SearchInputAndResults({
     <Box ref={containerRef}>
       <SearchInput
         value={inputValue}
-        onFocus={() => setDisplayDropdown(true)}
+        onFocus={() => {
+          setDisplayDropdown(true);
+          if (!inputValue) {
+            void searchRecentRevisions('');
+          }
+        }}
         compact={compact}
         inputPlaceholder={inputPlaceholder}
         searchType={searchType}


### PR DESCRIPTION
Updated `SearchInputAndResults` to:
* Track input value as state
* Check if the input is a hash and if it matches an existing hash
* Auto select the hash if it matches the full hash

@kala-moz @beatrice-acasandrei 

Fixes [Bug-1986319](https://bugzilla.mozilla.org/show_bug.cgi?id=1986319)
