### PR TITLE
Assorted fixes to improve the app when numbers are very large and not measuring time.

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,13 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh pr:*)",
+      "Bash(npm run:*)",
+      "Bash(python3:*)",
+      "Bash(node:*)",
+      "Bash(tail:*)",
+      "Bash(git add src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx && git rebase --continue 2>&1)",
+      "Bash(grep:*)"
+    ]
+  }
+}

--- a/src/__tests__/CompareResults/CommonGraph.test.tsx
+++ b/src/__tests__/CompareResults/CommonGraph.test.tsx
@@ -158,11 +158,12 @@ describe('CommonGraph', () => {
     expect(newAtTwenty?.[1]).toBe(0);
   });
 
-  it("falls back to Silverman's rule when ISJ bandwidth selection throws", () => {
-    // safeKde tries ISJ first; if that throws, it retries with 'silverman'.
-    (fftkde as jest.Mock).mockImplementation((_data: number[], bw: string) => {
-      if (bw === 'ISJ') {
-        throw new Error('ISJ failed to converge');
+  it("falls back to Silverman's rule when fftkde throws on the first attempt", () => {
+    // safeKde calls fftkde with the pre-computed numeric bandwidth first;
+    // if that throws it retries with 'silverman'.
+    (fftkde as jest.Mock).mockImplementation((_data: number[], bw: unknown) => {
+      if (typeof bw === 'number') {
+        throw new Error('fftkde failed to converge');
       }
       return { x: [10, 20, 30], y: [0.1, 0.2, 0.3], bandwidth: 1 };
     });
@@ -183,7 +184,6 @@ describe('CommonGraph', () => {
     const bandwidthArgs = (fftkde as jest.Mock).mock.calls.map(
       (call) => call[1] as string,
     );
-    expect(bandwidthArgs).toContain('ISJ');
     expect(bandwidthArgs).toContain('silverman');
 
     // The fallback output still drives a populated series.
@@ -341,14 +341,10 @@ describe('CommonGraph', () => {
     )[0];
     const format = xAxis.axisLabel.formatter;
 
-    // Whole numbers render without a trailing ".00".
-    expect(format(14)).toBe('14');
-    expect(format(0)).toBe('0');
-    expect(format(-7)).toBe('-7');
-
-    // Floats near integers (round-off) collapse to the bare integer.
-    expect(format(14 + 1e-12)).toBe('14');
-    expect(format(14 - 1e-12)).toBe('14');
+    // Values are scaled and formatted to the unit's decimal precision (2dp for ms).
+    expect(format(14)).toBe('14.00');
+    expect(format(0)).toBe('0.00');
+    expect(format(-7)).toBe('-7.00');
 
     // Fractional values render with 2 decimal places.
     expect(format(48.541)).toBe('48.54');

--- a/src/__tests__/CompareResults/RevisionRow.test.tsx
+++ b/src/__tests__/CompareResults/RevisionRow.test.tsx
@@ -345,15 +345,15 @@ describe('Expanded row', () => {
     // Wait for the expanded panel before reading alert text content.
     await screen.findByText(/Cliff's Delta/);
 
-    // The summary alert is "Δ median = +7.6 ms 95% CI [..., ...]". The
-    // median-of-new minus median-of-base is 712.44 - 704.84 = +7.6.
+    // The summary alert is "Δ median = +7.60 ms (+1.1%) 95% CI [..., ...]". The
+    // median-of-new minus median-of-base is 712.44 - 704.84 = +7.60.
     const alerts = screen.getAllByRole('alert');
     const summaryAlert = alerts.find((alert) =>
       alert.textContent?.includes('Δ median'),
     );
     expect(summaryAlert).toBeDefined();
-    expect(summaryAlert?.textContent).toContain('+7.6');
-    expect(summaryAlert?.textContent).toContain('ms 95% CI [');
+    expect(summaryAlert?.textContent).toContain('+7.60');
+    expect(summaryAlert?.textContent).toContain('ms');
 
     // The confidence-interval alert is "Confidence Interval: We are 95% ...".
     const ciAlert = alerts.find((alert) =>
@@ -423,7 +423,7 @@ describe('Expanded row', () => {
     const summaryAlert = alerts.find((alert) =>
       alert.textContent?.includes('Δ median'),
     );
-    expect(summaryAlert?.textContent).toContain('(not significant)');
+    expect(summaryAlert?.textContent).toContain('interval includes zero');
   });
 
   it('should display mean for base or new in row headers for mann-whitney-u testVersion', async () => {

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -290,13 +290,16 @@ exports[`Results View Should display Base, New and Common graphs with replicates
                   Δ median
                 </strong>
                  = 
-                +9.0
-                 ms 95% CI [
-                +0.0
+                +9.00
+                 
+                ms
+                 (+1.5%)
+                 
+                95% CI [
+                +0.00
                 , 
-                +18.0
+                +18.01
                 ]
-                  (not significant)
               </span>
             </div>
           </div>
@@ -329,12 +332,12 @@ exports[`Results View Should display Base, New and Common graphs with replicates
                 </strong>
                 : We are 95% confident the median difference is between 
                 <strong>
-                  +0.0
+                  +0.00
                 </strong>
                  and
                  
                 <strong>
-                  +18.0
+                  +18.01
                 </strong>
               </span>
             </div>
@@ -832,11 +835,15 @@ exports[`Results View Should display Base, New and Common graphs with tooltips 1
                   Δ median
                 </strong>
                  = 
-                +8.7
-                 ms 95% CI [
-                +3.6
+                +8.74
+                 
+                ms
+                 (+1.5%)
+                 
+                95% CI [
+                +3.27
                 , 
-                +18.5
+                +18.16
                 ]
               </span>
             </div>
@@ -870,12 +877,12 @@ exports[`Results View Should display Base, New and Common graphs with tooltips 1
                 </strong>
                 : We are 95% confident the median difference is between 
                 <strong>
-                  +3.6
+                  +3.27
                 </strong>
                  and
                  
                 <strong>
-                  +18.5
+                  +18.16
                 </strong>
               </span>
             </div>

--- a/src/common/testVersions/mannWhitney.tsx
+++ b/src/common/testVersions/mannWhitney.tsx
@@ -415,16 +415,30 @@ export const mannWhitneyStrategy = {
       baseRuns.length > 0 && newRuns.length > 0
         ? bootstrapMedianDiffCI(baseRuns, newRuns)
         : null;
-    const rawUnit = mwResult.base_measurement_unit ?? mwResult.new_measurement_unit ?? 'ms';
+    const rawUnit =
+      mwResult.base_measurement_unit ?? mwResult.new_measurement_unit ?? 'ms';
     const { fmt, displayUnit } = ci
       ? adaptUnit([ci.medianDiff, ci.ciLow, ci.ciHigh], rawUnit)
       : adaptUnit([], rawUnit);
     const ciCrossesZero = ci && ci.ciLow < 0 && ci.ciHigh > 0;
+    const baseMedian = (() => {
+      if (!baseRuns.length) return null;
+      const s = [...baseRuns].sort((a, b) => a - b);
+      const m = Math.floor(s.length / 2);
+      return s.length % 2 === 0 ? (s[m - 1] + s[m]) / 2 : s[m];
+    })();
+    const pctDiff =
+      baseMedian && ci ? ((ci.medianDiff / baseMedian) * 100).toFixed(1) : null;
     const summary = ci ? (
       <span>
-        <strong>Δ median</strong> = {fmt(ci.medianDiff)} {displayUnit} 95% CI [
-        {fmt(ci.ciLow)}, {fmt(ci.ciHigh)}]
-        {ciCrossesZero ? ' ⚠ interval includes zero — effect direction uncertain' : ''}
+        <strong>Δ median</strong> = {fmt(ci.medianDiff)} {displayUnit}
+        {pctDiff !== null
+          ? ` (${Number(pctDiff) >= 0 ? '+' : ''}${pctDiff}%)`
+          : ''}{' '}
+        95% CI [{fmt(ci.ciLow)}, {fmt(ci.ciHigh)}]
+        {ciCrossesZero
+          ? ' ⚠ interval includes zero — effect direction uncertain'
+          : ''}
       </span>
     ) : null;
     const confidenceInterval = ci && (

--- a/src/common/testVersions/mannWhitney.tsx
+++ b/src/common/testVersions/mannWhitney.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../types/state';
 import { TableConfig } from '../../types/types';
 import { bootstrapMedianDiffCI } from '../../utils/bootstrap-ci';
-import { formatNumber } from '../../utils/format';
+import { adaptUnit, formatNumber } from '../../utils/format';
 import { capitalize } from '../../utils/helpers';
 import { getBrowserDisplay, getPlatformShortName } from '../../utils/platform';
 import {
@@ -415,12 +415,16 @@ export const mannWhitneyStrategy = {
       baseRuns.length > 0 && newRuns.length > 0
         ? bootstrapMedianDiffCI(baseRuns, newRuns)
         : null;
-    const fmt = (n: number) => (n >= 0 ? '+' : '') + n.toFixed(1);
+    const rawUnit = mwResult.base_measurement_unit ?? mwResult.new_measurement_unit ?? 'ms';
+    const { fmt, displayUnit } = ci
+      ? adaptUnit([ci.medianDiff, ci.ciLow, ci.ciHigh], rawUnit)
+      : adaptUnit([], rawUnit);
+    const ciCrossesZero = ci && ci.ciLow < 0 && ci.ciHigh > 0;
     const summary = ci ? (
       <span>
-        <strong>Δ median</strong> = {fmt(ci.medianDiff)} ms 95% CI [
+        <strong>Δ median</strong> = {fmt(ci.medianDiff)} {displayUnit} 95% CI [
         {fmt(ci.ciLow)}, {fmt(ci.ciHigh)}]
-        {ci.significant ? '' : '  (not significant)'}
+        {ciCrossesZero ? ' ⚠ interval includes zero — effect direction uncertain' : ''}
       </span>
     ) : null;
     const confidenceInterval = ci && (

--- a/src/components/CompareResults/CommonGraph.tsx
+++ b/src/components/CompareResults/CommonGraph.tsx
@@ -11,11 +11,14 @@ import { init, type ECharts, type EChartsOption } from 'echarts';
 
 import { useAppSelector } from '../../hooks/app';
 import { Colors } from '../../styles/Colors';
+import { getDisplayScale } from '../../utils/format';
 import {
   areaFracs,
   assignLetters,
   fftkde,
   fitModesFromKde,
+  improvedSheatherJones,
+  silvermansRule,
 } from '../../utils/kde.js';
 
 // This computes the min, max from a list of numbers.
@@ -46,6 +49,10 @@ function computeMax(a?: number, b?: number) {
   return Math.max(a, b);
 }
 
+// Show the smoothing slider when the bandwidth exceeds half the data range —
+// at that point the KDE curve is genuinely flat and the user may want to dial
+// it down to see structure.
+const LARGE_BW_RATIO = 0.5;
 const KDE_GRID_POINTS = 1024;
 const LABEL_ROW_PX = 16; // vertical space per stagger level
 const KDE_TOP_BASE = 28;
@@ -138,6 +145,7 @@ function approximateSJBandwidth(sorted: number[]): number {
     sorted.reduce((sum, x) => sum + Math.pow(x - mean, 2), 0) / n,
   );
   const sigma = Math.min(std, iqr / 1.34);
+  if (sigma <= 0) return Math.abs(mean) * 0.001 || 1;
   return 0.9 * sigma * Math.pow(n, -1 / 5);
 }
 
@@ -150,7 +158,11 @@ function safeKde(values: number[], bw?: number) {
   try {
     return fftkde(values, bw ?? 'ISJ', undefined, KDE_GRID_POINTS);
   } catch {
-    return fftkde(values, 'silverman', undefined, KDE_GRID_POINTS);
+    try {
+      return fftkde(values, 'silverman', undefined, KDE_GRID_POINTS);
+    } catch {
+      return null;
+    }
   }
 }
 
@@ -200,6 +212,35 @@ function CommonGraph({
   // hex values into the chart option below.
   const themeMode = useAppSelector((state) => state.theme.mode);
 
+  const rawBandwidths = useMemo(() => {
+    const computeBw = (values: number[]) => {
+      if (values.length < 2) return undefined;
+      if (!isSubtest) {
+        return approximateSJBandwidth([...values].sort((a, b) => a - b));
+      }
+      try {
+        return improvedSheatherJones(values);
+      } catch {
+        return silvermansRule(values);
+      }
+    };
+    return { base: computeBw(baseValues), new: computeBw(newValues) };
+  }, [baseValues, newValues, isSubtest]);
+
+  const isLargeBw = useMemo(() => {
+    const allValues = [...baseValues, ...newValues];
+    if (allValues.length < 2) return false;
+    const lo = Math.min(...allValues);
+    const hi = Math.max(...allValues);
+    const range = hi - lo;
+    if (range === 0) return false;
+    const bw = Math.max(rawBandwidths?.base ?? 0, rawBandwidths?.new ?? 0);
+    return bw / range > LARGE_BW_RATIO;
+  }, [baseValues, newValues, rawBandwidths]);
+
+  const [bwMultiplier, setBwMultiplier] = useState(1.0);
+  useEffect(() => setBwMultiplier(1.0), [baseValues, newValues]);
+
   // Local mirror of vt that drives the slider thumb + percentage during drag.
   // We only push the value up to the parent (via onVtChange) when the user
   // releases the slider — keeping mode detection from re-running on every
@@ -218,25 +259,13 @@ function CommonGraph({
   const analysis = useMemo(() => {
     const statsForBase = computeStatisticsForRuns(baseValues);
     const statsForNew = computeStatisticsForRuns(newValues);
-    const min = computeMin(statsForBase?.min, statsForNew?.min) * 0.95;
-    const max = computeMax(statsForBase?.max, statsForNew?.max) * 1.05;
 
-    // Top-level results have fewer, more spread-out samples — use the SJ
-    // approximation for a wider (smoother) bandwidth. Subtest results have
-    // more data so ISJ can select a tighter, more accurate bandwidth.
-    let baseBw: number | undefined;
-    let newBw: number | undefined;
-    if (!isSubtest) {
-      const baseSorted = [...baseValues].sort((a, b) => a - b);
-      const newSorted = [...newValues].sort((a, b) => a - b);
-      baseBw =
-        baseSorted.length >= 2 ? approximateSJBandwidth(baseSorted) : undefined;
-      newBw =
-        newSorted.length >= 2 ? approximateSJBandwidth(newSorted) : undefined;
-    }
+    const sharedBw = rawBandwidths
+      ? Math.max(rawBandwidths.base ?? 0, rawBandwidths.new ?? 0) * bwMultiplier
+      : undefined;
 
-    const bKde = safeKde(baseValues, baseBw);
-    const nKde = safeKde(newValues, newBw);
+    const bKde = safeKde(baseValues, sharedBw);
+    const nKde = safeKde(newValues, sharedBw);
 
     // Build a shared x-grid covering both KDEs' ranges. Resampling both
     // curves onto identical x positions is what lets the axis-trigger tooltip
@@ -247,6 +276,32 @@ function CommonGraph({
       bKde?.x[bKde.x.length - 1],
       nKde?.x[nKde.x.length - 1],
     );
+
+    // Use the KDE grid extent as axis bounds — it is already padded by
+    // gaussianPracticalSupport(bandwidth) inside autogrid1D, so it scales
+    // correctly regardless of the absolute magnitude of the values.
+    // Fall back to additive range-based padding when no KDE is available.
+    let min: number;
+    let max: number;
+    if (Number.isFinite(xStart) && Number.isFinite(xEnd)) {
+      const pad = (xEnd - xStart) * 0.05;
+      min = xStart - pad;
+      max = xEnd + pad;
+    } else {
+      const dataMin = computeMin(statsForBase?.min, statsForNew?.min) ?? 0;
+      const dataMax = computeMax(statsForBase?.max, statsForNew?.max) ?? 0;
+      const pad = (dataMax - dataMin) * 0.05;
+      min = dataMin - pad;
+      max = dataMax + pad;
+    }
+    // When data is near-constant the axis range can be absurdly narrow.
+    // Enforce a minimum range of 1% of the midpoint value so ticks are readable.
+    const mid = (min + max) / 2;
+    const minRange = Math.abs(mid) * 0.01;
+    if (max - min < minRange) {
+      min = mid - minRange / 2;
+      max = mid + minRange / 2;
+    }
     const sharedX: number[] = [];
     if (Number.isFinite(xStart) && Number.isFinite(xEnd) && xEnd > xStart) {
       for (let i = 0; i < KDE_GRID_POINTS; i++) {
@@ -288,7 +343,7 @@ function CommonGraph({
       min,
       max,
     };
-  }, [baseValues, newValues, isSubtest]);
+  }, [baseValues, newValues, isSubtest, rawBandwidths, bwMultiplier]);
 
   // Mode detection (peaks, area fractions, label assignment, stagger levels)
   // lives in its own memo so it only re-runs when the threshold or the
@@ -352,9 +407,13 @@ function CommonGraph({
       height: SCATTER_HEIGHT,
     };
 
-    const unitSuffix = unit ? ` (${unit})` : '';
+    const { scale, displayUnit, decimals } = unit
+      ? getDisplayScale([min, max], unit)
+      : { scale: 1, displayUnit: unit ?? '', decimals: 2 };
+    const unitSuffix = displayUnit ? ` (${displayUnit})` : '';
     const totalCount = baseValues.length + newValues.length;
     const symbolSize = totalCount < 20 ? 14 : 10;
+    const tickFormatter = (value: number) => (value / scale).toFixed(decimals);
 
     // Build the per-peak markLine overlays. Each is a dataless line series
     // whose markLine renders on its own. They share names with their parent
@@ -411,12 +470,10 @@ function CommonGraph({
           type: 'value',
           min,
           max,
-          name: unit ?? '',
+          name: displayUnit,
           nameLocation: 'middle',
           nameGap: 30,
           nameTextStyle: { fontSize: 13, fontWeight: 'bold', color: textColor },
-          // Tick labels show 2 dp for fractional values, drop ".00" for whole
-          // numbers. Floats near integers (e.g. 14 + 1e-15) collapse to "14".
           axisLabel: { formatter: tickFormatter, color: textColor },
           splitLine: { show: true, lineStyle: { color: '#eee' } },
           axisLine: { show: true, lineStyle: { color: '#999' } },
@@ -494,7 +551,7 @@ function CommonGraph({
               .map((pts) => {
                 const marker = typeof pts.marker === 'string' ? pts.marker : '';
                 const xVal = (pts.value as [number, number])[0];
-                return `${marker}${pts.seriesName ?? ''}: ${xVal.toFixed(2)}${unitSuffix}`;
+                return `${marker}${pts.seriesName ?? ''}: ${(xVal / scale).toFixed(decimals)}${unitSuffix}`;
               })
               .join('<br>');
           }
@@ -502,7 +559,7 @@ function CommonGraph({
           const axisX =
             (items[0] as { axisValue?: number }).axisValue ??
             (items[0].value as [number, number])[0];
-          const header = `Value: ${Number(axisX).toFixed(2)}${unitSuffix}`;
+          const header = `Value: ${(Number(axisX) / scale).toFixed(decimals)}${unitSuffix}`;
           const lines = items.map((pts) => {
             const marker = typeof pts.marker === 'string' ? pts.marker : '';
             const y = (pts.value as [number, number])[1];
@@ -719,6 +776,23 @@ function CommonGraph({
           }}
         />
       </Box>
+      {isLargeBw && (
+        <Box sx={{ px: 2, pt: 0.5 }}>
+          <Typography variant='caption' color='text.secondary'>
+            High variance detected — smoothing ({bwMultiplier.toFixed(2)}×)
+          </Typography>
+          <Slider
+            size='small'
+            min={0.05}
+            max={1.5}
+            step={0.05}
+            value={bwMultiplier}
+            onChange={(_, v) => setBwMultiplier(v as number)}
+            valueLabelDisplay='auto'
+            valueLabelFormat={(v) => `${(v as number).toFixed(2)}×`}
+          />
+        </Box>
+      )}
     </>
   );
 }

--- a/src/components/CompareResults/CommonGraph.tsx
+++ b/src/components/CompareResults/CommonGraph.tsx
@@ -66,14 +66,6 @@ const VT_MIN = 0.1;
 const VT_MAX = 0.99;
 const VT_STEP = 0.01;
 
-// Tick labels show 2 dp for fractional values, drop ".00" for whole numbers.
-// Floats near integers (e.g. 14 + 1e-15) collapse to "14".
-function tickFormatter(value: number): string {
-  const rounded = Math.round(value);
-  if (Math.abs(value - rounded) < 1e-9) return String(rounded);
-  return value.toFixed(2);
-}
-
 // Per-series mode summary, suitable both for chart overlays and the blurb.
 type ModeInfo = {
   peakLocs: number[];
@@ -787,9 +779,9 @@ function CommonGraph({
             max={1.5}
             step={0.05}
             value={bwMultiplier}
-            onChange={(_, v) => setBwMultiplier(v as number)}
+            onChange={(_, v) => setBwMultiplier(v)}
             valueLabelDisplay='auto'
-            valueLabelFormat={(v) => `${(v as number).toFixed(2)}×`}
+            valueLabelFormat={(v) => `${v.toFixed(2)}×`}
           />
         </Box>
       )}

--- a/src/utils/bootstrap-ci.ts
+++ b/src/utils/bootstrap-ci.ts
@@ -1,7 +1,14 @@
 /**
- * Percentile bootstrap confidence interval for the difference of medians.
+ * BCa (bias-corrected and accelerated) bootstrap confidence interval for the
+ * difference of medians.
  *
- * No external dependencies.
+ * Matches scipy.stats.bootstrap(..., method='BCa', paired=False).
+ *
+ * References:
+ *   DiCiccio, T. J. & Efron, B. (1996): Bootstrap confidence intervals.
+ *     Statistical Science 11(3), 189-228.
+ *   Acklam, P. J. (2003): An algorithm for computing the inverse normal
+ *     cumulative distribution function.
  */
 
 function median(arr: ArrayLike<number>): number {
@@ -29,6 +36,87 @@ function mulberry32(seed: number): () => number {
   };
 }
 
+// Abramowitz & Stegun 7.1.26 — max error 1.5e-7
+function erf(x: number): number {
+  const t = 1 / (1 + 0.3275911 * Math.abs(x));
+  const p =
+    t *
+    (0.254829592 +
+      t * (-0.284496736 + t * (1.421413741 + t * (-1.453152027 + t * 1.061405429))));
+  return (x >= 0 ? 1 : -1) * (1 - p * Math.exp(-x * x));
+}
+
+function normalCDF(x: number): number {
+  return 0.5 * (1 + erf(x / Math.SQRT2));
+}
+
+// Acklam rational approximation — max absolute error 1.15e-9
+function normalPPF(p: number): number {
+  const a = [
+    -3.969683028665376e1, 2.20946098424520e2, -2.759285104469687e2,
+    1.38357751867269e2, -3.066479806614716e1, 2.506628277459239,
+  ];
+  const b = [
+    -5.447609879822406e1, 1.615858368580409e2, -1.556989798598866e2,
+    6.680131188771972e1, -1.328068155288572e1,
+  ];
+  const c = [
+    -7.784894002430293e-3, -3.223964580411365e-1, -2.400758277161838,
+    -2.549732539343734, 4.374664141464968, 2.938163982698783,
+  ];
+  const d = [
+    7.784695709041462e-3, 3.224671290700398e-1, 2.445134137142996,
+    3.754408661907416,
+  ];
+  const pLow = 0.02425;
+  if (p <= 0) return -Infinity;
+  if (p >= 1) return Infinity;
+  if (p < pLow) {
+    const q = Math.sqrt(-2 * Math.log(p));
+    return (
+      (((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) /
+      ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1)
+    );
+  }
+  if (p <= 1 - pLow) {
+    const q = p - 0.5;
+    const r = q * q;
+    return (
+      ((((((a[0] * r + a[1]) * r + a[2]) * r + a[3]) * r + a[4]) * r + a[5]) * q) /
+      (((((b[0] * r + b[1]) * r + b[2]) * r + b[3]) * r + b[4]) * r + 1)
+    );
+  }
+  const q = Math.sqrt(-2 * Math.log(1 - p));
+  return (
+    -(((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) /
+    ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1)
+  );
+}
+
+// Leave-one-out jackknife estimates of (median(new) - median(base)) for the
+// two-sample case: leave out each base observation in turn, then each new
+// observation in turn.
+function jackknifeDiffs(baseArr: Float64Array, newArr: Float64Array): number[] {
+  const medNew = median(newArr);
+  const medBase = median(baseArr);
+  const jack: number[] = [];
+  for (let i = 0; i < baseArr.length; i++) {
+    const leave = new Float64Array(baseArr.length - 1);
+    for (let j = 0, k = 0; j < baseArr.length; j++) {
+      if (j !== i) leave[k++] = baseArr[j];
+    }
+    jack.push(medNew - median(leave));
+  }
+  for (let i = 0; i < newArr.length; i++) {
+    const leave = new Float64Array(newArr.length - 1);
+    for (let j = 0, k = 0; j < newArr.length; j++) {
+      if (j !== i) leave[k++] = newArr[j];
+    }
+    jack.push(median(leave) - medBase);
+  }
+  return jack;
+}
+
 export type BootstrapCI = {
   medianDiff: number;
   ciLow: number;
@@ -37,55 +125,70 @@ export type BootstrapCI = {
 };
 
 /**
- * Percentile bootstrap confidence interval for (median(newData) - median(base)).
- * Matches scipy.stats.bootstrap(..., method="percentile", paired=False).
+ * BCa bootstrap confidence interval for (median(newData) - median(base)).
  *
- * How it works
- * ------------
- * A confidence interval answers: "given the samples we observed, what is the
- * plausible range for the true difference?"  The bootstrap approach avoids
- * assumptions about the underlying distribution (normality, etc.) by
- * simulating the sampling process directly:
+ * BCa improves on the basic percentile method by correcting for:
+ *   - Bias: the bootstrap distribution may be shifted relative to the true
+ *     sampling distribution (z0, the bias-correction factor).
+ *   - Skewness: the interval may need to be asymmetric (a, the acceleration,
+ *     estimated via leave-one-out jackknife).
  *
- *   1. Draw nIter synthetic datasets by sampling WITH replacement from each
- *      input array (a "resample" — same size, but some values repeat and some
- *      are absent).
- *   2. Compute (median(resampledNew) - median(resampledBase)) for each pair.
- *   3. Sort the resulting nIter differences.
- *   4. The CI is the [alpha/2, 1-alpha/2] percentile range of that distribution.
- *
- * If the CI does not straddle zero, the difference is statistically significant
- * at the chosen alpha level.
- *
- * @param base    - baseline sample values (e.g. before-patch timings)
- * @param newData - new/comparison sample values (e.g. after-patch timings)
- * @param nIter   - number of bootstrap resamples; 1000 is sufficient for most
- *                  uses, increase to 10 000 for publication-quality intervals
- * @param alpha   - two-tailed significance level: the CI covers (1-alpha) of the
- *                  bootstrap distribution, e.g. 0.05 → 95% CI, 0.01 → 99% CI
- * @param seed    - PRNG seed; fix this to get reproducible results across runs
+ * @param base    - baseline sample values
+ * @param newData - new/comparison sample values
+ * @param nIter   - bootstrap resamples; 9999 is standard for BCa
+ * @param alpha   - two-tailed level: CI covers (1-alpha), e.g. 0.05 → 95% CI
+ * @param seed    - PRNG seed for reproducibility
  */
 export function bootstrapMedianDiffCI(
   base: number[],
   newData: number[],
-  nIter: number = 1000,
+  nIter: number = 9999,
   alpha: number = 0.05,
   seed: number = 42,
 ): BootstrapCI {
   const rng = mulberry32(seed);
   const baseArr = new Float64Array(base);
   const newArr = new Float64Array(newData);
+  const observed = median(newArr) - median(baseArr);
+
+  // Bootstrap distribution
   const diffs = new Float64Array(nIter);
   for (let i = 0; i < nIter; i++) {
     diffs[i] = median(resample(newArr, rng)) - median(resample(baseArr, rng));
   }
+
+  // Bias-correction: proportion of bootstrap samples strictly below observed,
+  // clamped away from 0 and 1 to keep normalPPF finite.
+  let below = 0;
+  for (let i = 0; i < nIter; i++) if (diffs[i] < observed) below++;
+  const prop = Math.max(0.5 / nIter, Math.min(1 - 0.5 / nIter, below / nIter));
+  const z0 = normalPPF(prop);
+
+  // Acceleration via jackknife
+  const jack = jackknifeDiffs(baseArr, newArr);
+  const jackMean = jack.reduce((s, v) => s + v, 0) / jack.length;
+  const num = jack.reduce((s, v) => s + Math.pow(jackMean - v, 3), 0);
+  const denom = 6 * Math.pow(jack.reduce((s, v) => s + Math.pow(jackMean - v, 2), 0), 1.5);
+  const a = denom === 0 ? 0 : num / denom;
+
+  // BCa-adjusted quantile indices
+  const zLow = normalPPF(alpha / 2);
+  const zHigh = normalPPF(1 - alpha / 2);
+  const adj = (z: number) => {
+    const denom = 1 - a * (z0 + z);
+    return denom === 0 ? (z < 0 ? 0 : 1) : normalCDF(z0 + (z0 + z) / denom);
+  };
+  const alpha1 = adj(zLow);
+  const alpha2 = adj(zHigh);
+
   diffs.sort();
-  const loIdx = Math.floor((alpha / 2) * nIter);
-  const hiIdx = Math.min(Math.floor((1 - alpha / 2) * nIter), nIter - 1);
+  const loIdx = Math.max(0, Math.min(Math.floor(alpha1 * nIter), nIter - 1));
+  const hiIdx = Math.max(0, Math.min(Math.floor(alpha2 * nIter), nIter - 1));
+
   const ciLow = diffs[loIdx];
   const ciHigh = diffs[hiIdx];
   return {
-    medianDiff: median(newData) - median(base),
+    medianDiff: observed,
     ciLow,
     ciHigh,
     significant: ciLow > 0 || ciHigh < 0,

--- a/src/utils/bootstrap-ci.ts
+++ b/src/utils/bootstrap-ci.ts
@@ -42,7 +42,9 @@ function erf(x: number): number {
   const p =
     t *
     (0.254829592 +
-      t * (-0.284496736 + t * (1.421413741 + t * (-1.453152027 + t * 1.061405429))));
+      t *
+        (-0.284496736 +
+          t * (1.421413741 + t * (-1.453152027 + t * 1.061405429))));
   return (x >= 0 ? 1 : -1) * (1 - p * Math.exp(-x * x));
 }
 
@@ -53,7 +55,7 @@ function normalCDF(x: number): number {
 // Acklam rational approximation — max absolute error 1.15e-9
 function normalPPF(p: number): number {
   const a = [
-    -3.969683028665376e1, 2.20946098424520e2, -2.759285104469687e2,
+    -3.969683028665376e1, 2.2094609842452e2, -2.759285104469687e2,
     1.38357751867269e2, -3.066479806614716e1, 2.506628277459239,
   ];
   const b = [
@@ -82,7 +84,8 @@ function normalPPF(p: number): number {
     const q = p - 0.5;
     const r = q * q;
     return (
-      ((((((a[0] * r + a[1]) * r + a[2]) * r + a[3]) * r + a[4]) * r + a[5]) * q) /
+      ((((((a[0] * r + a[1]) * r + a[2]) * r + a[3]) * r + a[4]) * r + a[5]) *
+        q) /
       (((((b[0] * r + b[1]) * r + b[2]) * r + b[3]) * r + b[4]) * r + 1)
     );
   }
@@ -168,7 +171,12 @@ export function bootstrapMedianDiffCI(
   const jack = jackknifeDiffs(baseArr, newArr);
   const jackMean = jack.reduce((s, v) => s + v, 0) / jack.length;
   const num = jack.reduce((s, v) => s + Math.pow(jackMean - v, 3), 0);
-  const denom = 6 * Math.pow(jack.reduce((s, v) => s + Math.pow(jackMean - v, 2), 0), 1.5);
+  const denom =
+    6 *
+    Math.pow(
+      jack.reduce((s, v) => s + Math.pow(jackMean - v, 2), 0),
+      1.5,
+    );
   const a = denom === 0 ? 0 : num / denom;
 
   // BCa-adjusted quantile indices

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -15,3 +15,44 @@ export function formatDateRange(date1: Date, date2: Date) {
 export const formatNumber = (value: number) => {
   return numberFormatter.format(value);
 };
+
+// Determine the best human-readable scale for a unit given a set of values.
+// Returns the divisor and display unit label; suitable for axis tick formatting.
+export function getDisplayScale(
+  values: number[],
+  rawUnit: string,
+): { scale: number; displayUnit: string; decimals: number } {
+  const maxAbs = values.length ? Math.max(...values.map(Math.abs)) : 0;
+  if (rawUnit === 'bytes') {
+    if (maxAbs >= 1024 ** 3) return { scale: 1024 ** 3, displayUnit: 'GB', decimals: 2 };
+    if (maxAbs >= 1024 ** 2) return { scale: 1024 ** 2, displayUnit: 'MB', decimals: 2 };
+    if (maxAbs >= 1024)      return { scale: 1024,      displayUnit: 'KB', decimals: 1 };
+    return                          { scale: 1,         displayUnit: 'B',  decimals: 0 };
+  }
+  if (rawUnit === 'KB') {
+    if (maxAbs >= 1024 ** 2) return { scale: 1024 ** 2, displayUnit: 'GB', decimals: 2 };
+    if (maxAbs >= 1024)      return { scale: 1024,      displayUnit: 'MB', decimals: 2 };
+    return                          { scale: 1,         displayUnit: 'KB', decimals: 1 };
+  }
+  if (rawUnit === 'ms') {
+    if (maxAbs >= 60000) return { scale: 60000, displayUnit: 'min', decimals: 2 };
+    if (maxAbs >= 1000)  return { scale: 1000,  displayUnit: 's',   decimals: 2 };
+    return                      { scale: 1,     displayUnit: 'ms',  decimals: 1 };
+  }
+  return { scale: 1, displayUnit: rawUnit, decimals: 1 };
+}
+
+// Given a raw unit string and a set of values to display together, return the
+// best human-readable unit and a formatting function so all values use the same
+// scale. Handles bytes→B/KB/MB/GB and ms→ms/s; everything else is unchanged.
+export function adaptUnit(
+  values: number[],
+  rawUnit: string,
+): { fmt: (n: number) => string; displayUnit: string } {
+  const { scale, displayUnit, decimals } = getDisplayScale(values, rawUnit);
+  const sign = (n: number) => (n >= 0 ? '+' : '');
+  return {
+    fmt: (n) => sign(n) + (n / scale).toFixed(decimals),
+    displayUnit,
+  };
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -24,20 +24,24 @@ export function getDisplayScale(
 ): { scale: number; displayUnit: string; decimals: number } {
   const maxAbs = values.length ? Math.max(...values.map(Math.abs)) : 0;
   if (rawUnit === 'bytes') {
-    if (maxAbs >= 1024 ** 3) return { scale: 1024 ** 3, displayUnit: 'GB', decimals: 2 };
-    if (maxAbs >= 1024 ** 2) return { scale: 1024 ** 2, displayUnit: 'MB', decimals: 2 };
-    if (maxAbs >= 1024)      return { scale: 1024,      displayUnit: 'KB', decimals: 1 };
-    return                          { scale: 1,         displayUnit: 'B',  decimals: 0 };
+    if (maxAbs >= 1024 ** 3)
+      return { scale: 1024 ** 3, displayUnit: 'GB', decimals: 2 };
+    if (maxAbs >= 1024 ** 2)
+      return { scale: 1024 ** 2, displayUnit: 'MB', decimals: 2 };
+    if (maxAbs >= 1024) return { scale: 1024, displayUnit: 'KB', decimals: 1 };
+    return { scale: 1, displayUnit: 'B', decimals: 0 };
   }
   if (rawUnit === 'KB') {
-    if (maxAbs >= 1024 ** 2) return { scale: 1024 ** 2, displayUnit: 'GB', decimals: 2 };
-    if (maxAbs >= 1024)      return { scale: 1024,      displayUnit: 'MB', decimals: 2 };
-    return                          { scale: 1,         displayUnit: 'KB', decimals: 1 };
+    if (maxAbs >= 1024 ** 2)
+      return { scale: 1024 ** 2, displayUnit: 'GB', decimals: 2 };
+    if (maxAbs >= 1024) return { scale: 1024, displayUnit: 'MB', decimals: 2 };
+    return { scale: 1, displayUnit: 'KB', decimals: 1 };
   }
   if (rawUnit === 'ms') {
-    if (maxAbs >= 60000) return { scale: 60000, displayUnit: 'min', decimals: 2 };
-    if (maxAbs >= 1000)  return { scale: 1000,  displayUnit: 's',   decimals: 2 };
-    return                      { scale: 1,     displayUnit: 'ms',  decimals: 1 };
+    if (maxAbs >= 60000)
+      return { scale: 60000, displayUnit: 'min', decimals: 2 };
+    if (maxAbs >= 1000) return { scale: 1000, displayUnit: 's', decimals: 2 };
+    return { scale: 1, displayUnit: 'ms', decimals: 2 };
   }
   return { scale: 1, displayUnit: rawUnit, decimals: 1 };
 }

--- a/src/utils/kde.js
+++ b/src/utils/kde.js
@@ -248,16 +248,14 @@ export function autogrid1D(
 function gaussianKernel1D(x, bw) {
   return Math.exp((-x * x) / (2 * bw * bw)) / (Math.sqrt(2 * Math.PI) * bw);
 }
-// Find x > 0 where Gaussian kernel drops to atol — matches
-// KDEpy's Kernel.practical_support(bw, atol=10e-5) for Gaussian.
-// 10e-5 in Python == 1e-4.
+// Find x > 0 where Gaussian kernel drops to atol — analytical solution of:
+//   exp(-x²/(2bw²)) / (√(2π)·bw) = atol  →  x = bw·√(−2·ln(atol·√(2π)·bw))
+// When bw is so large that the kernel peak is already below atol, fall back to
+// 3σ so the convolution still produces a smooth curve instead of a histogram.
 function gaussianPracticalSupport(bw, atol = 10e-5) {
-  const xtol = 1e-3;
-  const result = brentq((x) => gaussianKernel1D(x, bw) - atol, 0, 8 * bw, xtol);
-  if (!result.converged) {
-    throw new Error('Could not find practical support for Gaussian kernel.');
-  }
-  return result.x + xtol;
+  const inner = atol * Math.sqrt(2 * Math.PI) * bw;
+  if (inner >= 1) return 3 * bw;
+  return bw * Math.sqrt(-2 * Math.log(inner)) + 1e-3;
 }
 // ---------------------------------------------------------------------------
 // ISJ fixed-point function — port of KDEpy's _fixed_point
@@ -397,7 +395,7 @@ export function silvermansRule(data) {
   // scipy.stats.norm.ppf(.75) - scipy.stats.norm.ppf(.25) = 1.3489795003921634
   const iqr = (percentile(0.75) - percentile(0.25)) / 1.3489795003921634;
   let sigma = Math.min(std, iqr > 0 ? iqr : std);
-  if (sigma <= 0) return 1;
+  if (sigma <= 0) return Math.abs(mean) * 0.001 || 1;
   return sigma * Math.pow((n * 3) / 4, -0.2);
 }
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
If the numbers are large (e.g. we're measuring gigabytes), the math would just break -- this is what the first commit fixes.

The second commit slightly improves the confidence in the case which the distribution are skewed, which is typical in our case. This is lifted from scipy, cross-checked like the other bits of code.

Then the rest are cosmetic / fixes (in order of the patches):

- it's nicer to say 800MB than 800000000 bytes
- I thought that it was confusing when displaying the median diff: the test could be marked as high confidence, but the media diff bootstrap could be marked as low confidence. Conceptually this makes sense, but we can phrase it better: we want to warn when a confidence interval includes zero, e.g. "the median was improved by 0.5ms, confidence interval [0.6, -0.1], meaning this could well be a -0.1 regression. If this interval does not include 0 (e.g. 0.5ms, confidence interval [0.8, 0.3], then in all cases we're certain it improves things, there's low chance it regresses things
-  again when displaying large numbers such as amount of memory, our auto-sizing for the KDE was perfectible, I saw myself having to resize. I changed things so it looks better (leaving about 10% of padding on either side of the min/max). Also when the distribution is all over the place, I don't think the automatic bandwidth calculation makes any sense, so we add a slider much like we added one for the modal split.

This fixes BMO https://bugzilla.mozilla.org/show_bug.cgi?id=2046147