### PR TITLE
Added the optional param enable_silverman_kde to loaders and treeherder logic

### DIFF
--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -75,6 +75,7 @@ export default function ResultsTable() {
     searchParams.set('test_version', testVersion);
     if (testVersion !== MANN_WHITNEY_U) {
       searchParams.delete('replicates');
+      searchParams.delete('enable_silverman_kde');
     }
     setSearchParams(searchParams);
   };

--- a/src/components/CompareResults/hashToCommitLoader.ts
+++ b/src/components/CompareResults/hashToCommitLoader.ts
@@ -67,6 +67,9 @@ export async function loader({ request }: { request: Request }) {
   const baseRevsFromHash = commits_from_hashes.baseRevision;
   const newRevsFromHash = [commits_from_hashes.newRevision];
   const replicatesFromUrl = url.searchParams.has('replicates');
+  const enableSilvermanKDEFromUrl = url.searchParams.has(
+    'enable_silverman_kde',
+  );
   const {
     baseRev,
     baseRepo,
@@ -76,6 +79,7 @@ export async function loader({ request }: { request: Request }) {
     frameworkName,
     replicates,
     testVersion,
+    silvermanKDEEnabled,
   } = checkValues({
     baseRev: baseRevsFromHash,
     baseRepo: baseRepoFromUrl,
@@ -84,6 +88,7 @@ export async function loader({ request }: { request: Request }) {
     framework: frameworkFromUrl,
     replicates: replicatesFromUrl,
     testVersion: testVersionFromUrl,
+    silvermanKDEEnabled: enableSilvermanKDEFromUrl,
   });
   return await getComparisonInformation(
     baseRev,
@@ -94,6 +99,7 @@ export async function loader({ request }: { request: Request }) {
     frameworkName,
     replicates,
     testVersion,
+    silvermanKDEEnabled,
   );
 }
 
@@ -110,6 +116,7 @@ type HashLoaderData = {
   view: typeof compareView;
   generation: number;
   testVersion: TestVersion;
+  silvermanKDEEnabled: boolean;
 };
 
 export type HashLoaderReturnValue = HashLoaderData;

--- a/src/components/CompareResults/hashToCommitLoader.ts
+++ b/src/components/CompareResults/hashToCommitLoader.ts
@@ -98,8 +98,8 @@ export async function loader({ request }: { request: Request }) {
     frameworkId,
     frameworkName,
     replicates,
-    testVersion,
     silvermanKDEEnabled,
+    testVersion,
   );
 }
 

--- a/src/components/CompareResults/landoToCommitLoader.ts
+++ b/src/components/CompareResults/landoToCommitLoader.ts
@@ -69,8 +69,8 @@ export async function loader({ request }: { request: Request }) {
     frameworkId,
     frameworkName,
     replicates,
-    testVersion,
     silvermanKDEEnabled,
+    testVersion,
   );
 }
 

--- a/src/components/CompareResults/landoToCommitLoader.ts
+++ b/src/components/CompareResults/landoToCommitLoader.ts
@@ -30,6 +30,9 @@ export async function loader({ request }: { request: Request }) {
     );
   }
   const replicatesFromUrl = url.searchParams.has('replicates');
+  const enableSilvermanKDEFromUrl = url.searchParams.has(
+    'enable_silverman_kde',
+  );
 
   const baseRevisionsFromLando =
     await fetchRevisionFromLandoId(baseLandoIDFromUrl);
