### PR TITLE
Add median diff percentage to blue blurb in expanded view

### DIFF
--- a/src/__tests__/CompareResults/RevisionRow.test.tsx
+++ b/src/__tests__/CompareResults/RevisionRow.test.tsx
@@ -345,15 +345,17 @@ describe('Expanded row', () => {
     // Wait for the expanded panel before reading alert text content.
     await screen.findByText(/Cliff's Delta/);
 
-    // The summary alert is "Δ median = +7.6 ms 95% CI [..., ...]". The
-    // median-of-new minus median-of-base is 712.44 - 704.84 = +7.6.
+    // The summary alert is "Δ median = +7.6 ms (+1.1%) 95% CI [..., ...]".
+    // The median-of-new minus median-of-base is 712.44 - 704.84 = +7.6,
+    // and +7.6 / 704.84 * 100 ≈ +1.1%.
     const alerts = screen.getAllByRole('alert');
     const summaryAlert = alerts.find((alert) =>
       alert.textContent?.includes('Δ median'),
     );
     expect(summaryAlert).toBeDefined();
     expect(summaryAlert?.textContent).toContain('+7.6');
-    expect(summaryAlert?.textContent).toContain('ms 95% CI [');
+    expect(summaryAlert?.textContent).toMatch(/\(\+1\.1%\)/);
+    expect(summaryAlert?.textContent).toContain('95% CI [');
 
     // The confidence-interval alert is "Confidence Interval: We are 95% ...".
     const ciAlert = alerts.find((alert) =>

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -201,7 +201,8 @@ exports[`Results View Should display Base, New and Common graphs with replicates
                 </strong>
                  = 
                 +9.0
-                 ms 95% CI [
+                 ms
+                 95% CI [
                 +0.0
                 , 
                 +18.0
@@ -653,7 +654,8 @@ exports[`Results View Should display Base, New and Common graphs with tooltips 1
                 </strong>
                  = 
                 +8.7
-                 ms 95% CI [
+                 ms
+                 95% CI [
                 +3.6
                 , 
                 +18.5

--- a/src/common/testVersions/mannWhitney.tsx
+++ b/src/common/testVersions/mannWhitney.tsx
@@ -416,9 +416,13 @@ export const mannWhitneyStrategy = {
         ? bootstrapMedianDiffCI(baseRuns, newRuns)
         : null;
     const fmt = (n: number) => (n >= 0 ? '+' : '') + n.toFixed(1);
+    const baseMedian = mwResult.base_standard_stats?.median ?? 0;
+    const medianDiffPct =
+      ci && baseMedian !== 0 ? (ci.medianDiff / baseMedian) * 100 : null;
     const summary = ci ? (
       <span>
-        <strong>Δ median</strong> = {fmt(ci.medianDiff)} ms 95% CI [
+        <strong>Δ median</strong> = {fmt(ci.medianDiff)} ms
+        {medianDiffPct !== null && ` (${fmt(medianDiffPct)}%)`} 95% CI [
         {fmt(ci.ciLow)}, {fmt(ci.ciHigh)}]
         {ci.significant ? '' : '  (not significant)'}
       </span>


### PR DESCRIPTION
There was request to add the median percentage to the blue median difference blurb in the expanded section. Please check that the math is correct. 