### PR TITLE
Bug: 2044194 Port client-side KDE mode detection from kde-widget into CommonGraph

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   node: circleci/node@5.1.0
-  codecov: codecov/codecov@3.2.2
+  codecov: codecov/codecov@5.4.3
 
 executors:
   node:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   node: circleci/node@5.1.0
-  codecov: codecov/codecov@5.4.3
+  codecov: codecov/codecov@6.0.0
 
 executors:
   node:

--- a/src/__tests__/CompareResults/CommonGraph.test.tsx
+++ b/src/__tests__/CompareResults/CommonGraph.test.tsx
@@ -90,6 +90,8 @@ describe('CommonGraph', () => {
         isSubtest={false}
         vt={0.5}
         onVtChange={jest.fn()}
+        showModes={true}
+        onShowModesChange={jest.fn()}
       />,
     );
 
@@ -136,6 +138,8 @@ describe('CommonGraph', () => {
         isSubtest={false}
         vt={0.5}
         onVtChange={jest.fn()}
+        showModes={true}
+        onShowModesChange={jest.fn()}
       />,
     );
 
@@ -170,6 +174,8 @@ describe('CommonGraph', () => {
         isSubtest={true}
         vt={0.5}
         onVtChange={jest.fn()}
+        showModes={true}
+        onShowModesChange={jest.fn()}
       />,
     );
 
@@ -202,6 +208,8 @@ describe('CommonGraph', () => {
         isSubtest={false}
         vt={0.5}
         onVtChange={jest.fn()}
+        showModes={true}
+        onShowModesChange={jest.fn()}
       />,
     );
 
@@ -246,6 +254,8 @@ describe('CommonGraph', () => {
         isSubtest={false}
         vt={0.5}
         onVtChange={jest.fn()}
+        showModes={true}
+        onShowModesChange={jest.fn()}
       />,
     );
 
@@ -270,6 +280,8 @@ describe('CommonGraph', () => {
         isSubtest={false}
         vt={0.5}
         onVtChange={jest.fn()}
+        showModes={true}
+        onShowModesChange={jest.fn()}
       />,
     );
 
@@ -314,6 +326,8 @@ describe('CommonGraph', () => {
         isSubtest={false}
         vt={0.5}
         onVtChange={jest.fn()}
+        showModes={true}
+        onShowModesChange={jest.fn()}
       />,
     );
 
@@ -356,6 +370,8 @@ describe('CommonGraph', () => {
         isSubtest={false}
         vt={0.5}
         onVtChange={jest.fn()}
+        showModes={true}
+        onShowModesChange={jest.fn()}
       />,
     );
 
@@ -392,6 +408,8 @@ describe('CommonGraph', () => {
         isSubtest={false}
         vt={0.5}
         onVtChange={jest.fn()}
+        showModes={true}
+        onShowModesChange={jest.fn()}
       />,
     );
 
@@ -430,6 +448,8 @@ describe('CommonGraph', () => {
         isSubtest={false}
         vt={0.5}
         onVtChange={jest.fn()}
+        showModes={true}
+        onShowModesChange={jest.fn()}
       />,
     );
 
@@ -447,7 +467,7 @@ describe('CommonGraph', () => {
     expect(rendered).toBe('[m]Base: 12.50 (ms)');
   });
 
-  it("labels the scatter y-axis as 'Base' for 0 and 'New' for 1", () => {
+  it("labels the scatter y-axis as 'Base' for 1 and 'New' for 0", () => {
     (fftkde as jest.Mock).mockImplementation(() => ({
       x: [10, 20, 30],
       y: [0.1, 0.2, 0.3],
@@ -462,6 +482,8 @@ describe('CommonGraph', () => {
         isSubtest={false}
         vt={0.5}
         onVtChange={jest.fn()}
+        showModes={true}
+        onShowModesChange={jest.fn()}
       />,
     );
 
@@ -471,8 +493,8 @@ describe('CommonGraph', () => {
     }>;
     const scatterYAxisFormatter = yAxes[1]?.axisLabel?.formatter;
     expect(scatterYAxisFormatter).toBeDefined();
-    expect(scatterYAxisFormatter!(0)).toBe('Base');
-    expect(scatterYAxisFormatter!(1)).toBe('New');
+    expect(scatterYAxisFormatter!(1)).toBe('Base');
+    expect(scatterYAxisFormatter!(0)).toBe('New');
     // Anything else returns empty so intermediate jitter values stay unlabelled.
     expect(scatterYAxisFormatter!(0.5)).toBe('');
   });

--- a/src/__tests__/CompareResults/CommonGraph.test.tsx
+++ b/src/__tests__/CompareResults/CommonGraph.test.tsx
@@ -88,6 +88,8 @@ describe('CommonGraph', () => {
         newValues={[3, 4]}
         unit='ms'
         isSubtest={false}
+        vt={0.5}
+        onVtChange={jest.fn()}
       />,
     );
 
@@ -132,6 +134,8 @@ describe('CommonGraph', () => {
         newValues={[3, 4]}
         unit='ms'
         isSubtest={false}
+        vt={0.5}
+        onVtChange={jest.fn()}
       />,
     );
 
@@ -164,6 +168,8 @@ describe('CommonGraph', () => {
         newValues={[3, 4]}
         unit='ms'
         isSubtest={true}
+        vt={0.5}
+        onVtChange={jest.fn()}
       />,
     );
 
@@ -194,12 +200,18 @@ describe('CommonGraph', () => {
         newValues={[]}
         unit='ms'
         isSubtest={false}
+        vt={0.5}
+        onVtChange={jest.fn()}
       />,
     );
 
     const option = getLatestEChartsOption();
     const allSeries = option.series as LineSeriesOption[];
-    const series = allSeries.filter((s) => s.type === 'line');
+    // Exclude the mode-overlay markLine series (named "_mode-*") — only count
+    // the two underlying KDE curves.
+    const series = allSeries.filter(
+      (s) => s.type === 'line' && !String(s.name ?? '').startsWith('_mode-'),
+    );
     expect(series).toHaveLength(2);
     // Base side has a resampled density curve.
     expect(series[0].data as unknown[]).toHaveLength(1024);
@@ -232,6 +244,8 @@ describe('CommonGraph', () => {
         newValues={[3, 4]}
         unit='ms'
         isSubtest={false}
+        vt={0.5}
+        onVtChange={jest.fn()}
       />,
     );
 
@@ -254,6 +268,8 @@ describe('CommonGraph', () => {
         newValues={[3, 4]}
         unit='ms'
         isSubtest={false}
+        vt={0.5}
+        onVtChange={jest.fn()}
       />,
     );
 
@@ -296,6 +312,8 @@ describe('CommonGraph', () => {
         newValues={[3, 4]}
         unit='ms'
         isSubtest={false}
+        vt={0.5}
+        onVtChange={jest.fn()}
       />,
     );
 
@@ -336,6 +354,8 @@ describe('CommonGraph', () => {
         newValues={[3, 4]}
         unit={null}
         isSubtest={false}
+        vt={0.5}
+        onVtChange={jest.fn()}
       />,
     );
 
@@ -352,5 +372,46 @@ describe('CommonGraph', () => {
     ]);
     // No "(unit)" suffix after the value when unit is null.
     expect(rendered).toBe('Value: 5.00<br>Base: 0.1000');
+  });
+
+  it('emits a mode-overlay markLine series for each detected peak', () => {
+    // Strictly increasing fake KDE — fitModesFromKde returns a single peak at
+    // the global max (last x). That yields exactly one "_mode-*" overlay per
+    // series, with a label tagged by series and letter A.
+    (fftkde as jest.Mock).mockImplementation(() => ({
+      x: [10, 20, 30],
+      y: [0.1, 0.2, 0.3],
+      bandwidth: 1,
+    }));
+
+    render(
+      <CommonGraph
+        baseValues={[1, 2]}
+        newValues={[3, 4]}
+        unit='ms'
+        isSubtest={false}
+        vt={0.5}
+        onVtChange={jest.fn()}
+      />,
+    );
+
+    const option = getLatestEChartsOption();
+    const series = option.series as Array<{
+      name?: string;
+      markLine?: {
+        data?: Array<{ xAxis?: number }>;
+        label?: { formatter?: string };
+        lineStyle?: { color?: string };
+      };
+    }>;
+    const overlays = series.filter((s) =>
+      String(s.name ?? '').startsWith('_mode-'),
+    );
+    // One overlay per series (Base + New), both peaking at the same x.
+    expect(overlays).toHaveLength(2);
+    expect(overlays[0].markLine?.data?.[0]?.xAxis).toBe(30);
+    expect(overlays[1].markLine?.data?.[0]?.xAxis).toBe(30);
+    expect(overlays[0].markLine?.label?.formatter).toMatch(/^Base A: 30/);
+    expect(overlays[1].markLine?.label?.formatter).toMatch(/^New A: 30/);
   });
 });

--- a/src/__tests__/CompareResults/CommonGraph.test.tsx
+++ b/src/__tests__/CompareResults/CommonGraph.test.tsx
@@ -216,10 +216,11 @@ describe('CommonGraph', () => {
 
     const option = getLatestEChartsOption();
     const allSeries = option.series as LineSeriesOption[];
-    // Exclude the mode-overlay markLine series (named "_mode-*") — only count
-    // the two underlying KDE curves.
+    // Mode-overlay markLine series share names with the parent KDE lines
+    // (Base/New) so the legend can toggle them together — identify the
+    // underlying KDE curves by the absence of a markLine config.
     const series = allSeries.filter(
-      (s) => s.type === 'line' && !String(s.name ?? '').startsWith('_mode-'),
+      (s) => s.type === 'line' && !(s as { markLine?: unknown }).markLine,
     );
     expect(series).toHaveLength(2);
     // Base side has a resampled density curve.
@@ -393,8 +394,10 @@ describe('CommonGraph', () => {
 
   it('emits a mode-overlay markLine series for each detected peak', () => {
     // Strictly increasing fake KDE — fitModesFromKde returns a single peak at
-    // the global max (last x). That yields exactly one "_mode-*" overlay per
-    // series, with a label tagged by series and letter A.
+    // the global max (last x). That yields exactly one markLine overlay per
+    // series, with a label tagged by series and letter A. Overlays share
+    // names with the parent KDE series (Base/New) so the legend can toggle
+    // them — identify them by the markLine config rather than name.
     (fftkde as jest.Mock).mockImplementation(() => ({
       x: [10, 20, 30],
       y: [0.1, 0.2, 0.3],
@@ -423,11 +426,15 @@ describe('CommonGraph', () => {
         lineStyle?: { color?: string };
       };
     }>;
-    const overlays = series.filter((s) =>
-      String(s.name ?? '').startsWith('_mode-'),
+    // Peak overlays are line-type series with a markLine. Scatter rows also
+    // carry a baseline markLine but they're scatter-type, so type filters them out.
+    const overlays = series.filter(
+      (s) => (s as { type?: string }).type === 'line' && Boolean(s.markLine),
     );
     // One overlay per series (Base + New), both peaking at the same x.
     expect(overlays).toHaveLength(2);
+    expect(overlays[0].name).toBe('Base');
+    expect(overlays[1].name).toBe('New');
     expect(overlays[0].markLine?.data?.[0]?.xAxis).toBe(30);
     expect(overlays[1].markLine?.data?.[0]?.xAxis).toBe(30);
     expect(overlays[0].markLine?.label?.formatter).toMatch(/^Base A: 30/);

--- a/src/__tests__/CompareResults/CommonGraph.test.tsx
+++ b/src/__tests__/CompareResults/CommonGraph.test.tsx
@@ -1,9 +1,10 @@
+import { fireEvent } from '@testing-library/react';
 import { init as echartsInit } from 'echarts';
 import type { EChartsOption, LineSeriesOption } from 'echarts';
 
 import CommonGraph from '../../components/CompareResults/CommonGraph';
 import { fftkde } from '../../utils/kde.js';
-import { render } from '../utils/test-utils';
+import { render, screen } from '../utils/test-utils';
 
 // Wrap React.useRef so a single test can substitute a stubbed ref whose
 // `.current` stays null — used to exercise the "no DOM element attached"
@@ -497,5 +498,92 @@ describe('CommonGraph', () => {
     expect(scatterYAxisFormatter!(0)).toBe('New');
     // Anything else returns empty so intermediate jitter values stay unlabelled.
     expect(scatterYAxisFormatter!(0.5)).toBe('');
+  });
+
+  it('wires the slider through both onChange (local) and onChangeCommitted (parent)', () => {
+    // The slider uses MUI's two-event API: onChange updates a local mirror for
+    // the thumb/percentage during drag, and onChangeCommitted pushes the final
+    // value up. fireEvent.change on the underlying <input type="range"> drives
+    // both — confirming both handlers are wired correctly.
+    (fftkde as jest.Mock).mockImplementation(() => ({
+      x: [10, 20, 30],
+      y: [0.1, 0.2, 0.3],
+      bandwidth: 1,
+    }));
+    const onVtChange = jest.fn();
+
+    render(
+      <CommonGraph
+        baseValues={[1, 2]}
+        newValues={[3, 4]}
+        unit='ms'
+        isSubtest={false}
+        vt={0.5}
+        onVtChange={onVtChange}
+        showModes={true}
+        onShowModesChange={jest.fn()}
+      />,
+    );
+
+    // Starts at vt = 0.5 → 50%.
+    expect(screen.getByText('50%')).toBeInTheDocument();
+
+    const slider = screen.getByRole('slider', { name: /valley depth/i });
+    fireEvent.change(slider, { target: { value: '0.7' } });
+
+    // Local mirror updated → percentage reflects the new value.
+    expect(screen.getByText('70%')).toBeInTheDocument();
+    // Parent committed callback also fired with the same value.
+    expect(onVtChange).toHaveBeenCalledWith(0.7);
+  });
+
+  it('disables the slider when showModes is false', () => {
+    (fftkde as jest.Mock).mockImplementation(() => ({
+      x: [10, 20, 30],
+      y: [0.1, 0.2, 0.3],
+      bandwidth: 1,
+    }));
+
+    render(
+      <CommonGraph
+        baseValues={[1, 2]}
+        newValues={[3, 4]}
+        unit='ms'
+        isSubtest={false}
+        vt={0.5}
+        onVtChange={jest.fn()}
+        showModes={false}
+        onShowModesChange={jest.fn()}
+      />,
+    );
+
+    const slider = screen.getByRole('slider', { name: /valley depth/i });
+    expect(slider).toBeDisabled();
+  });
+
+  it('calls onShowModesChange when the Show modes checkbox is toggled', () => {
+    (fftkde as jest.Mock).mockImplementation(() => ({
+      x: [10, 20, 30],
+      y: [0.1, 0.2, 0.3],
+      bandwidth: 1,
+    }));
+    const onShowModesChange = jest.fn();
+
+    render(
+      <CommonGraph
+        baseValues={[1, 2]}
+        newValues={[3, 4]}
+        unit='ms'
+        isSubtest={false}
+        vt={0.5}
+        onVtChange={jest.fn()}
+        showModes={true}
+        onShowModesChange={onShowModesChange}
+      />,
+    );
+
+    const checkbox = screen.getByRole('checkbox', { name: /show modes/i });
+    fireEvent.click(checkbox);
+    expect(onShowModesChange).toHaveBeenCalledWith(false);
   });
 });

--- a/src/__tests__/CompareResults/CommonGraph.test.tsx
+++ b/src/__tests__/CompareResults/CommonGraph.test.tsx
@@ -414,4 +414,66 @@ describe('CommonGraph', () => {
     expect(overlays[0].markLine?.label?.formatter).toMatch(/^Base A: 30/);
     expect(overlays[1].markLine?.label?.formatter).toMatch(/^New A: 30/);
   });
+
+  it('shows raw run values in the scatter tooltip with the unit suffix', () => {
+    (fftkde as jest.Mock).mockImplementation(() => ({
+      x: [10, 20, 30],
+      y: [0.1, 0.2, 0.3],
+      bandwidth: 1,
+    }));
+
+    render(
+      <CommonGraph
+        baseValues={[1, 2]}
+        newValues={[3, 4]}
+        unit='ms'
+        isSubtest={false}
+        vt={0.5}
+        onVtChange={jest.fn()}
+      />,
+    );
+
+    const formatter = getTooltipFormatter(getLatestEChartsOption());
+    // The formatter inspects items[0].seriesType to pick between scatter and
+    // KDE rendering — pass a scatter-shaped item to exercise the scatter path.
+    const rendered = formatter([
+      {
+        seriesType: 'scatter',
+        seriesName: 'Base',
+        value: [12.5, 0],
+        marker: '[m]',
+      },
+    ] as unknown as Parameters<typeof formatter>[0]);
+    expect(rendered).toBe('[m]Base: 12.50 (ms)');
+  });
+
+  it("labels the scatter y-axis as 'Base' for 0 and 'New' for 1", () => {
+    (fftkde as jest.Mock).mockImplementation(() => ({
+      x: [10, 20, 30],
+      y: [0.1, 0.2, 0.3],
+      bandwidth: 1,
+    }));
+
+    render(
+      <CommonGraph
+        baseValues={[1, 2]}
+        newValues={[3, 4]}
+        unit='ms'
+        isSubtest={false}
+        vt={0.5}
+        onVtChange={jest.fn()}
+      />,
+    );
+
+    const option = getLatestEChartsOption();
+    const yAxes = option.yAxis as Array<{
+      axisLabel?: { formatter?: (v: number) => string };
+    }>;
+    const scatterYAxisFormatter = yAxes[1]?.axisLabel?.formatter;
+    expect(scatterYAxisFormatter).toBeDefined();
+    expect(scatterYAxisFormatter!(0)).toBe('Base');
+    expect(scatterYAxisFormatter!(1)).toBe('New');
+    // Anything else returns empty so intermediate jitter values stay unlabelled.
+    expect(scatterYAxisFormatter!(0.5)).toBe('');
+  });
 });

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -89,6 +89,36 @@ exports[`Results View Should display Base, New and Common graphs with replicates
               50
               %
             </span>
+            <label
+              class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-qhrps9-MuiFormControlLabel-root"
+            >
+              <span
+                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-1nff2up-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+              >
+                <input
+                  checked=""
+                  class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
+                  data-indeterminate="false"
+                  type="checkbox"
+                />
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                  data-testid="CheckBoxIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                  />
+                </svg>
+              </span>
+              <span
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-n290n7-MuiTypography-root"
+              >
+                Show modes
+              </span>
+            </label>
           </div>
           <div
             class="MuiBox-root css-72fd9l"
@@ -601,6 +631,36 @@ exports[`Results View Should display Base, New and Common graphs with tooltips 1
               50
               %
             </span>
+            <label
+              class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-qhrps9-MuiFormControlLabel-root"
+            >
+              <span
+                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeSmall css-1nff2up-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+              >
+                <input
+                  checked=""
+                  class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
+                  data-indeterminate="false"
+                  type="checkbox"
+                />
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                  data-testid="CheckBoxIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                  />
+                </svg>
+              </span>
+              <span
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-n290n7-MuiTypography-root"
+              >
+                Show modes
+              </span>
+            </label>
           </div>
           <div
             class="MuiBox-root css-72fd9l"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Results View Should display Base, New and Common graphs with replicates
 <section
   aria-label="Revision Row Details"
   class="MuiBox-root css-13s8wtg"
-  id="_r_c3_"
+  id="_r_c4_"
 >
   <div
     class="MuiStack-root css-1714cpj-MuiStack-root"
@@ -31,10 +31,70 @@ exports[`Results View Should display Base, New and Common graphs with replicates
             Runs Density Distribution
           </h3>
           <div
+            class="MuiBox-root css-1ntc4s6"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 css-ftpr4e-MuiTypography-root"
+            >
+              Valley depth threshold
+              <svg
+                aria-hidden="true"
+                aria-label="A valley between two peaks must be shallower than this fraction of the shorter peak to count as a mode boundary. Higher = more splits detected."
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-86dkbz-MuiSvgIcon-root"
+                data-mui-internal-clone-element="true"
+                data-testid="InfoOutlinedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8"
+                />
+              </svg>
+              :
+            </span>
+            <span
+              class="MuiSlider-root MuiSlider-colorPrimary MuiSlider-sizeSmall css-hrrccv-MuiSlider-root"
+            >
+              <span
+                class="MuiSlider-rail css-r64h58-MuiSlider-rail"
+              />
+              <span
+                class="MuiSlider-track css-1iqz70e-MuiSlider-track"
+                style="left: 0%; width: 44.9438202247191%;"
+              />
+              <span
+                class="MuiSlider-thumb MuiSlider-thumbSizeSmall MuiSlider-thumbColorPrimary MuiSlider-thumb MuiSlider-thumbSizeSmall MuiSlider-thumbColorPrimary css-1rsdqdo-MuiSlider-thumb"
+                data-index="0"
+                style="left: 44.9438202247191%;"
+              >
+                <input
+                  aria-label="Valley depth threshold"
+                  aria-orientation="horizontal"
+                  aria-valuemax="0.99"
+                  aria-valuemin="0.1"
+                  aria-valuenow="0.5"
+                  data-index="0"
+                  max="0.99"
+                  min="0.1"
+                  step="0.01"
+                  style="border: 0px; height: 100%; margin: -1px; overflow: hidden; padding: 0px; position: absolute; white-space: nowrap; width: 100%; direction: ltr;"
+                  type="range"
+                  value="0.5"
+                />
+              </span>
+            </span>
+            <span
+              class="MuiTypography-root MuiTypography-body2 css-19x59xu-MuiTypography-root"
+            >
+              50
+              %
+            </span>
+          </div>
+          <div
             class="MuiBox-root css-72fd9l"
           >
             <div
-              style="width: 100%; height: 325px;"
+              style="width: 100%; height: 340px;"
             />
           </div>
         </div>
@@ -483,10 +543,70 @@ exports[`Results View Should display Base, New and Common graphs with tooltips 1
             Runs Density Distribution
           </h3>
           <div
+            class="MuiBox-root css-1ntc4s6"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 css-ftpr4e-MuiTypography-root"
+            >
+              Valley depth threshold
+              <svg
+                aria-hidden="true"
+                aria-label="A valley between two peaks must be shallower than this fraction of the shorter peak to count as a mode boundary. Higher = more splits detected."
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-86dkbz-MuiSvgIcon-root"
+                data-mui-internal-clone-element="true"
+                data-testid="InfoOutlinedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8"
+                />
+              </svg>
+              :
+            </span>
+            <span
+              class="MuiSlider-root MuiSlider-colorPrimary MuiSlider-sizeSmall css-hrrccv-MuiSlider-root"
+            >
+              <span
+                class="MuiSlider-rail css-r64h58-MuiSlider-rail"
+              />
+              <span
+                class="MuiSlider-track css-1iqz70e-MuiSlider-track"
+                style="left: 0%; width: 44.9438202247191%;"
+              />
+              <span
+                class="MuiSlider-thumb MuiSlider-thumbSizeSmall MuiSlider-thumbColorPrimary MuiSlider-thumb MuiSlider-thumbSizeSmall MuiSlider-thumbColorPrimary css-1rsdqdo-MuiSlider-thumb"
+                data-index="0"
+                style="left: 44.9438202247191%;"
+              >
+                <input
+                  aria-label="Valley depth threshold"
+                  aria-orientation="horizontal"
+                  aria-valuemax="0.99"
+                  aria-valuemin="0.1"
+                  aria-valuenow="0.5"
+                  data-index="0"
+                  max="0.99"
+                  min="0.1"
+                  step="0.01"
+                  style="border: 0px; height: 100%; margin: -1px; overflow: hidden; padding: 0px; position: absolute; white-space: nowrap; width: 100%; direction: ltr;"
+                  type="range"
+                  value="0.5"
+                />
+              </span>
+            </span>
+            <span
+              class="MuiTypography-root MuiTypography-body2 css-19x59xu-MuiTypography-root"
+            >
+              50
+              %
+            </span>
+          </div>
+          <div
             class="MuiBox-root css-72fd9l"
           >
             <div
-              style="width: 100%; height: 325px;"
+              style="width: 100%; height: 340px;"
             />
           </div>
         </div>

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -2643,7 +2643,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                           aria-invalid="false"
                           aria-label="Search by title"
                           class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-3v3un6-MuiInputBase-input-MuiOutlinedInput-input"
-                          id="_r_r3_"
+                          id="_r_r9_"
                           placeholder="Filter results"
                           type="search"
                           value=""
@@ -3153,7 +3153,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_r9_"
+                    aria-controls="_r_rf_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -3329,7 +3329,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_rc_"
+                    aria-controls="_r_ri_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -3492,7 +3492,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_rf_"
+                    aria-controls="_r_rl_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -3655,7 +3655,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_ri_"
+                    aria-controls="_r_ro_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -3818,7 +3818,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_rl_"
+                    aria-controls="_r_rr_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -4239,7 +4239,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                           aria-invalid="false"
                           aria-label="Search by title"
                           class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-3v3un6-MuiInputBase-input-MuiOutlinedInput-input"
-                          id="_r_ob_"
+                          id="_r_og_"
                           placeholder="Filter results"
                           type="search"
                           value=""
@@ -4749,7 +4749,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_oh_"
+                    aria-controls="_r_om_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -4925,7 +4925,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_ok_"
+                    aria-controls="_r_op_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -5088,7 +5088,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_on_"
+                    aria-controls="_r_os_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -5251,7 +5251,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_oq_"
+                    aria-controls="_r_ov_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -5414,7 +5414,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_ot_"
+                    aria-controls="_r_p2_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -5835,7 +5835,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                           aria-invalid="false"
                           aria-label="Search by title"
                           class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-3v3un6-MuiInputBase-input-MuiOutlinedInput-input"
-                          id="_r_en_"
+                          id="_r_eq_"
                           placeholder="Filter results"
                           type="search"
                           value=""
@@ -6345,7 +6345,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_et_"
+                    aria-controls="_r_f0_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -6521,7 +6521,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_f0_"
+                    aria-controls="_r_f3_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -6684,7 +6684,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_f3_"
+                    aria-controls="_r_f6_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -6847,7 +6847,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_f6_"
+                    aria-controls="_r_f9_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -7010,7 +7010,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_f9_"
+                    aria-controls="_r_fc_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -7431,7 +7431,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                           aria-invalid="false"
                           aria-label="Search by title"
                           class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-3v3un6-MuiInputBase-input-MuiOutlinedInput-input"
-                          id="_r_bv_"
+                          id="_r_c1_"
                           placeholder="Filter results"
                           type="search"
                           value=""
@@ -7939,7 +7939,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_c5_"
+                    aria-controls="_r_c7_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -8087,7 +8087,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_c8_"
+                    aria-controls="_r_ca_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -8235,7 +8235,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_cb_"
+                    aria-controls="_r_cd_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -8383,7 +8383,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_ce_"
+                    aria-controls="_r_cg_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -8531,7 +8531,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_ch_"
+                    aria-controls="_r_cj_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"

--- a/src/__tests__/kdeModes.test.ts
+++ b/src/__tests__/kdeModes.test.ts
@@ -1,0 +1,211 @@
+import {
+  areaFracs,
+  assignLetters,
+  fitModesFromKde,
+  matchModes,
+  splitByMode,
+} from '../utils/kde.js';
+
+// Build a synthetic KDE: a sum of narrow Gaussian bumps on a uniform grid.
+// Useful for tests that need a curve with known peak locations.
+function gaussianBumps(
+  grid: { lo: number; hi: number; n: number },
+  bumps: Array<{ mu: number; sigma: number; weight: number }>,
+) {
+  const { lo, hi, n } = grid;
+  const x: number[] = [];
+  const y: number[] = [];
+  for (let i = 0; i < n; i++) {
+    const xi = lo + ((hi - lo) * i) / (n - 1);
+    let yi = 0;
+    for (const { mu, sigma, weight } of bumps) {
+      yi +=
+        (weight * Math.exp(-((xi - mu) ** 2) / (2 * sigma ** 2))) /
+        (sigma * Math.sqrt(2 * Math.PI));
+    }
+    x.push(xi);
+    y.push(yi);
+  }
+  return { x, y };
+}
+
+describe('areaFracs', () => {
+  it('integrates a flat curve uniformly across buckets', () => {
+    // Constant y over [0, 10] with one boundary at 5 → two equal halves.
+    const x = Array.from({ length: 101 }, (_, i) => i * 0.1);
+    const y = x.map(() => 1);
+    const fracs = areaFracs(x, y, [5]);
+    expect(fracs).toHaveLength(2);
+    expect(fracs[0]).toBeCloseTo(0.5, 5);
+    expect(fracs[1]).toBeCloseTo(0.5, 5);
+  });
+
+  it('weights area toward whichever side has more density', () => {
+    // Triangle from y=2 at x=0 down to y=0 at x=10; boundary at 5 splits a
+    // 3:1 area ratio (left half integrates to 7.5, right half to 2.5).
+    const x = Array.from({ length: 101 }, (_, i) => i * 0.1);
+    const y = x.map((xi) => Math.max(0, 2 - xi * 0.2));
+    const fracs = areaFracs(x, y, [5]);
+    expect(fracs[0]).toBeCloseTo(0.75, 2);
+    expect(fracs[1]).toBeCloseTo(0.25, 2);
+  });
+
+  it('falls back to uniform fractions when total area is zero', () => {
+    const x = [0, 1, 2, 3];
+    const y = [0, 0, 0, 0];
+    expect(areaFracs(x, y, [1.5])).toEqual([0.5, 0.5]);
+  });
+
+  it('handles no boundaries (everything in one bucket)', () => {
+    const x = Array.from({ length: 11 }, (_, i) => i);
+    const y = x.map(() => 1);
+    const fracs = areaFracs(x, y, []);
+    expect(fracs).toEqual([1]);
+  });
+});
+
+describe('fitModesFromKde', () => {
+  it('returns a single mode for a unimodal curve', () => {
+    const { x, y } = gaussianBumps({ lo: 0, hi: 100, n: 1024 }, [
+      { mu: 50, sigma: 5, weight: 1 },
+    ]);
+    const modes = fitModesFromKde(x, y, 0.5);
+    expect(modes.peakLocs).toHaveLength(1);
+    expect(modes.peakLocs[0]).toBeCloseTo(50, 0);
+    expect(modes.boundaries).toEqual([]);
+  });
+
+  it('detects two well-separated modes', () => {
+    const { x, y } = gaussianBumps({ lo: 0, hi: 100, n: 1024 }, [
+      { mu: 20, sigma: 3, weight: 1 },
+      { mu: 80, sigma: 3, weight: 1 },
+    ]);
+    const modes = fitModesFromKde(x, y, 0.5);
+    expect(modes.peakLocs).toHaveLength(2);
+    expect(modes.peakLocs[0]).toBeCloseTo(20, 0);
+    expect(modes.peakLocs[1]).toBeCloseTo(80, 0);
+    expect(modes.boundaries).toHaveLength(1);
+    expect(modes.boundaries[0]).toBeGreaterThan(20);
+    expect(modes.boundaries[0]).toBeLessThan(80);
+  });
+
+  it('collapses overlapping bumps when valley is shallow (vt strict)', () => {
+    // Two nearby bumps share a shallow valley. vt = 0.1 (strict) keeps them
+    // merged, vt = 0.9 (lenient) splits them.
+    const { x, y } = gaussianBumps({ lo: 0, hi: 100, n: 1024 }, [
+      { mu: 48, sigma: 5, weight: 1 },
+      { mu: 56, sigma: 5, weight: 1 },
+    ]);
+    const strict = fitModesFromKde(x, y, 0.1);
+    const lenient = fitModesFromKde(x, y, 0.99);
+    expect(strict.peakLocs).toHaveLength(1);
+    // Lenient may still merge depending on the valley depth — what matters
+    // is that strict ≤ lenient mode count, never the other way around.
+    expect(lenient.peakLocs.length).toBeGreaterThanOrEqual(
+      strict.peakLocs.length,
+    );
+  });
+
+  it('applies the minimum-separation guard on near-integer data', () => {
+    // Two bumps closer than minSep = max(2, 5% of range) — they're > 5%
+    // valley-deep but < 2 units apart, so the guard collapses them.
+    const { x, y } = gaussianBumps({ lo: 0, hi: 100, n: 1024 }, [
+      { mu: 50, sigma: 0.3, weight: 1 },
+      { mu: 51, sigma: 0.3, weight: 1 },
+    ]);
+    const modes = fitModesFromKde(x, y, 0.9);
+    expect(modes.peakLocs).toHaveLength(1);
+  });
+
+  it('returns the global max location when no peak clears mpf', () => {
+    // Strictly increasing curve has no interior local maxima.
+    const x = Array.from({ length: 100 }, (_, i) => i);
+    const y = x.map((xi) => xi);
+    const modes = fitModesFromKde(x, y, 0.5);
+    expect(modes.peakLocs).toEqual([99]);
+    expect(modes.boundaries).toEqual([]);
+  });
+});
+
+describe('assignLetters', () => {
+  it('assigns A to the smallest location', () => {
+    expect(assignLetters([30, 10, 20])).toEqual(['C', 'A', 'B']);
+  });
+
+  it('preserves a single mode as A', () => {
+    expect(assignLetters([42])).toEqual(['A']);
+  });
+
+  it('handles already-sorted input', () => {
+    expect(assignLetters([1, 2, 3, 4])).toEqual(['A', 'B', 'C', 'D']);
+  });
+});
+
+describe('matchModes', () => {
+  it('pairs modes by proximity when counts match', () => {
+    // Base modes at 10, 90; new modes at 12, 88 — should match index-to-index.
+    const result = matchModes([10, 90], [0.5, 0.5], [12, 88], [0.5, 0.5]);
+    expect(result.pairs).toEqual([
+      [0, 0],
+      [1, 1],
+    ]);
+    expect(result.ub).toEqual([]);
+    expect(result.un).toEqual([]);
+  });
+
+  it('flips pairing when the closer match crosses indices', () => {
+    // Base at [10, 90], new at [85, 15]: indices are reversed, so the optimal
+    // pairing crosses: base[0] ↔ new[1], base[1] ↔ new[0].
+    const result = matchModes([10, 90], [0.5, 0.5], [85, 15], [0.5, 0.5]);
+    expect(result.pairs).toEqual([
+      [0, 1],
+      [1, 0],
+    ]);
+  });
+
+  it('reports unmatched new modes when new has more than base', () => {
+    const result = matchModes([50], [1], [10, 50, 90], [0.3, 0.4, 0.3]);
+    expect(result.pairs).toEqual([[0, 1]]);
+    expect(result.ub).toEqual([]);
+    expect(result.un.sort()).toEqual([0, 2]);
+  });
+
+  it('reports unmatched base modes when base has more than new', () => {
+    const result = matchModes([10, 50, 90], [0.3, 0.4, 0.3], [50], [1]);
+    expect(result.pairs).toEqual([[1, 0]]);
+    expect(result.un).toEqual([]);
+    expect(result.ub.sort()).toEqual([0, 2]);
+  });
+
+  it('returns empty pairs when either side is empty', () => {
+    expect(matchModes([], [], [10], [1])).toEqual({
+      pairs: [],
+      ub: [],
+      un: [0],
+    });
+    expect(matchModes([10], [1], [], [])).toEqual({
+      pairs: [],
+      ub: [0],
+      un: [],
+    });
+  });
+});
+
+describe('splitByMode', () => {
+  it('buckets samples by boundary', () => {
+    expect(splitByMode([1, 3, 5, 7, 9], [4, 8])).toEqual([[1, 3], [5, 7], [9]]);
+  });
+
+  it('puts samples equal to a boundary into the lower bucket', () => {
+    // splitByMode uses v > boundary, so boundary values go into bucket[m-1].
+    expect(splitByMode([5], [5])).toEqual([[5], []]);
+  });
+
+  it('handles no boundaries (one bucket with everything)', () => {
+    expect(splitByMode([1, 2, 3], [])).toEqual([[1, 2, 3]]);
+  });
+
+  it('returns empty buckets for empty data', () => {
+    expect(splitByMode([], [4, 8])).toEqual([[], [], []]);
+  });
+});

--- a/src/__tests__/utils/setupTests.ts
+++ b/src/__tests__/utils/setupTests.ts
@@ -52,7 +52,13 @@ jest.mock('echarts', () => ({
 }));
 const MockedEchartsInit = echartsInit as jest.Mock;
 
+// Partial mock: only fftkde is mocked (each test sets its own implementation).
+// The mode-detection helpers (argrelmax, fitModesFromKde, areaFracs, …) keep
+// their real implementations so unit tests can exercise them directly.
 jest.mock('../../utils/kde.js', () => ({
+  ...jest.requireActual<typeof import('../../utils/kde.js')>(
+    '../../utils/kde.js',
+  ),
   fftkde: jest.fn(),
 }));
 const MockedFftkde = fftkde as jest.Mock;

--- a/src/components/CompareResults/CommonGraph.tsx
+++ b/src/components/CompareResults/CommonGraph.tsx
@@ -2,6 +2,8 @@ import { useEffect, useMemo, useRef } from 'react';
 
 import InfoIcon from '@mui/icons-material/InfoOutlined';
 import Box from '@mui/material/Box';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
 import Slider from '@mui/material/Slider';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
@@ -184,6 +186,8 @@ function CommonGraph({
   isSubtest,
   vt,
   onVtChange,
+  showModes,
+  onShowModesChange,
 }: CommonGraphProps) {
   const chartContainerRef = useRef<HTMLDivElement | null>(null);
   const chartInstanceRef = useRef<ECharts | null>(null);
@@ -320,8 +324,10 @@ function CommonGraph({
         });
       });
     }
-    pushOverlays(0, 'Base', baseModes, Colors.ChartBase);
-    pushOverlays(1, 'New', newModes, Colors.ChartNew);
+    if (showModes) {
+      pushOverlays(0, 'Base', baseModes, Colors.ChartBase);
+      pushOverlays(1, 'New', newModes, Colors.ChartNew);
+    }
 
     return {
       animation: false,
@@ -537,7 +543,7 @@ function CommonGraph({
         ...((modeOverlays ?? []) as []),
       ],
     };
-  }, [baseValues, newValues, unit, isSubtest, vt, themeMode]);
+  }, [baseValues, newValues, unit, isSubtest, vt, themeMode, showModes]);
 
   useEffect(() => {
     if (!chartContainerRef.current) {
@@ -601,6 +607,7 @@ function CommonGraph({
           min={VT_MIN}
           max={VT_MAX}
           step={VT_STEP}
+          disabled={!showModes}
           onChange={(_, value) => onVtChange(value)}
           aria-label='Valley depth threshold'
           sx={{ maxWidth: 240 }}
@@ -611,6 +618,17 @@ function CommonGraph({
         >
           {Math.round(vt * 100)}%
         </Typography>
+        <FormControlLabel
+          control={
+            <Checkbox
+              size='small'
+              checked={showModes}
+              onChange={(_, checked) => onShowModesChange(checked)}
+            />
+          }
+          label='Show modes'
+          sx={{ ml: 1, '& .MuiFormControlLabel-label': { fontSize: 14 } }}
+        />
       </Box>
       <Box sx={{ flex: 0 }}>
         <div
@@ -629,6 +647,8 @@ interface CommonGraphProps {
   isSubtest: boolean;
   vt: number;
   onVtChange: (value: number) => void;
+  showModes: boolean;
+  onShowModesChange: (value: boolean) => void;
 }
 
 export default CommonGraph;

--- a/src/components/CompareResults/CommonGraph.tsx
+++ b/src/components/CompareResults/CommonGraph.tsx
@@ -601,9 +601,7 @@ function CommonGraph({
           min={VT_MIN}
           max={VT_MAX}
           step={VT_STEP}
-          onChange={(_, value) =>
-            onVtChange(typeof value === 'number' ? value : value[0])
-          }
+          onChange={(_, value) => onVtChange(value)}
           aria-label='Valley depth threshold'
           sx={{ maxWidth: 240 }}
         />

--- a/src/components/CompareResults/CommonGraph.tsx
+++ b/src/components/CompareResults/CommonGraph.tsx
@@ -197,13 +197,14 @@ function CommonGraph({
   // hex values into the chart option below.
   const themeMode = useAppSelector((state) => state.theme.mode);
 
-  const option: EChartsOption = useMemo(() => {
-    const textColor =
-      themeMode === 'dark' ? Colors.PrimaryTextDark : Colors.PrimaryText;
+  // Vt-independent precompute: KDE, shared-grid resample, scatter jitter, and
+  // axis bounds. Pulled out of the main option memo so dragging the valley-
+  // depth slider doesn't (a) re-run the expensive fftkde call and (b) reroll
+  // Math.random() jitter — which made the scatter dots visibly jump while
+  // tuning the threshold.
+  const analysis = useMemo(() => {
     const statsForBase = computeStatisticsForRuns(baseValues);
     const statsForNew = computeStatisticsForRuns(newValues);
-
-    // Compute the global min and max with some grace value.
     const min = computeMin(statsForBase?.min, statsForNew?.min) * 0.95;
     const max = computeMax(statsForBase?.max, statsForNew?.max) * 1.05;
 
@@ -250,11 +251,6 @@ function CommonGraph({
       ? sharedX.map((xCoord, i) => [xCoord, newY[i]])
       : [];
 
-    const unitSuffix = unit ? ` (${unit})` : '';
-
-    const totalCount = baseValues.length + newValues.length;
-    const symbolSize = totalCount < 20 ? 14 : 10;
-
     const JITTER = 0.6;
     // Base sits on the top row (y = 1), New on the bottom row (y = 0).
     const baseScatterData: [number, number][] = baseValues.map((v) => [
@@ -265,6 +261,42 @@ function CommonGraph({
       v,
       (Math.random() - 0.5) * JITTER,
     ]);
+
+    return {
+      bKde,
+      nKde,
+      sharedX,
+      baseY,
+      newY,
+      baseRunsDensity,
+      newRunsDensity,
+      baseScatterData,
+      newScatterData,
+      min,
+      max,
+    };
+  }, [baseValues, newValues, isSubtest]);
+
+  const option: EChartsOption = useMemo(() => {
+    const textColor =
+      themeMode === 'dark' ? Colors.PrimaryTextDark : Colors.PrimaryText;
+    const {
+      bKde,
+      nKde,
+      sharedX,
+      baseY,
+      newY,
+      baseRunsDensity,
+      newRunsDensity,
+      baseScatterData,
+      newScatterData,
+      min,
+      max,
+    } = analysis;
+
+    const unitSuffix = unit ? ` (${unit})` : '';
+    const totalCount = baseValues.length + newValues.length;
+    const symbolSize = totalCount < 20 ? 14 : 10;
 
     // Mode detection on the shared-grid curves so peak x-coords align across series.
     const baseModes = bKde
@@ -543,7 +575,7 @@ function CommonGraph({
         ...((modeOverlays ?? []) as []),
       ],
     };
-  }, [baseValues, newValues, unit, isSubtest, vt, themeMode, showModes]);
+  }, [analysis, baseValues, newValues, unit, vt, themeMode, showModes]);
 
   useEffect(() => {
     if (!chartContainerRef.current) {

--- a/src/components/CompareResults/CommonGraph.tsx
+++ b/src/components/CompareResults/CommonGraph.tsx
@@ -338,9 +338,13 @@ function CommonGraph({
     const totalCount = baseValues.length + newValues.length;
     const symbolSize = totalCount < 20 ? 14 : 10;
 
-    // Build the per-peak markLine overlays. Each is a dataless line series so
-    // the markLine renders on its own. Names start with "_mode-" so the tooltip
-    // and legend can filter them out.
+    // Build the per-peak markLine overlays. Each is a dataless line series
+    // whose markLine renders on its own. They share names with their parent
+    // series ('Base' / 'New') so the legend's toggle action cascades to the
+    // overlays automatically — clicking 'Base' hides every series named
+    // 'Base', including the overlays. The legend itself only renders the two
+    // entries listed in `legend.data` regardless of how many series share
+    // those names.
     const modeOverlays: EChartsOption['series'] = [];
     function pushOverlays(
       seriesIdx: 0 | 1,
@@ -351,7 +355,7 @@ function CommonGraph({
       modes.peakLocs.forEach((loc, peakIdx) => {
         const level = levelLookup.get(`${seriesIdx}-${peakIdx}`) ?? 0;
         (modeOverlays as unknown[]).push({
-          name: `_mode-${seriesIdx}-${peakIdx}`,
+          name: seriesName,
           type: 'line',
           xAxisIndex: 0,
           yAxisIndex: 0,

--- a/src/components/CompareResults/CommonGraph.tsx
+++ b/src/components/CompareResults/CommonGraph.tsx
@@ -1,12 +1,20 @@
 import { useEffect, useMemo, useRef } from 'react';
 
+import InfoIcon from '@mui/icons-material/InfoOutlined';
 import Box from '@mui/material/Box';
+import Slider from '@mui/material/Slider';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { init, type ECharts, type EChartsOption } from 'echarts';
 
 import { useAppSelector } from '../../hooks/app';
 import { Colors } from '../../styles/Colors';
-import { fftkde } from '../../utils/kde.js';
+import {
+  areaFracs,
+  assignLetters,
+  fftkde,
+  fitModesFromKde,
+} from '../../utils/kde.js';
 
 // This computes the min, max from a list of numbers.
 function computeStatisticsForRuns(data: number[]) {
@@ -36,10 +44,70 @@ function computeMax(a?: number, b?: number) {
   return Math.max(a, b);
 }
 
-const CHART_HEIGHT = 325;
+const CHART_HEIGHT = 340;
 const KDE_GRID_POINTS = 1024;
 const KDE_GRID = { left: 70, right: 70, top: 28, height: 155 };
-const SCATTER_GRID = { left: 70, right: 70, top: 238, height: 50 };
+const SCATTER_GRID = { left: 70, right: 70, top: 250, height: 50 };
+
+// Valley-depth threshold bounds for the mode-detection slider.
+const VT_MIN = 0.1;
+const VT_MAX = 0.99;
+const VT_STEP = 0.01;
+
+// Tick labels show 2 dp for fractional values, drop ".00" for whole numbers.
+// Floats near integers (e.g. 14 + 1e-15) collapse to "14".
+function tickFormatter(value: number): string {
+  const rounded = Math.round(value);
+  if (Math.abs(value - rounded) < 1e-9) return String(rounded);
+  return value.toFixed(2);
+}
+
+// Per-series mode summary, suitable both for chart overlays and the blurb.
+type ModeInfo = {
+  peakLocs: number[];
+  fracs: number[];
+  letters: string[];
+};
+
+function computeModeInfo(x: number[], y: number[], vt: number): ModeInfo {
+  if (!x.length || !y.length) {
+    return { peakLocs: [], fracs: [], letters: [] };
+  }
+  const { peakLocs, boundaries } = fitModesFromKde(x, y, vt);
+  if (!peakLocs.length) {
+    return { peakLocs: [], fracs: [], letters: [] };
+  }
+  const fracs = areaFracs(x, y, boundaries);
+  const letters = assignLetters(peakLocs);
+  return { peakLocs, fracs, letters };
+}
+
+// Stagger levels (0, 1, 2 …) for peak labels: peaks closer than ~13% of the
+// x-span get bumped to different levels so their labels don't overlap. Ported
+// from kde-widget.js's allPeaks.level pass; we use a fixed 13% threshold
+// because the chart's pixel width isn't known inside useMemo.
+type PeakRef = {
+  loc: number;
+  seriesIdx: number;
+  peakIdx: number;
+  level: number;
+};
+
+function assignStaggerLevels(peaks: PeakRef[], xSpan: number): void {
+  peaks.sort((a, b) => a.loc - b.loc);
+  const threshold = xSpan * 0.13;
+  for (let idx = 0; idx < peaks.length; idx++) {
+    const used = new Set<number>();
+    for (let k = 0; k < idx; k++) {
+      if (Math.abs(peaks[k].loc - peaks[idx].loc) < threshold) {
+        used.add(peaks[k].level);
+      }
+    }
+    let level = 0;
+    while (used.has(level)) level++;
+    peaks[idx].level = level;
+  }
+}
 
 function quantileSorted(sorted: number[], q: number): number {
   const pos = (sorted.length - 1) * q;
@@ -114,6 +182,8 @@ function CommonGraph({
   newValues,
   unit,
   isSubtest,
+  vt,
+  onVtChange,
 }: CommonGraphProps) {
   const chartContainerRef = useRef<HTMLDivElement | null>(null);
   const chartInstanceRef = useRef<ECharts | null>(null);
@@ -192,11 +262,66 @@ function CommonGraph({
       (Math.random() - 0.5) * JITTER,
     ]);
 
-    const tickFormatter = (value: number) => {
-      const rounded = Math.round(value);
-      if (Math.abs(value - rounded) < 1e-9) return String(rounded);
-      return value.toFixed(2);
-    };
+    // Mode detection on the shared-grid curves so peak x-coords align across series.
+    const baseModes = bKde
+      ? computeModeInfo(sharedX, baseY, vt)
+      : { peakLocs: [], fracs: [], letters: [] };
+    const newModes = nKde
+      ? computeModeInfo(sharedX, newY, vt)
+      : { peakLocs: [], fracs: [], letters: [] };
+
+    // Assign vertical stagger levels across all peaks so labels don't collide.
+    const allPeaks: PeakRef[] = [];
+    baseModes.peakLocs.forEach((loc, peakIdx) =>
+      allPeaks.push({ loc, seriesIdx: 0, peakIdx, level: 0 }),
+    );
+    newModes.peakLocs.forEach((loc, peakIdx) =>
+      allPeaks.push({ loc, seriesIdx: 1, peakIdx, level: 0 }),
+    );
+    const xSpan = max - min;
+    if (xSpan > 0) assignStaggerLevels(allPeaks, xSpan);
+    const levelLookup = new Map<string, number>();
+    for (const p of allPeaks) {
+      levelLookup.set(`${p.seriesIdx}-${p.peakIdx}`, p.level);
+    }
+
+    // Build the per-peak markLine overlays. Each is a dataless line series so
+    // the markLine renders on its own. Names start with "_mode-" so the tooltip
+    // and legend can filter them out.
+    const modeOverlays: EChartsOption['series'] = [];
+    function pushOverlays(
+      seriesIdx: 0 | 1,
+      seriesName: 'Base' | 'New',
+      modes: ModeInfo,
+      color: string,
+    ) {
+      modes.peakLocs.forEach((loc, peakIdx) => {
+        const level = levelLookup.get(`${seriesIdx}-${peakIdx}`) ?? 0;
+        (modeOverlays as unknown[]).push({
+          name: `_mode-${seriesIdx}-${peakIdx}`,
+          type: 'line',
+          xAxisIndex: 0,
+          yAxisIndex: 0,
+          data: [],
+          markLine: {
+            silent: true,
+            symbol: 'none',
+            data: [{ xAxis: loc }],
+            lineStyle: { color, type: 'solid', width: 1.5 },
+            label: {
+              formatter:
+                `${seriesName} ${modes.letters[peakIdx]}: ` +
+                `${tickFormatter(loc)} (${Math.round(modes.fracs[peakIdx] * 100)}%)`,
+              distance: [0, level * 16],
+              color,
+              fontSize: 12,
+            },
+          },
+        });
+      });
+    }
+    pushOverlays(0, 'Base', baseModes, Colors.ChartBase);
+    pushOverlays(1, 'New', newModes, Colors.ChartNew);
 
     return {
       animation: false,
@@ -317,7 +442,9 @@ function CommonGraph({
       },
       legend: {
         data: ['Base', 'New'],
-        top: 4,
+        // Sit below the centered x-axis unit label, between the KDE grid and
+        // the scatter strip, with a small gap above and below.
+        top: 232,
         left: 'center',
         itemHeight: 10,
         itemWidth: 30,
@@ -407,9 +534,10 @@ function CommonGraph({
             },
           },
         },
+        ...((modeOverlays ?? []) as []),
       ],
     };
-  }, [baseValues, newValues, unit, isSubtest, themeMode]);
+  }, [baseValues, newValues, unit, isSubtest, vt, themeMode]);
 
   useEffect(() => {
     if (!chartContainerRef.current) {
@@ -437,6 +565,55 @@ function CommonGraph({
       <Typography id='retrigger-modal-title' component='h3' variant='h3'>
         Runs Density Distribution
       </Typography>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1.5,
+          mt: 1,
+          mb: 0.5,
+        }}
+      >
+        <Typography
+          variant='body2'
+          sx={{
+            color: '#000',
+            whiteSpace: 'nowrap',
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          Valley depth threshold
+          <Tooltip
+            placement='top'
+            title='A valley between two peaks must be shallower than this fraction of the shorter peak to count as a mode boundary. Higher = more splits detected.'
+          >
+            <InfoIcon
+              fontSize='small'
+              sx={{ color: '#000', cursor: 'help', mx: 0.5 }}
+            />
+          </Tooltip>
+          :
+        </Typography>
+        <Slider
+          size='small'
+          value={vt}
+          min={VT_MIN}
+          max={VT_MAX}
+          step={VT_STEP}
+          onChange={(_, value) =>
+            onVtChange(typeof value === 'number' ? value : value[0])
+          }
+          aria-label='Valley depth threshold'
+          sx={{ maxWidth: 240 }}
+        />
+        <Typography
+          variant='body2'
+          sx={{ color: '#555', minWidth: 36, textAlign: 'right' }}
+        >
+          {Math.round(vt * 100)}%
+        </Typography>
+      </Box>
       <Box sx={{ flex: 0 }}>
         <div
           ref={chartContainerRef}
@@ -452,6 +629,8 @@ interface CommonGraphProps {
   newValues: number[];
   unit: string | null;
   isSubtest: boolean;
+  vt: number;
+  onVtChange: (value: number) => void;
 }
 
 export default CommonGraph;

--- a/src/components/CompareResults/CommonGraph.tsx
+++ b/src/components/CompareResults/CommonGraph.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import InfoIcon from '@mui/icons-material/InfoOutlined';
 import Box from '@mui/material/Box';
@@ -197,6 +197,16 @@ function CommonGraph({
   // hex values into the chart option below.
   const themeMode = useAppSelector((state) => state.theme.mode);
 
+  // Local mirror of vt that drives the slider thumb + percentage during drag.
+  // We only push the value up to the parent (via onVtChange) when the user
+  // releases the slider — keeping mode detection from re-running on every
+  // pixel of slider movement. Synced back to the prop so external resets
+  // still work.
+  const [localVt, setLocalVt] = useState(vt);
+  useEffect(() => {
+    setLocalVt(vt);
+  }, [vt]);
+
   // Vt-independent precompute: KDE, shared-grid resample, scatter jitter, and
   // axis bounds. Pulled out of the main option memo so dragging the valley-
   // depth slider doesn't (a) re-run the expensive fftkde call and (b) reroll
@@ -277,28 +287,15 @@ function CommonGraph({
     };
   }, [baseValues, newValues, isSubtest]);
 
-  const option: EChartsOption = useMemo(() => {
-    const textColor =
-      themeMode === 'dark' ? Colors.PrimaryTextDark : Colors.PrimaryText;
-    const {
-      bKde,
-      nKde,
-      sharedX,
-      baseY,
-      newY,
-      baseRunsDensity,
-      newRunsDensity,
-      baseScatterData,
-      newScatterData,
-      min,
-      max,
-    } = analysis;
+  // Mode detection (peaks, area fractions, label assignment, stagger levels)
+  // lives in its own memo so it only re-runs when `vt` or the underlying
+  // curves change — not on theme switch, scatter strip toggle, or unit
+  // changes. `fitModesFromKde` is non-trivial work (argrelmax + valley/area
+  // filtering on a 1024-point grid for each series), so keeping it out of
+  // the option-building memo's deps avoids wasted recomputes.
+  const modes = useMemo(() => {
+    const { bKde, nKde, sharedX, baseY, newY, min, max } = analysis;
 
-    const unitSuffix = unit ? ` (${unit})` : '';
-    const totalCount = baseValues.length + newValues.length;
-    const symbolSize = totalCount < 20 ? 14 : 10;
-
-    // Mode detection on the shared-grid curves so peak x-coords align across series.
     const baseModes = bKde
       ? computeModeInfo(sharedX, baseY, vt)
       : { peakLocs: [], fracs: [], letters: [] };
@@ -320,6 +317,26 @@ function CommonGraph({
     for (const p of allPeaks) {
       levelLookup.set(`${p.seriesIdx}-${p.peakIdx}`, p.level);
     }
+
+    return { baseModes, newModes, levelLookup };
+  }, [analysis, vt]);
+
+  const option: EChartsOption = useMemo(() => {
+    const textColor =
+      themeMode === 'dark' ? Colors.PrimaryTextDark : Colors.PrimaryText;
+    const {
+      baseRunsDensity,
+      newRunsDensity,
+      baseScatterData,
+      newScatterData,
+      min,
+      max,
+    } = analysis;
+    const { baseModes, newModes, levelLookup } = modes;
+
+    const unitSuffix = unit ? ` (${unit})` : '';
+    const totalCount = baseValues.length + newValues.length;
+    const symbolSize = totalCount < 20 ? 14 : 10;
 
     // Build the per-peak markLine overlays. Each is a dataless line series so
     // the markLine renders on its own. Names start with "_mode-" so the tooltip
@@ -575,7 +592,7 @@ function CommonGraph({
         ...((modeOverlays ?? []) as []),
       ],
     };
-  }, [analysis, baseValues, newValues, unit, vt, themeMode, showModes]);
+  }, [analysis, modes, baseValues, newValues, unit, themeMode, showModes]);
 
   useEffect(() => {
     if (!chartContainerRef.current) {
@@ -633,14 +650,23 @@ function CommonGraph({
           </Tooltip>
           :
         </Typography>
+        {/*
+          MUI Slider exposes two events: `onChange` fires continuously during
+          drag (we send it to local state for a smooth thumb), and
+          `onChangeCommitted` fires once when the user releases (we push the
+          final value up to the parent then). This is the moral equivalent of
+          a debounce — the expensive consumer (`computeModeInfo`) runs once
+          per drag instead of on every pixel of movement.
+        */}
         <Slider
           size='small'
-          value={vt}
+          value={localVt}
           min={VT_MIN}
           max={VT_MAX}
           step={VT_STEP}
           disabled={!showModes}
-          onChange={(_, value) => onVtChange(value)}
+          onChange={(_, value) => setLocalVt(value)}
+          onChangeCommitted={(_, value) => onVtChange(value)}
           aria-label='Valley depth threshold'
           sx={{ maxWidth: 240 }}
         />
@@ -648,7 +674,7 @@ function CommonGraph({
           variant='body2'
           sx={{ color: '#555', minWidth: 36, textAlign: 'right' }}
         >
-          {Math.round(vt * 100)}%
+          {Math.round(localVt * 100)}%
         </Typography>
         <FormControlLabel
           control={

--- a/src/components/CompareResults/RevisionRowExpandable.tsx
+++ b/src/components/CompareResults/RevisionRowExpandable.tsx
@@ -21,6 +21,7 @@ function RevisionRowExpandable(props: RevisionRowExpandableProps) {
   // chart. Lifted to this row so the future mode-blurb panel can read the same
   // detected modes without recomputing the KDE.
   const [vt, setVt] = useState(0.5);
+  const [showModes, setShowModes] = useState(true);
 
   const {
     base_runs: baseRuns,
@@ -80,6 +81,8 @@ function RevisionRowExpandable(props: RevisionRowExpandableProps) {
                   isSubtest={result.base_parent_signature !== null}
                   vt={vt}
                   onVtChange={setVt}
+                  showModes={showModes}
+                  onShowModesChange={setShowModes}
                 />
               )}
               {strategy.renderExpandedLeft(result)}

--- a/src/components/CompareResults/RevisionRowExpandable.tsx
+++ b/src/components/CompareResults/RevisionRowExpandable.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
 import Grid from '@mui/material/Grid';
@@ -14,6 +16,11 @@ const { singleRun } = Strings.components.expandableRow;
 
 function RevisionRowExpandable(props: RevisionRowExpandableProps) {
   const { result, id, testVersion } = props;
+
+  // Valley-depth threshold for the mode-detection slider rendered next to the
+  // chart. Lifted to this row so the future mode-blurb panel can read the same
+  // detected modes without recomputing the KDE.
+  const [vt, setVt] = useState(0.5);
 
   const {
     base_runs: baseRuns,
@@ -71,6 +78,8 @@ function RevisionRowExpandable(props: RevisionRowExpandableProps) {
                   newValues={newValues}
                   unit={baseUnit || newUnit}
                   isSubtest={result.base_parent_signature !== null}
+                  vt={vt}
+                  onVtChange={setVt}
                 />
               )}
               {strategy.renderExpandedLeft(result)}

--- a/src/utils/kde.d.ts
+++ b/src/utils/kde.d.ts
@@ -59,3 +59,35 @@ export declare function fitKdeModes(
   minPeakFraction?: number,
   minDataFraction?: number,
 ): KDEModeResult;
+export type FitModesFromKdeResult = {
+  peakLocs: number[];
+  boundaries: number[];
+};
+export declare function fitModesFromKde(
+  x: ArrayLike<number>,
+  y: ArrayLike<number>,
+  vt: number,
+  mpf?: number,
+  mdf?: number,
+): FitModesFromKdeResult;
+export declare function areaFracs(
+  x: ArrayLike<number>,
+  y: ArrayLike<number>,
+  boundaries: number[],
+): number[];
+export declare function assignLetters(locs: number[]): string[];
+export type MatchModesResult = {
+  pairs: Array<[number, number]>;
+  ub: number[];
+  un: number[];
+};
+export declare function matchModes(
+  bLocs: number[],
+  bFracs: number[],
+  nLocs: number[],
+  nFracs: number[],
+): MatchModesResult;
+export declare function splitByMode(
+  data: number[],
+  boundaries: number[],
+): number[][];

--- a/src/utils/kde.js
+++ b/src/utils/kde.js
@@ -583,6 +583,249 @@ export function argrelmax(y, order = 1) {
   return peaks;
 }
 // ---------------------------------------------------------------------------
+// Mode detection on a pre-computed KDE
+//
+// The helpers below operate on (x, y) arrays produced by fftkde rather than
+// running KDE themselves. This lets an interactive UI tune the valley-depth
+// threshold without recomputing the KDE on every change.
+// ---------------------------------------------------------------------------
+/**
+ * Compute the fraction of total KDE area falling in each mode bucket.
+ *
+ * Buckets are delimited by `boundaries`: bucket[0] covers x < boundaries[0],
+ * bucket[k] covers boundaries[k-1] < x ≤ boundaries[k], and the final bucket
+ * covers x > last boundary. Area is integrated via the trapezoid rule over
+ * the KDE grid.
+ *
+ * @param x          - KDE x grid
+ * @param y          - KDE density at each x
+ * @param boundaries - sorted mode boundaries (x values, increasing)
+ * @returns array of length boundaries.length + 1 summing to 1; falls back to
+ *          uniform 1/N if the total integrated area is zero
+ */
+export function areaFracs(x, y, boundaries) {
+  const buckets = new Array(boundaries.length + 1).fill(0);
+  let total = 0;
+  for (let i = 1; i < x.length; i++) {
+    const area = 0.5 * (y[i] + y[i - 1]) * (x[i] - x[i - 1]);
+    total += area;
+    let m = 0;
+    while (m < boundaries.length && x[i] > boundaries[m]) m++;
+    buckets[m] += area;
+  }
+  return total > 0
+    ? buckets.map((b) => b / total)
+    : buckets.map(() => 1 / buckets.length);
+}
+/**
+ * Detect modes from a pre-computed KDE curve.
+ *
+ * Like fitKdeModes but takes (x, y) instead of raw data, so an interactive
+ * widget can re-fit modes on a slider change without recomputing the KDE.
+ *
+ * Differences from fitKdeModes:
+ *   - Filters modes by KDE *area* (areaFracs) rather than the fraction of
+ *     raw data points falling in each bucket.
+ *   - Adds a minimum-separation guard: peaks closer than max(2, 5% of the x
+ *     range) collapse to the higher peak. This suppresses spurious modes
+ *     that KDE can produce on near-integer data (e.g. samples ∈ {0, 1}).
+ *
+ * @param x   - KDE x grid (uniform spacing)
+ * @param y   - KDE density at each x
+ * @param vt  - valley-depth threshold; the valley between two peaks must be
+ *              shallower than vt × min(peak heights) for them to count as
+ *              separate modes (0 = never split, 1 = always split)
+ * @param mpf - minimum peak height as a fraction of the global max (default 0.05)
+ * @param mdf - minimum area fraction a mode must contain to be kept (default 0.05)
+ * @returns { peakLocs, boundaries } in the same units as x
+ */
+export function fitModesFromKde(x, y, vt, mpf = 0.05, mdf = 0.05) {
+  let yMax = 0;
+  for (let i = 0; i < y.length; i++) if (y[i] > yMax) yMax = y[i];
+  const peaks = argrelmax(y, 3).filter((i) => y[i] >= mpf * yMax);
+  if (!peaks.length) {
+    let gm = 0;
+    for (let i = 1; i < y.length; i++) if (y[i] > y[gm]) gm = i;
+    return { peakLocs: [x[gm]], boundaries: [] };
+  }
+  // Valley-depth filter — walk peaks left to right, keeping a peak only if
+  // the valley between it and the previous kept peak is deep enough.
+  const good = [peaks[0]];
+  for (let k = 1; k < peaks.length; k++) {
+    const nxt = peaks[k];
+    const prev = good[good.length - 1];
+    let valleyMin = y[prev];
+    for (let j = prev; j <= nxt; j++) if (y[j] < valleyMin) valleyMin = y[j];
+    if (valleyMin < vt * Math.min(y[prev], y[nxt])) {
+      good.push(nxt);
+    } else if (y[nxt] > y[good[good.length - 1]]) {
+      good[good.length - 1] = nxt;
+    }
+  }
+  function computeBoundaries(ps) {
+    const bs = [];
+    for (let i = 0; i < ps.length - 1; i++) {
+      let mi = ps[i];
+      for (let j = ps[i]; j <= ps[i + 1]; j++) if (y[j] < y[mi]) mi = j;
+      bs.push(x[mi]);
+    }
+    return bs;
+  }
+  // Area-fraction filter — drop modes whose KDE area is below mdf.
+  const bs0 = computeBoundaries(good);
+  const fr0 = areaFracs(x, y, bs0);
+  const keep = good.map((_, i) => i).filter((i) => fr0[i] >= mdf);
+  if (keep.length < 2) {
+    const bp = good.reduce((a, b) => (y[a] > y[b] ? a : b));
+    return { peakLocs: [x[bp]], boundaries: [] };
+  }
+  const fg = keep.map((i) => good[i]);
+  const fb = computeBoundaries(fg);
+  const locs = fg.map((i) => x[i]);
+  // Minimum-separation guard: KDE artefacts on near-integer data can put
+  // distinct peaks within a sample of each other. Collapse those to one.
+  const dataRange = x[x.length - 1] - x[0];
+  const minSep = Math.max(2, dataRange * 0.05);
+  for (let k = 1; k < locs.length; k++) {
+    if (locs[k] - locs[k - 1] < minSep) {
+      const bestIdx = fg.reduce((a, b) => (y[a] > y[b] ? a : b));
+      return { peakLocs: [x[bestIdx]], boundaries: [] };
+    }
+  }
+  return { peakLocs: locs, boundaries: fb };
+}
+/**
+ * Assign single-letter labels to modes, with A = lowest peak location.
+ *
+ * Performance convention: A is the fastest (lowest) path, B is the next,
+ * etc. Locations don't need to be pre-sorted — this function sorts internally
+ * and returns letters in the *original* input order, so out[i] is the letter
+ * for locs[i].
+ *
+ * @param locs - array of peak x positions
+ * @returns array of single-character letter labels, same length as locs
+ */
+export function assignLetters(locs) {
+  const idx = locs.map((_, i) => i).sort((a, b) => locs[a] - locs[b]);
+  const out = new Array(locs.length);
+  idx.forEach((i, rank) => {
+    out[i] = String.fromCharCode(65 + rank);
+  });
+  return out;
+}
+function popcount(x) {
+  let c = 0;
+  let v = x;
+  while (v) {
+    c += v & 1;
+    v >>>= 1;
+  }
+  return c;
+}
+function range(n) {
+  return Array.from({ length: n }, (_, i) => i);
+}
+/**
+ * Pair modes between base and comparison runs by minimum total distance.
+ *
+ * When comparing base vs. new, mode A in the base may correspond to mode B
+ * in the new run (same code path, just shifted or re-ordered by peak height).
+ * Naive index-by-index matching can pair the wrong paths.
+ *
+ * Solves a minimum-cost assignment problem: pair each base mode to a new
+ * mode so the total distance is minimised, where distance is
+ *   0.75 × |bLoc - nLoc| / span + 0.25 × |bFrac - nFrac|
+ *
+ * Uses bitmask DP over subsets of new modes — exact, and fast for the small
+ * mode counts seen in practice (n, m ≤ ~8).
+ *
+ * @returns { pairs, ub, un }
+ *   pairs : array of [baseIdx, newIdx] tuples
+ *   ub    : base indices with no match (path disappeared)
+ *   un    : new indices with no match (new path appeared)
+ */
+export function matchModes(bLocs, bFracs, nLocs, nFracs) {
+  const n = bLocs.length;
+  const m = nLocs.length;
+  if (!n || !m) return { pairs: [], ub: range(n), un: range(m) };
+  // If base has more modes than new, swap roles and flip the resulting pairs.
+  if (n > m) {
+    const sw = matchModes(nLocs, nFracs, bLocs, bFracs);
+    return {
+      pairs: sw.pairs.map((p) => [p[1], p[0]]),
+      ub: sw.un,
+      un: sw.ub,
+    };
+  }
+  const all = bLocs.concat(nLocs);
+  const span = Math.max(...all) - Math.min(...all) || 1;
+  const cost = bLocs.map((bl, i) =>
+    nLocs.map(
+      (nl, j) =>
+        (0.75 * Math.abs(bl - nl)) / span +
+        0.25 * Math.abs(bFracs[i] - nFracs[j]),
+    ),
+  );
+  const INF = 1e9;
+  const states = 1 << m;
+  const dp = new Float64Array(states).fill(INF);
+  const prev = new Int16Array(states).fill(-1);
+  dp[0] = 0;
+  for (let mask = 0; mask < states; mask++) {
+    if (dp[mask] === INF) continue;
+    const i = popcount(mask);
+    if (i >= n) continue;
+    for (let j = 0; j < m; j++) {
+      if ((mask >> j) & 1) continue;
+      const nm = mask | (1 << j);
+      const c = dp[mask] + cost[i][j];
+      if (c < dp[nm]) {
+        dp[nm] = c;
+        prev[nm] = j;
+      }
+    }
+  }
+  let best = -1;
+  let bc = INF;
+  for (let mask = 0; mask < states; mask++) {
+    if (popcount(mask) === n && dp[mask] < bc) {
+      bc = dp[mask];
+      best = mask;
+    }
+  }
+  const pairs = [];
+  let cur = best;
+  for (let i = n - 1; i >= 0; i--) {
+    const j = prev[cur];
+    pairs.unshift([i, j]);
+    cur ^= 1 << j;
+  }
+  const mNew = new Set(pairs.map((p) => p[1]));
+  return { pairs, ub: [], un: range(m).filter((j) => !mNew.has(j)) };
+}
+/**
+ * Bucket raw samples into mode-aligned arrays.
+ *
+ * Returns buckets[0..boundaries.length], where buckets[k] holds samples
+ * with value > boundaries[k-1] and ≤ boundaries[k]. The first bucket has
+ * no lower bound, the last has no upper bound. Used to compute per-mode
+ * bootstrap CIs on the actual samples rather than on the KDE density.
+ *
+ * @param data       - raw sample values
+ * @param boundaries - sorted mode boundaries
+ * @returns array of bucketed sample arrays, length boundaries.length + 1
+ */
+export function splitByMode(data, boundaries) {
+  const buckets = boundaries.map(() => []);
+  buckets.push([]);
+  data.forEach((v) => {
+    let m = 0;
+    while (m < boundaries.length && v > boundaries[m]) m++;
+    buckets[m].push(v);
+  });
+  return buckets;
+}
+// ---------------------------------------------------------------------------
 // fitKdeModes — port of perf_compare_stats.fit_kde_modes
 //
 // Runs FFTKDE with ISJ bandwidth, finds local maxima, applies valley-depth

--- a/src/utils/kde.js
+++ b/src/utils/kde.js
@@ -725,6 +725,11 @@ function popcount(x) {
 function range(n) {
   return Array.from({ length: n }, (_, i) => i);
 }
+// `matchModes` and `splitByMode` below are intentionally unused
+// in this PR — they're the pure-logic helpers that the follow-up
+// `KdeModesPanel` (per-mode blurb) will consume. They live here so the
+// follow-up PR stays focused on the UI rather than re-introducing utility
+// code, and they're exercised by kdeModes.test.ts.
 /**
  * Pair modes between base and comparison runs by minimum total distance.
  *


### PR DESCRIPTION
[See Bug 2044194](https://bugzilla.mozilla.org/show_bug.cgi?id=2044194)

This PR adds client-side KDE mode detection by porting the pure-logic helpers (`fitModesFromKde, areaFracs, assignLetters, matchModes, splitByMode`) from the [`kde-widget `](https://github.com/padenot/perfcompare-new-stats/blob/main/standalone-stats/kde-widget.js) into `src/utils/kde.js`. See Paul's example [here](https://paul.cx/public/example-output.html).

It wires those helpers into `CommonGraph` so detected peaks render as labelled vertical markers on the KDE chart (e.g. "Base A: 12.34 (45%)"). Also adds the interactive valley-depth slider — with the threshold state lifted to `RevisionRowExpandable` so the upcoming mode-blurb panel can read the same modes without recomputing the KDE. 

Includes unit tests for the new pure functions and updated CommonGraph tests covering the slider props and mode-overlay series. 

Note: There's still more work to do like the upcoming blurb panel but didn't want to overload this PR by touching too many different files.

[
Deploy Link](https://deploy-preview-1045--mozilla-perfcompare.netlify.app/compare-results?baseRev=29a14637a9d81a23621ff9e0e555a4f958aca482&baseRepo=mozilla-central&newRev=ee0e0aa2307fae09742d269717b416b918b1e96e&newRepo=mozilla-central&newRev=59a2ff528e3bee0556fc2dfac7b3bee390367e70&newRepo=mozilla-central&newRev=cc299aa6a1cb20497aee5004231a0c0a0be1d0d1&newRepo=mozilla-central&framework=1&filter_status=improvement%2Cregression)

<img width="1370" height="641" alt="Screenshot 2026-06-09 at 09 42 30" src="https://github.com/user-attachments/assets/ba7d2c7f-05c0-48c9-a636-010ce8f8da28" />

