### PR TITLE
Bug-2003889: Return an appropriate message when lando is still loading

### DIFF
--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -148,6 +148,35 @@ describe('App', () => {
       expect(document.body).toMatchSnapshot();
     });
 
+    it('Should render the correct error message to the console when new_revision is required but missing', async () => {
+      // Silence console.error for a better console output.
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      fetchMock.get(
+        'begin:https://treeherder.mozilla.org/api/perfcompare/results/',
+        {
+          status: 400,
+          body: JSON.stringify({
+            new_revision: ['This field may not be blank.'],
+          }),
+        },
+      );
+
+      await router.navigate(
+        '/compare-results/?baseRev=spam&baseRepo=mozilla-central&framework=2',
+      );
+      render(<App />);
+
+      await screen.findByText(/Error/);
+      expect(console.error).toHaveBeenCalledWith(
+        new Error(
+          'The comparison cannot be performed because the `new_revision` field is missing. ' +
+            'This typically happens when the `mach try perf` push is still being processed by Lando. ' +
+            'Please wait a few moments for the push to complete and then refresh the page.',
+        ),
+      );
+      expect(document.body).toMatchSnapshot();
+    });
+
     it('Should render an error page for compare over time when the treeherder request fails with an error 400', async () => {
       // Silence console.error for a better console output. We'll check its result later.
       jest.spyOn(console, 'error').mockImplementation(() => {});

--- a/src/__tests__/__snapshots__/App.test.tsx.snap
+++ b/src/__tests__/__snapshots__/App.test.tsx.snap
@@ -708,7 +708,7 @@ exports[`App CompareResults or CompareOverTime loader Should render the correct 
       class="fcndgf6"
     >
       <div
-        class="MuiGrid-root MuiGrid-direction-xs-row header-container container_fjtw4pp css-k4qgqg-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-direction-xs-row header-container container_f16a4r9k css-k4qgqg-MuiGrid-root"
       >
         <div
           class="MuiBox-root css-1e39pab"
@@ -733,6 +733,7 @@ exports[`App CompareResults or CompareOverTime loader Should render the correct 
                       class="PrivateSwitchBase-input MuiSwitch-input css-12xagqm-MuiSwitchBase-root"
                       id="Dark mode"
                       name="toggle-dark-mode"
+                      role="switch"
                       type="checkbox"
                     />
                     <span
@@ -744,22 +745,27 @@ exports[`App CompareResults or CompareOverTime loader Should render the correct 
                   />
                 </span>
                 <span
-                  class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1vajmro-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-n290n7-MuiTypography-root"
                 >
                   Dark mode
                 </span>
               </label>
             </div>
           </div>
+          <h2
+            class="MuiTypography-root MuiTypography-h2 perfcompare-header css-1lhc7rx-MuiTypography-root"
+          >
+            PerfCompare
+          </h2>
           <div
-            class="MuiBox-root css-1cuyom4"
+            class="MuiBox-root css-u7c4o"
           >
             <div
               class="MuiBox-root css-0"
             >
               <a
                 aria-label="Docs"
-                class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-xt1vmc-MuiTypography-root-MuiLink-root"
+                class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-husciy-MuiTypography-root-MuiLink-root"
                 href="https://firefox-source-docs.mozilla.org/testing/perfdocs/perfcompare.html"
                 target="_blank"
                 title="View the documentation"
@@ -780,7 +786,7 @@ exports[`App CompareResults or CompareOverTime loader Should render the correct 
             >
               <a
                 aria-label="Source"
-                class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-xt1vmc-MuiTypography-root-MuiLink-root"
+                class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-husciy-MuiTypography-root-MuiLink-root"
                 href="https://github.com/mozilla/perfcompare"
                 target="_blank"
                 title="View the source code on GitHub"
@@ -801,7 +807,7 @@ exports[`App CompareResults or CompareOverTime loader Should render the correct 
             >
               <a
                 aria-label="Matrix"
-                class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-xt1vmc-MuiTypography-root-MuiLink-root"
+                class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-husciy-MuiTypography-root-MuiLink-root"
                 href="https://matrix.to/#/#perfcompare:mozilla.org"
                 target="_blank"
                 title="Chat with us on Matrix"
@@ -822,7 +828,7 @@ exports[`App CompareResults or CompareOverTime loader Should render the correct 
             >
               <a
                 aria-label="Bugzilla"
-                class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-xt1vmc-MuiTypography-root-MuiLink-root"
+                class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-husciy-MuiTypography-root-MuiLink-root"
                 href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Testing&component=PerfCompare&status_whiteboard=[pcf]"
                 target="_blank"
                 title="Report an issue on Bugzilla"
@@ -840,26 +846,16 @@ exports[`App CompareResults or CompareOverTime loader Should render the correct 
             </div>
           </div>
         </div>
-        <div
-          class="header-text MuiBox-root css-0"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-19e1hs-MuiTypography-root"
-            style="--Typography-textAlign: center;"
-          >
-            PerfCompare
-          </h1>
-        </div>
       </div>
       <section
-        class="container_f1h7ern2"
+        class="container_f13838vn"
       >
         <div
           class="MuiBox-root css-i3pbo"
         >
           <a
             aria-label="link to home"
-            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-13qcp0f-MuiTypography-root-MuiLink-root"
+            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-725yfl-MuiTypography-root-MuiLink-root"
             href="/"
           >
             <div

--- a/src/__tests__/__snapshots__/App.test.tsx.snap
+++ b/src/__tests__/__snapshots__/App.test.tsx.snap
@@ -695,3 +695,204 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
   </div>
 </body>
 `;
+
+exports[`App CompareResults or CompareOverTime loader Should render the correct error message to the console when new_revision is required but missing 1`] = `
+<body>
+  <div>
+    <div
+      aria-live="assertive"
+      class="alert-container"
+      role="alert"
+    />
+    <div
+      class="fcndgf6"
+    >
+      <div
+        class="MuiGrid-root MuiGrid-direction-xs-row header-container container_fjtw4pp css-k4qgqg-MuiGrid-root"
+      >
+        <div
+          class="MuiBox-root css-1e39pab"
+        >
+          <div
+            class="toggle-dark-mode f1y1dem6 MuiBox-root css-0"
+          >
+            <div
+              class="MuiFormGroup-root css-1mac7pt-MuiFormGroup-root"
+            >
+              <label
+                class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementStart toggle-text css-1lhdpr4-MuiFormControlLabel-root"
+              >
+                <span
+                  class="MuiSwitch-root MuiSwitch-sizeMedium toggle-switch toggle-dark-mode css-rehya9-MuiSwitch-root"
+                >
+                  <span
+                    class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-1jkkk7l-MuiButtonBase-root-MuiSwitchBase-root-MuiSwitch-switchBase"
+                  >
+                    <input
+                      aria-label="Dark mode switch"
+                      class="PrivateSwitchBase-input MuiSwitch-input css-12xagqm-MuiSwitchBase-root"
+                      id="Dark mode"
+                      name="toggle-dark-mode"
+                      type="checkbox"
+                    />
+                    <span
+                      class="MuiSwitch-thumb css-1mw77bv-MuiSwitch-thumb"
+                    />
+                  </span>
+                  <span
+                    class="MuiSwitch-track css-1kf3qur-MuiSwitch-track"
+                  />
+                </span>
+                <span
+                  class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-1vajmro-MuiTypography-root"
+                >
+                  Dark mode
+                </span>
+              </label>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root css-1cuyom4"
+          >
+            <div
+              class="MuiBox-root css-0"
+            >
+              <a
+                aria-label="Docs"
+                class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-xt1vmc-MuiTypography-root-MuiLink-root"
+                href="https://firefox-source-docs.mozilla.org/testing/perfdocs/perfcompare.html"
+                target="_blank"
+                title="View the documentation"
+              >
+                <div
+                  class="MuiStack-root css-ljomt-MuiStack-root"
+                >
+                  <span
+                    class="MuiBox-root css-0"
+                  >
+                    Docs
+                  </span>
+                </div>
+              </a>
+            </div>
+            <div
+              class="MuiBox-root css-0"
+            >
+              <a
+                aria-label="Source"
+                class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-xt1vmc-MuiTypography-root-MuiLink-root"
+                href="https://github.com/mozilla/perfcompare"
+                target="_blank"
+                title="View the source code on GitHub"
+              >
+                <div
+                  class="MuiStack-root css-ljomt-MuiStack-root"
+                >
+                  <span
+                    class="MuiBox-root css-0"
+                  >
+                    Source
+                  </span>
+                </div>
+              </a>
+            </div>
+            <div
+              class="MuiBox-root css-0"
+            >
+              <a
+                aria-label="Matrix"
+                class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-xt1vmc-MuiTypography-root-MuiLink-root"
+                href="https://matrix.to/#/#perfcompare:mozilla.org"
+                target="_blank"
+                title="Chat with us on Matrix"
+              >
+                <div
+                  class="MuiStack-root css-ljomt-MuiStack-root"
+                >
+                  <span
+                    class="MuiBox-root css-0"
+                  >
+                    Matrix
+                  </span>
+                </div>
+              </a>
+            </div>
+            <div
+              class="MuiBox-root css-0"
+            >
+              <a
+                aria-label="Bugzilla"
+                class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-xt1vmc-MuiTypography-root-MuiLink-root"
+                href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Testing&component=PerfCompare&status_whiteboard=[pcf]"
+                target="_blank"
+                title="Report an issue on Bugzilla"
+              >
+                <div
+                  class="MuiStack-root css-ljomt-MuiStack-root"
+                >
+                  <span
+                    class="MuiBox-root css-0"
+                  >
+                    Bugzilla
+                  </span>
+                </div>
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          class="header-text MuiBox-root css-0"
+        >
+          <h1
+            class="MuiTypography-root MuiTypography-h1 MuiTypography-alignCenter MuiTypography-gutterBottom perfcompare-header css-19e1hs-MuiTypography-root"
+            style="--Typography-textAlign: center;"
+          >
+            PerfCompare
+          </h1>
+        </div>
+      </div>
+      <section
+        class="container_f1h7ern2"
+      >
+        <div
+          class="MuiBox-root css-i3pbo"
+        >
+          <a
+            aria-label="link to home"
+            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-13qcp0f-MuiTypography-root-MuiLink-root"
+            href="/"
+          >
+            <div
+              class="MuiStack-root css-ljomt-MuiStack-root"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                data-testid="ChevronLeftIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+                />
+              </svg>
+              <span
+                class="MuiBox-root css-0"
+              >
+                Home
+              </span>
+            </div>
+          </a>
+        </div>
+        <p>
+          Error: 
+          The comparison cannot be performed because the \`new_revision\` field is missing. This typically happens when the \`mach try perf\` push is still being processed by Lando. Please wait a few moments for the push to complete and then refresh the page.
+        </p>
+        <p>
+          More information about this error has been written to the Web Console.
+        </p>
+      </section>
+    </div>
+  </div>
+</body>
+`;

--- a/src/logic/treeherder.ts
+++ b/src/logic/treeherder.ts
@@ -85,15 +85,30 @@ export async function fetchRevisionFromHash(
 async function fetchFromTreeherder(url: string) {
   const response = await fetch(url);
   if (!response.ok) {
+    const errorText = await response.text();
     if (response.status === 400) {
-      throw new Error(
-        `Error when requesting treeherder: ${await response.text()}`,
-      );
-    } else {
-      throw new Error(
-        `Error when requesting treeherder: (${response.status}) ${response.statusText}`,
-      );
+      let errorJson: Record<string, string[]> | null = null;
+      try {
+        errorJson = JSON.parse(errorText) as Record<string, string[]>;
+      } catch {
+        // Fall through to the generic error below if parsing fails
+      }
+
+      if (
+        errorJson?.new_revision?.[0]?.trim() === 'This field may not be blank.'
+      ) {
+        throw new Error(
+          'The comparison cannot be performed because the `new_revision` field is missing. ' +
+            'This typically happens when the `mach try perf` push is still being processed by Lando. ' +
+            'Please wait a few moments for the push to complete and then refresh the page.',
+        );
+      }
+
+      throw new Error(`Error when requesting treeherder: ${errorText}`);
     }
+    throw new Error(
+      `Error when requesting treeherder: (${response.status}) ${response.statusText}`,
+    );
   }
   return response;
 }


### PR DESCRIPTION
## Changes Introduced
Updated the response message in `src/logic/treeherder.ts` to convey to the user that lando has still not completed the try pushes.

## Testing
The App.test.tsx has been updated with a test for the new change

@kala-moz @gmierz 