### PR TITLE
Bug 2034263: Give subtest column in subtest page a max-width

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -1106,7 +1106,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 />
               </div>
               <div
-                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -1242,7 +1242,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   </div>
                 </div>
                 <div
-                  class="cell MuiBox-root css-172osot"
+                  class="cell MuiBox-root css-ddfjla"
                   role="cell"
                 >
                   <button
@@ -1268,7 +1268,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -1390,7 +1390,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   </div>
                 </div>
                 <div
-                  class="cell MuiBox-root css-172osot"
+                  class="cell MuiBox-root css-ddfjla"
                   role="cell"
                 >
                   <button
@@ -1416,7 +1416,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -1538,7 +1538,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   </div>
                 </div>
                 <div
-                  class="cell MuiBox-root css-172osot"
+                  class="cell MuiBox-root css-ddfjla"
                   role="cell"
                 >
                   <button
@@ -1564,7 +1564,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -1686,7 +1686,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   </div>
                 </div>
                 <div
-                  class="cell MuiBox-root css-172osot"
+                  class="cell MuiBox-root css-ddfjla"
                   role="cell"
                 >
                   <button
@@ -1712,7 +1712,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -1834,7 +1834,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   </div>
                 </div>
                 <div
-                  class="cell MuiBox-root css-172osot"
+                  class="cell MuiBox-root css-ddfjla"
                   role="cell"
                 >
                   <button
@@ -3011,7 +3011,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 />
               </div>
               <div
-                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -3149,7 +3149,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   </div>
                 </div>
                 <div
-                  class="cell MuiBox-root css-172osot"
+                  class="cell MuiBox-root css-ddfjla"
                   role="cell"
                 >
                   <button
@@ -3175,7 +3175,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -3325,7 +3325,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   </div>
                 </div>
                 <div
-                  class="cell MuiBox-root css-172osot"
+                  class="cell MuiBox-root css-ddfjla"
                   role="cell"
                 >
                   <button
@@ -3351,7 +3351,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -3488,7 +3488,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   </div>
                 </div>
                 <div
-                  class="cell MuiBox-root css-172osot"
+                  class="cell MuiBox-root css-ddfjla"
                   role="cell"
                 >
                   <button
@@ -3514,7 +3514,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -3651,7 +3651,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   </div>
                 </div>
                 <div
-                  class="cell MuiBox-root css-172osot"
+                  class="cell MuiBox-root css-ddfjla"
                   role="cell"
                 >
                   <button
@@ -3677,7 +3677,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -3814,7 +3814,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   </div>
                 </div>
                 <div
-                  class="cell MuiBox-root css-172osot"
+                  class="cell MuiBox-root css-ddfjla"
                   role="cell"
                 >
                   <button
@@ -4607,7 +4607,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 />
               </div>
               <div
-                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -4745,7 +4745,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   </div>
                 </div>
                 <div
-                  class="cell MuiBox-root css-172osot"
+                  class="cell MuiBox-root css-ddfjla"
                   role="cell"
                 >
                   <button
@@ -4771,7 +4771,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -4921,7 +4921,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   </div>
                 </div>
                 <div
-                  class="cell MuiBox-root css-172osot"
+                  class="cell MuiBox-root css-ddfjla"
                   role="cell"
                 >
                   <button
@@ -4947,7 +4947,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -5084,7 +5084,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   </div>
                 </div>
                 <div
-                  class="cell MuiBox-root css-172osot"
+                  class="cell MuiBox-root css-ddfjla"
                   role="cell"
                 >
                   <button
@@ -5110,7 +5110,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -5247,7 +5247,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   </div>
                 </div>
                 <div
-                  class="cell MuiBox-root css-172osot"
+                  class="cell MuiBox-root css-ddfjla"
                   role="cell"
                 >
                   <button
@@ -5273,7 +5273,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -5410,7 +5410,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   </div>
                 </div>
                 <div
-                  class="cell MuiBox-root css-172osot"
+                  class="cell MuiBox-root css-ddfjla"
                   role="cell"
                 >
                   <button
@@ -6203,7 +6203,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                 />
               </div>
               <div
-                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -6341,7 +6341,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   </div>
                 </div>
                 <div
-                  class="cell MuiBox-root css-172osot"
+                  class="cell MuiBox-root css-ddfjla"
                   role="cell"
                 >
                   <button
@@ -6367,7 +6367,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                 </div>
               </div>
               <div
-                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -6517,7 +6517,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   </div>
                 </div>
                 <div
-                  class="cell MuiBox-root css-172osot"
+                  class="cell MuiBox-root css-ddfjla"
                   role="cell"
                 >
                   <button
@@ -6543,7 +6543,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                 </div>
               </div>
               <div
-                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -6680,7 +6680,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   </div>
                 </div>
                 <div
-                  class="cell MuiBox-root css-172osot"
+                  class="cell MuiBox-root css-ddfjla"
                   role="cell"
                 >
                   <button
@@ -6706,7 +6706,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                 </div>
               </div>
               <div
-                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -6843,7 +6843,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   </div>
                 </div>
                 <div