@@ -47,6 +50,7 @@ export async function loader({ request }: { request: Request }) {
     frameworkName,
     replicates,
     testVersion,
+    silvermanKDEEnabled,
   } = checkValues({
     baseRev: baseRevisionsFromLando.commit_id,
     baseRepo: baseRepoFromUrl,
@@ -55,6 +59,7 @@ export async function loader({ request }: { request: Request }) {
     framework: frameworkFromUrl,
     replicates: replicatesFromUrl,
     testVersion: testVersionFromUrl,
+    silvermanKDEEnabled: enableSilvermanKDEFromUrl,
   });
   return await getComparisonInformation(
     baseRev,
@@ -65,6 +70,7 @@ export async function loader({ request }: { request: Request }) {
     frameworkName,
     replicates,
     testVersion,
+    silvermanKDEEnabled,
   );
 }
 
@@ -81,6 +87,7 @@ type LandoLoaderData = {
   view: typeof compareView;
   generation: number;
   testVersion: TestVersion;
+  silvermanKDEEnabled: boolean;
 };
 
 export type LandoLoaderReturnValue = LandoLoaderData;

--- a/src/components/CompareResults/loader.ts
+++ b/src/components/CompareResults/loader.ts
@@ -26,6 +26,7 @@ export function checkValues({
   framework,
   replicates,
   testVersion,
+  silvermanKDEEnabled,
 }: {
   baseRev: string | null;
   baseRepo: Repository['name'] | null;
@@ -34,6 +35,7 @@ export function checkValues({
   framework: string | number | null;
   replicates: boolean;
   testVersion: TestVersion | null;
+  silvermanKDEEnabled: boolean;
 }): {
   baseRev: string;
   baseRepo: Repository['name'];
@@ -43,6 +45,7 @@ export function checkValues({
   frameworkName: Framework['name'];
   replicates: boolean;
   testVersion: TestVersion;
+  silvermanKDEEnabled: boolean;
 } {
   if (baseRev === null) {
     throw new Error('The parameter baseRev is missing.');
@@ -83,6 +86,7 @@ export function checkValues({
 
   if (testVersion === MANN_WHITNEY_U || testVersion === null) {
     replicates = true;
+    silvermanKDEEnabled = true;
   }
 
   if (testVersion === null) {
@@ -99,6 +103,7 @@ export function checkValues({
       frameworkName,
       replicates,
       testVersion,
+      silvermanKDEEnabled,
     };
   }
 
@@ -124,6 +129,7 @@ export function checkValues({
     frameworkName,
     replicates,
     testVersion,
+    silvermanKDEEnabled,
   };
 }
 
@@ -137,6 +143,7 @@ async function fetchCompareResultsOnTreeherder({
   framework,
   replicates,
   testVersion,
+  silvermanKDEEnabled,
 }: {
   baseRev: string;
   baseRepo: Repository['name'];
@@ -145,6 +152,7 @@ async function fetchCompareResultsOnTreeherder({
   framework: Framework['id'];
   replicates: boolean;
   testVersion?: TestVersion;
+  silvermanKDEEnabled: boolean;
 }) {
   const promises = newRevs.map((newRev, i) =>
     fetchCompareResults({
@@ -155,6 +163,7 @@ async function fetchCompareResultsOnTreeherder({
       framework,
       replicates,
       testVersion,
+      silvermanKDEEnabled,
     }),
   );
   return Promise.all(promises);
@@ -226,6 +235,9 @@ export async function loader({ request }: { request: Request }) {
   const testVersionFromUrl = url.searchParams.get(
     'test_version',
   ) as TestVersion;
+  const enableSilvermanKDEFromUrl = url.searchParams.has(
+    'enable_silverman_kde',
+  );
 
   const {
     baseRev,
@@ -236,6 +248,7 @@ export async function loader({ request }: { request: Request }) {
     frameworkName,
     replicates,
     testVersion,
+    silvermanKDEEnabled,
   } = checkValues({
     baseRev: baseRevFromUrl,
     baseRepo: baseRepoFromUrl,
@@ -244,6 +257,7 @@ export async function loader({ request }: { request: Request }) {
     framework: frameworkFromUrl,
     replicates: replicatesFromUrl,
     testVersion: testVersionFromUrl,
+    silvermanKDEEnabled: enableSilvermanKDEFromUrl,
   });
 
   return await getComparisonInformation(
@@ -254,6 +268,7 @@ export async function loader({ request }: { request: Request }) {
     frameworkId,
     frameworkName,
     replicates,
+    silvermanKDEEnabled,
     testVersion,
   );
 }
@@ -266,6 +281,7 @@ export async function getComparisonInformation(
   frameworkId: Framework['id'],
   frameworkName: Framework['name'],
   replicates: boolean,
+  silvermanKDEEnabled: boolean,
   testVersion?: TestVersion,
 ) {
   const resultsPromise = fetchCompareResultsOnTreeherder({
@@ -276,6 +292,7 @@ export async function getComparisonInformation(
     framework: frameworkId,
     replicates,
     testVersion,
+    silvermanKDEEnabled,
   });
 
   // TODO what happens if there's no result?
@@ -309,6 +326,7 @@ export async function getComparisonInformation(
     generation: generationCounter++,
     replicates,
     testVersion,
+    silvermanKDEEnabled,
   };
 }
 
@@ -326,6 +344,7 @@ type DeferredLoaderData = {
   generation: number;
   replicates: boolean;
   testVersion: TestVersion;
+  silvermanKDEEnabled: boolean;
 };
 
 // Be explicit with the returned type to control it better than if we were

--- a/src/components/CompareResults/loader.ts
+++ b/src/components/CompareResults/loader.ts
@@ -86,7 +86,6 @@ export function checkValues({
 
   if (testVersion === MANN_WHITNEY_U || testVersion === null) {
     replicates = true;
-    silvermanKDEEnabled = true;
   }
 
   if (testVersion === null) {

--- a/src/components/CompareResults/overTimeLoader.ts
+++ b/src/components/CompareResults/overTimeLoader.ts
@@ -111,7 +111,6 @@ function checkValues({
 
   if (testVersion === MANN_WHITNEY_U || testVersion === null) {
     replicates = true;
-    silvermanKDEEnabled = true;
   }
 
   if (!testVersion) {

--- a/src/components/CompareResults/overTimeLoader.ts
+++ b/src/components/CompareResults/overTimeLoader.ts
@@ -26,6 +26,7 @@ function checkValues({
   interval,
   replicates,
   testVersion,
+  silvermanKDEEnabled,
 }: {
   baseRepo: Repository['name'] | null;
   newRevs: string[];
@@ -34,6 +35,7 @@ function checkValues({
   interval: string | number | null;
   replicates: boolean;
   testVersion?: TestVersion | null;
+  silvermanKDEEnabled: boolean;
 }): {
   baseRepo: Repository['name'];
   newRevs: string[];
@@ -44,6 +46,7 @@ function checkValues({
   intervalText: TimeRange['text'];
   replicates: boolean;
   testVersion: TestVersion;
+  silvermanKDEEnabled: boolean;
 } {
   if (baseRepo === null) {
     throw new Error('The parameter baseRepo is missing.');
@@ -108,6 +111,7 @@ function checkValues({
 
   if (testVersion === MANN_WHITNEY_U || testVersion === null) {
     replicates = true;
+    silvermanKDEEnabled = true;
   }
 
   if (!testVersion) {
@@ -124,6 +128,7 @@ function checkValues({
     intervalValue,
     replicates,
     testVersion,
+    silvermanKDEEnabled,
   };
 }
 
@@ -137,6 +142,7 @@ async function fetchCompareOverTimeResultsOnTreeherder({
   interval,
   replicates,
   testVersion,
+  silvermanKDEEnabled,
 }: {
   baseRepo: Repository['name'];
   newRevs: string[];
@@ -145,6 +151,7 @@ async function fetchCompareOverTimeResultsOnTreeherder({
   interval: TimeRange['value'];
   replicates: boolean;
   testVersion: TestVersion;
+  silvermanKDEEnabled: boolean;
 }) {
   const promises = newRevs.map((newRev, i) =>
     fetchCompareOverTimeResults({
@@ -155,6 +162,7 @@ async function fetchCompareOverTimeResultsOnTreeherder({
       interval,
       replicates,
       testVersion,
+      silvermanKDEEnabled,
     }),
   );
   return Promise.all(promises);
@@ -186,6 +194,9 @@ export async function loader({ request }: { request: Request }) {
   const testVersionFromUrl = url.searchParams.get(
     'test_version',
   ) as TestVersion;
+  const enableSilvermanKDEFromUrl = url.searchParams.has(
+    'enable_silverman_kde',
+  );
 
   const {
     baseRepo,
@@ -197,6 +208,7 @@ export async function loader({ request }: { request: Request }) {
     intervalText,
     replicates,
     testVersion,
+    silvermanKDEEnabled,
   } = checkValues({
     baseRepo: baseRepoFromUrl,
     newRevs: newRevsFromUrl,
@@ -205,6 +217,7 @@ export async function loader({ request }: { request: Request }) {
     interval: intervalFromUrl,
     replicates: replicatesFromUrl,
     testVersion: testVersionFromUrl,
+    silvermanKDEEnabled: enableSilvermanKDEFromUrl,
   });
 
   const resultsTimePromise = fetchCompareOverTimeResultsOnTreeherder({
@@ -215,6 +228,7 @@ export async function loader({ request }: { request: Request }) {
     interval: intervalValue,
     replicates,
     testVersion,
+    silvermanKDEEnabled,
   });
 
   const newRevsInfoPromises = newRevs.map((newRev, i) =>
@@ -240,6 +254,7 @@ export async function loader({ request }: { request: Request }) {
     generation: generationCounter++,
     replicates,
     testVersion,
+    silvermanKDEEnabled,
   };
 }
 
@@ -257,6 +272,7 @@ type DeferredLoaderData = {
   generation: number;
   replicates: boolean;
   testVersion: TestVersion;
+  silvermanKDEEnabled: boolean;
 };
 
 // Be explicit with the returned type to control it better than if we were

--- a/src/components/CompareResults/subtestsLoader.ts
+++ b/src/components/CompareResults/subtestsLoader.ts
@@ -102,7 +102,6 @@ function checkValues({
 
   if (testVersion === MANN_WHITNEY_U || testVersion === null) {
     replicates = true;
-    silvermanKDEEnabled = true;
   }
 
   if (!testVersion) {

--- a/src/components/CompareResults/subtestsLoader.ts
+++ b/src/components/CompareResults/subtestsLoader.ts
@@ -15,6 +15,7 @@ function checkValues({
   newParentSignature,
   replicates,
   testVersion,
+  silvermanKDEEnabled,
 }: {
   baseRev: string | null;
   baseRepo: Repository['name'] | null;
@@ -25,6 +26,7 @@ function checkValues({
   newParentSignature: string | null;
   replicates: boolean;
   testVersion?: TestVersion;
+  silvermanKDEEnabled: boolean;
 }): {
   baseRev: string;
   baseRepo: Repository['name'];
@@ -36,6 +38,7 @@ function checkValues({
   newParentSignature: string;
   replicates: boolean;
   testVersion?: TestVersion;
+  silvermanKDEEnabled: boolean;
 } {
   if (baseRev === null) {
     throw new Error('The parameter baseRev is missing.');
@@ -99,6 +102,7 @@ function checkValues({
 
   if (testVersion === MANN_WHITNEY_U || testVersion === null) {
     replicates = true;
+    silvermanKDEEnabled = true;
   }
 
   if (!testVersion) {
@@ -116,6 +120,7 @@ function checkValues({
     newParentSignature,
     replicates,
     testVersion,
+    silvermanKDEEnabled,
   };
 }
 
@@ -142,6 +147,9 @@ export function loader({ request }: { request: Request }) {
   const replicatesFromUrl = url.searchParams.has('replicates');
   const testVersionFromUrl = (url.searchParams.get('test_version') ??
     MANN_WHITNEY_U) as TestVersion;
+  const enableSilvermanKDEFromUrl = url.searchParams.has(
+    'enable_silverman_kde',
+  );
 
   const {
     baseRev,
@@ -154,6 +162,7 @@ export function loader({ request }: { request: Request }) {
     baseParentSignature,
     replicates,
     testVersion,
+    silvermanKDEEnabled,
   } = checkValues({
     baseRev: baseRevFromUrl,
     baseRepo: baseRepoFromUrl,
@@ -164,6 +173,7 @@ export function loader({ request }: { request: Request }) {
     newParentSignature: newParentSignatureFromUrl,
     replicates: replicatesFromUrl,
     testVersion: testVersionFromUrl,
+    silvermanKDEEnabled: enableSilvermanKDEFromUrl,
   });
 
   const results = fetchSubtestsCompareResults({
@@ -176,6 +186,7 @@ export function loader({ request }: { request: Request }) {
     newParentSignature,
     replicates,
     testVersion,
+    silvermanKDEEnabled,
   });
 
   return {
@@ -190,6 +201,7 @@ export function loader({ request }: { request: Request }) {
     newParentSignature,
     replicates,
     testVersion,
+    silvermanKDEEnabled,
   };
 }
 

--- a/src/components/CompareResults/subtestsOverTimeLoader.tsx
+++ b/src/components/CompareResults/subtestsOverTimeLoader.tsx
@@ -173,7 +173,9 @@ export function loader({ request }: { request: Request }) {
   const testVersionFromUrl = url.searchParams.get(
     'test_version',
   ) as TestVersion;
-  const enableSilvermanKDEFromUrl = url.searchParams.has('enable_silverman_kde');
+  const enableSilvermanKDEFromUrl = url.searchParams.has(
+    'enable_silverman_kde',
+  );
   const {
     baseRepo,
     newRev,

--- a/src/components/CompareResults/subtestsOverTimeLoader.tsx
+++ b/src/components/CompareResults/subtestsOverTimeLoader.tsx
@@ -20,6 +20,7 @@ function checkValues({
   newParentSignature,
   replicates,
   testVersion,
+  silvermanKDEEnabled,
 }: {
   baseRepo: Repository['name'] | null;
   newRev: string | null;
@@ -30,6 +31,7 @@ function checkValues({
   newParentSignature: string | null;
   replicates: boolean;
   testVersion?: TestVersion | null;
+  silvermanKDEEnabled: boolean;
 }): {
   baseRepo: Repository['name'];
   newRev: string;
@@ -42,6 +44,7 @@ function checkValues({
   newParentSignature: string;
   replicates: boolean;
   testVersion: TestVersion;
+  silvermanKDEEnabled: boolean;
 } {
   if (baseRepo === null) {
     throw new Error('The parameter baseRepo is missing.');
@@ -123,6 +126,7 @@ function checkValues({
 
   if (testVersion === MANN_WHITNEY_U || testVersion === null) {
     replicates = true;
+    silvermanKDEEnabled = true;
   }
 
   if (!testVersion) {
@@ -141,6 +145,7 @@ function checkValues({
     newParentSignature,
     replicates,
     testVersion,
+    silvermanKDEEnabled,
   };
 }
 
@@ -168,6 +173,7 @@ export function loader({ request }: { request: Request }) {
   const testVersionFromUrl = url.searchParams.get(
     'test_version',
   ) as TestVersion;
+  const enableSilvermanKDEFromUrl = url.searchParams.has('enable_silverman_kde');
   const {
     baseRepo,
     newRev,
@@ -180,6 +186,7 @@ export function loader({ request }: { request: Request }) {
     newParentSignature,
     replicates,
     testVersion,
+    silvermanKDEEnabled,
   } = checkValues({
     baseRepo: baseRepoFromUrl,
     newRev: newRevFromUrl,
@@ -190,6 +197,7 @@ export function loader({ request }: { request: Request }) {
     newParentSignature: newParentSignatureFromUrl,
     replicates: replicatesFromUrl,
     testVersion: testVersionFromUrl,
+    silvermanKDEEnabled: enableSilvermanKDEFromUrl,
   });
 
   const results = fetchSubtestsCompareOverTimeResults({
@@ -202,6 +210,7 @@ export function loader({ request }: { request: Request }) {
     newParentSignature,
     replicates,
     testVersion,
+    silvermanKDEEnabled,
   });
 
   return {
@@ -217,6 +226,7 @@ export function loader({ request }: { request: Request }) {
     newParentSignature,
     replicates,
     testVersion,
+    silvermanKDEEnabled,
   };
 }
 

--- a/src/components/CompareResults/subtestsOverTimeLoader.tsx
+++ b/src/components/CompareResults/subtestsOverTimeLoader.tsx
@@ -126,7 +126,6 @@ function checkValues({
 
   if (testVersion === MANN_WHITNEY_U || testVersion === null) {
     replicates = true;
-    silvermanKDEEnabled = true;
   }
 
   if (!testVersion) {

--- a/src/logic/treeherder.ts
+++ b/src/logic/treeherder.ts
@@ -22,6 +22,7 @@ type FetchProps = {
   framework: Framework['id'];
   replicates: boolean;
   testVersion?: TestVersion;
+  silvermanKDEEnabled?: boolean;
 };
 
 type FetchOverTimeProps = {
@@ -32,6 +33,7 @@ type FetchOverTimeProps = {
   interval: TimeRange['value'];
   replicates: boolean;
   testVersion?: TestVersion;
+  silvermanKDEEnabled?: boolean;
 };
 
 type FetchSubtestsProps = {
@@ -44,6 +46,7 @@ type FetchSubtestsProps = {
   newParentSignature: string;
   replicates: boolean;
   testVersion?: TestVersion;
+  silvermanKDEEnabled?: boolean;
 };
 
 type FetchSubtestsOverTimeProps = {
@@ -55,7 +58,8 @@ type FetchSubtestsOverTimeProps = {
   baseParentSignature: string;
   newParentSignature: string;
   replicates: boolean;
-  testVersion?: string;
+  testVersion?: TestVersion;
+  silvermanKDEEnabled?: boolean;
 };
 
 export async function fetchRevisionFromHash(
@@ -105,6 +109,7 @@ export async function fetchCompareResults({
   framework,
   replicates,
   testVersion,
+  silvermanKDEEnabled,
 }: FetchProps) {
   const searchParams = new URLSearchParams({
     base_repository: baseRepo,
@@ -115,6 +120,7 @@ export async function fetchCompareResults({
     no_subtests: 'true',
     replicates: String(replicates),
     test_version: testVersion ?? STUDENT_T,
+    enable_silverman_kde: String(silvermanKDEEnabled),
   });
   const url = `${treeherderBaseURL}/api/perfcompare/results/?${searchParams.toString()}`;
   const response = await fetchFromTreeherder(url);
@@ -131,6 +137,7 @@ export async function fetchCompareOverTimeResults({
   interval,
   replicates,
   testVersion,
+  silvermanKDEEnabled,
 }: FetchOverTimeProps) {
   const searchParams = new URLSearchParams({
     base_repository: baseRepo,
@@ -141,6 +148,7 @@ export async function fetchCompareOverTimeResults({
     no_subtests: 'true',
     replicates: String(replicates),
     test_version: testVersion ?? STUDENT_T,
+    enable_silverman_kde: String(silvermanKDEEnabled),
   });
   const url = `${treeherderBaseURL}/api/perfcompare/results/?${searchParams.toString()}`;
   const response = await fetchFromTreeherder(url);
@@ -159,6 +167,7 @@ export async function fetchSubtestsCompareResults({
   newParentSignature,
   replicates,
   testVersion,
+  silvermanKDEEnabled,
 }: FetchSubtestsProps) {
   const searchParams = new URLSearchParams({
     base_repository: baseRepo,
@@ -170,6 +179,7 @@ export async function fetchSubtestsCompareResults({
     new_parent_signature: newParentSignature,
     replicates: String(replicates),
     test_version: testVersion ?? STUDENT_T,
+    enable_silverman_kde: String(silvermanKDEEnabled),
   });
 
   const url = `${treeherderBaseURL}/api/perfcompare/results/?${searchParams.toString()}`;
@@ -189,6 +199,7 @@ export async function fetchSubtestsCompareOverTimeResults({
   newParentSignature,
   replicates,
   testVersion,
+  silvermanKDEEnabled,
 }: FetchSubtestsOverTimeProps) {
   const searchParams = new URLSearchParams({
     base_repository: baseRepo,
@@ -200,6 +211,7 @@ export async function fetchSubtestsCompareOverTimeResults({
     new_parent_signature: newParentSignature,
     replicates: String(replicates),
     test_version: testVersion ?? STUDENT_T,
+    enable_silverman_kde: String(silvermanKDEEnabled),
   });
 
   const url = `${treeherderBaseURL}/api/perfcompare/results/?${searchParams.toString()}`;


### PR DESCRIPTION
Quick PR to enable the Silverman KDE for perfcompare: 

[Deploy link](https://deploy-preview-1027--mozilla-perfcompare.netlify.app/compare-results?baseRev=215a333dede39c4849a3ccbe28c58fd827bb1f7c&baseRepo=try&newRev=3ca79c893ced2264860775a789dc51146cfcc7ca&newRepo=try&framework=13)


<img width="1395" height="817" alt="Screenshot 2026-04-09 at 12 14 30 PM" src="https://github.com/user-attachments/assets/a8545301-c031-474a-823c-fb89dee6c558" />