-                  class="cell MuiBox-root css-172osot"
+                  class="cell MuiBox-root css-ddfjla"
                   role="cell"
                 >
                   <button
@@ -6869,7 +6869,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                 </div>
               </div>
               <div
-                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -7006,7 +7006,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   </div>
                 </div>
                 <div
-                  class="cell MuiBox-root css-172osot"
+                  class="cell MuiBox-root css-ddfjla"
                   role="cell"
                 >
                   <button
@@ -7799,7 +7799,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 />
               </div>
               <div
-                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -7935,7 +7935,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   </div>
                 </div>
                 <div
-                  class="cell MuiBox-root css-172osot"
+                  class="cell MuiBox-root css-ddfjla"
                   role="cell"
                 >
                   <button
@@ -7961,7 +7961,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -8083,7 +8083,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   </div>
                 </div>
                 <div
-                  class="cell MuiBox-root css-172osot"
+                  class="cell MuiBox-root css-ddfjla"
                   role="cell"
                 >
                   <button
@@ -8109,7 +8109,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -8231,7 +8231,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   </div>
                 </div>
                 <div
-                  class="cell MuiBox-root css-172osot"
+                  class="cell MuiBox-root css-ddfjla"
                   role="cell"
                 >
                   <button
@@ -8257,7 +8257,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -8379,7 +8379,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   </div>
                 </div>
                 <div
-                  class="cell MuiBox-root css-172osot"
+                  class="cell MuiBox-root css-ddfjla"
                   role="cell"
                 >
                   <button
@@ -8405,7 +8405,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
                 role="row"
               >
                 <div
@@ -8527,7 +8527,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   </div>
                 </div>
                 <div
-                  class="cell MuiBox-root css-172osot"
+                  class="cell MuiBox-root css-ddfjla"
                   role="cell"
                 >
                   <button

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsRevisionRow.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsRevisionRow.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`SubtestsRevisionRow Component renders browser name when base and new ap
 <body>
   <div>
     <div
-      class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-1uflkrc"
+      class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1uflkrc"
       role="row"
     >
       <div
@@ -150,7 +150,7 @@ exports[`SubtestsRevisionRow Component renders browser name when base and new ap
         </div>
       </div>
       <div
-        class="cell MuiBox-root css-172osot"
+        class="cell MuiBox-root css-ddfjla"
         role="cell"
       >
         <button
@@ -183,7 +183,7 @@ exports[`SubtestsRevisionRow Component renders doesnt render browser name when b
 <body>
   <div>
     <div
-      class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-1uflkrc"
+      class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1uflkrc"
       role="row"
     >
       <div
@@ -304,7 +304,7 @@ exports[`SubtestsRevisionRow Component renders doesnt render browser name when b
         </div>
       </div>
       <div
-        class="cell MuiBox-root css-172osot"
+        class="cell MuiBox-root css-ddfjla"
         role="cell"
       >
         <button
@@ -337,7 +337,7 @@ exports[`SubtestsRevisionRow Component renders the component with correct data 1
 <body>
   <div>
     <div
-      class="revisionRow f1t3zec9 f1dlt78d MuiBox-root css-1uflkrc"
+      class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1uflkrc"
       role="row"
     >
       <div
@@ -458,7 +458,7 @@ exports[`SubtestsRevisionRow Component renders the component with correct data 1
         </div>
       </div>
       <div
-        class="cell MuiBox-root css-172osot"
+        class="cell MuiBox-root css-ddfjla"
         role="cell"
       >
         <button

--- a/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
@@ -38,7 +38,8 @@ const revisionRow = style({
     '.subtests': {
       borderRadius: '4px 0 0 4px',
       paddingLeft: Spacing.Medium, // Synchronize with its header
-      justifyContent: 'left',
+      maxWidth: '150px',
+      wordBreak: 'break-word',
     },
 
     '.status': {
@@ -159,7 +160,10 @@ function SubtestsRevisionRow(props: RevisionRowProps) {
         <Box
           className='cell'
           role='cell'
-          sx={{ backgroundColor: 'background.default' }}
+          sx={{
+            backgroundColor: 'background.default',
+            alignSelf: 'stretch',
+          }}
         >
           <IconButton
             title={


### PR DESCRIPTION
Quick PR to fix alignment issue with the subtest names in subtest results page. See [Bug 2034263](https://bugzilla.mozilla.org/show_bug.cgi?id=2034263)

[Production ](https://perf.compare/subtests-compare-results?baseRev=4fa704fed44d4d89db9f8055c67c7588b91fafa1&baseRepo=try&newRev=c58c27eeab4843a91a25499fdf12eb350b2f1c6c&newRepo=try&framework=12&baseParentSignature=5288973&newParentSignature=5288973&test_version=mann-whitney-u) vs [Deploy Link](https://deploy-preview-1047--mozilla-perfcompare.netlify.app/subtests-compare-results?baseRev=4fa704fed44d4d89db9f8055c67c7588b91fafa1&baseRepo=try&newRev=c58c27eeab4843a91a25499fdf12eb350b2f1c6c&newRepo=try&framework=12&baseParentSignature=5288973&newParentSignature=5288973&test_version=mann-whitney-u)
