### PR TITLE
Bug-1855186: Show whether lower or higher is "better" for each metric

### DIFF
--- a/src/__tests__/CompareResults/ResultsTable.test.tsx
+++ b/src/__tests__/CompareResults/ResultsTable.test.tsx
@@ -57,8 +57,14 @@ function summarizeVisibleRows(testVersion?: TestVersion) {
     const optionsElements = Array.from(
       titleElement.nextElementSibling!.children,
     );
+    // The "better direction" indicator is asserted separately (and via
+    // snapshots); strip it here so the data-focused expectations stay stable.
+    const titleClone = titleElement.cloneNode(true) as HTMLElement;
+    titleClone
+      .querySelector('[data-testid="better-direction-indicator"]')
+      ?.remove();
     const title = [
-      titleElement.textContent,
+      titleClone.textContent,
       ...optionsElements.map((element) => element.textContent),
     ].join(' ');
     result.push(title);

--- a/src/__tests__/CompareResults/ResultsView.test.tsx
+++ b/src/__tests__/CompareResults/ResultsView.test.tsx
@@ -158,6 +158,7 @@ describe('Results View', () => {
       option_name: 'opt',
       suite: 'allyr',
       test: '3DGraphics-WebGL',
+      lower_is_better: true,
     };
 
     renderWithRoute(<TestHeader result={revisionHeader} withRevision={true} />);
@@ -176,12 +177,42 @@ describe('Results View', () => {
       option_name: 'opt',
       suite: 'idle-bg',
       test: '3DGraphics-WebGL',
+      lower_is_better: true,
     };
 
     renderWithRoute(<TestHeader result={revisionHeader} withRevision={true} />);
     await screen.findByText(/idle-bg/);
     const linkToSuite = screen.queryByLabelText('link to suite documentation');
     expect(linkToSuite).not.toBeInTheDocument();
+  });
+
+  it('Should show the better-direction label based on lower_is_better', async () => {
+    const baseHeader = {
+      extra_options: 'e10s fission stylo webgl-ipc webrender',
+      framework_id: 1 as Framework['id'],
+      new_repository_name: 'mozilla-central' as Repository['name'],
+      new_rev: 'a998c42399a8fcea623690bf65bef49de20535b4',
+      option_name: 'opt',
+      suite: 'allyr',
+      test: '3DGraphics-WebGL',
+    };
+
+    const { unmount } = renderWithRoute(
+      <TestHeader
+        result={{ ...baseHeader, lower_is_better: true }}
+        withRevision={true}
+      />,
+    );
+    expect(await screen.findByText('Lower is better')).toBeInTheDocument();
+    unmount();
+
+    renderWithRoute(
+      <TestHeader
+        result={{ ...baseHeader, lower_is_better: false }}
+        withRevision={true}
+      />,
+    );
+    expect(await screen.findByText('Higher is better')).toBeInTheDocument();
   });
 
   it('Should display Base, New and Common graphs with tooltips', async () => {

--- a/src/__tests__/CompareResults/SubtestsResultsView.test.tsx
+++ b/src/__tests__/CompareResults/SubtestsResultsView.test.tsx
@@ -94,6 +94,25 @@ describe('SubtestsResultsView Component Tests', () => {
     expect(document.body).toMatchSnapshot();
   });
 
+  it('Should show the better-direction label once in the subtests header', async () => {
+    const { subtestsResult } = getTestData();
+    setup({
+      element: (
+        <SubtestsResultsView title={Strings.metaData.pageTitle.subtests} />
+      ),
+      route: '/subtests-compare-results/',
+      search:
+        '?baseRev=f49863193c13c1def4db2dd3ea9c5d6bd9d517a7&baseRepo=mozilla-central&newRev=2cb6128d7dca8c9a9266b3505d64d55ac1bcc8a8&newRepo=mozilla-central&framework=1&baseParentSignature=4774487&newParentSignature=4774487',
+      subtestsResult,
+    });
+
+    // The mock data is `lower_is_better: true`, and direction is a property of
+    // the parent suite, so the label is shown once in the header rather than
+    // repeated on every subtest row.
+    const labels = await screen.findAllByText('Lower is better');
+    expect(labels).toHaveLength(1);
+  });
+
   it('should render the subtests results view with mann-whitney-u testVersions in url', async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     const { subtestsMannWhitneyResult } = getTestData();

--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -651,7 +651,7 @@ exports[`Results View The table should match snapshot and other elements should 
               class="revision-header fh103jg"
             >
               <div
-                class="f195ysgj"
+                class="fnf9lyn"
               >
                 <strong>
                   <a
@@ -701,6 +701,12 @@ exports[`Results View The table should match snapshot and other elements should 
                     </button>
                   </span>
                 </div>
+                <span
+                  class="MuiBox-root css-1b0hjcp"
+                  data-testid="better-direction-indicator"
+                >
+                  Lower is better
+                </span>
               </div>
               <div
                 class="MuiBox-root css-56tgmi"

--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -702,7 +702,7 @@ exports[`Results View The table should match snapshot and other elements should 
                   </span>
                 </div>
                 <span
-                  class="MuiBox-root css-1b0hjcp"
+                  class="MuiBox-root css-1bi5h41"
                   data-testid="better-direction-indicator"
                 >
                   Lower is better

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -1624,7 +1624,7 @@ exports[`Results Table Should match snapshot 1`] = `
                           class="revision-header fh103jg"
                         >
                           <div
-                            class="f195ysgj"
+                            class="fnf9lyn"
                           >
                             <strong>
                               <a
@@ -1674,6 +1674,12 @@ exports[`Results Table Should match snapshot 1`] = `
                                 </button>
                               </span>
                             </div>
+                            <span
+                              class="MuiBox-root css-1b0hjcp"
+                              data-testid="better-direction-indicator"
+                            >
+                              Lower is better
+                            </span>
                           </div>
                           <div
                             class="MuiBox-root css-56tgmi"
@@ -2321,7 +2327,7 @@ exports[`Results Table Should match snapshot 1`] = `
                           class="revision-header fh103jg"
                         >
                           <div
-                            class="f195ysgj"
+                            class="fnf9lyn"
                           >
                             <strong>
                               <a
@@ -2371,6 +2377,12 @@ exports[`Results Table Should match snapshot 1`] = `
                                 </button>
                               </span>
                             </div>
+                            <span
+                              class="MuiBox-root css-1b0hjcp"
+                              data-testid="better-direction-indicator"
+                            >
+                              Lower is better
+                            </span>
                           </div>
                           <div
                             class="MuiBox-root css-56tgmi"
@@ -4495,7 +4507,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                           class="revision-header fh103jg"
                         >
                           <div
-                            class="f195ysgj"
+                            class="fnf9lyn"
                           >
                             <strong>
                               <a
@@ -4545,6 +4557,12 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                                 </button>
                               </span>
                             </div>
+                            <span
+                              class="MuiBox-root css-1b0hjcp"
+                              data-testid="better-direction-indicator"
+                            >
+                              Lower is better
+                            </span>
                           </div>
                           <div
                             class="MuiBox-root css-56tgmi"
@@ -5231,7 +5249,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                           class="revision-header fh103jg"
                         >
                           <div
-                            class="f195ysgj"
+                            class="fnf9lyn"
                           >
                             <strong>
                               <a
@@ -5281,6 +5299,12 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                                 </button>
                               </span>
                             </div>
+                            <span
+                              class="MuiBox-root css-1b0hjcp"
+                              data-testid="better-direction-indicator"
+                            >
+                              Lower is better
+                            </span>
                           </div>
                           <div
                             class="MuiBox-root css-56tgmi"
@@ -6021,7 +6045,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
     class="revision-header fh103jg"
   >
     <div
-      class="f195ysgj"
+      class="fnf9lyn"
     >
       <strong>
         <a
@@ -6035,6 +6059,12 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
         </a>
          dhtml.html
       </strong>
+      <span
+        class="MuiBox-root css-1b0hjcp"
+        data-testid="better-direction-indicator"
+      >
+        Lower is better
+      </span>
     </div>
     <div
       class="MuiBox-root css-56tgmi"
@@ -6580,7 +6610,7 @@ exports[`Results Table should render different blocks when rendering several rev
     class="revision-header fh103jg"
   >
     <div
-      class="f195ysgj"
+      class="fnf9lyn"
     >
       <strong>
         <a
@@ -6594,6 +6624,12 @@ exports[`Results Table should render different blocks when rendering several rev
         </a>
          dhtml.html
       </strong>
+      <span
+        class="MuiBox-root css-1b0hjcp"
+        data-testid="better-direction-indicator"
+      >
+        Lower is better
+      </span>
     </div>
     <div
       class="MuiBox-root css-56tgmi"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -1675,7 +1675,7 @@ exports[`Results Table Should match snapshot 1`] = `
                               </span>
                             </div>
                             <span
-                              class="MuiBox-root css-1b0hjcp"
+                              class="MuiBox-root css-1bi5h41"
                               data-testid="better-direction-indicator"
                             >
                               Lower is better
@@ -2378,7 +2378,7 @@ exports[`Results Table Should match snapshot 1`] = `
                               </span>
                             </div>
                             <span
-                              class="MuiBox-root css-1b0hjcp"
+                              class="MuiBox-root css-1bi5h41"
                               data-testid="better-direction-indicator"
                             >
                               Lower is better
@@ -4558,7 +4558,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                               </span>
                             </div>
                             <span
-                              class="MuiBox-root css-1b0hjcp"
+                              class="MuiBox-root css-1bi5h41"
                               data-testid="better-direction-indicator"
                             >
                               Lower is better
@@ -5300,7 +5300,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                               </span>
                             </div>
                             <span
-                              class="MuiBox-root css-1b0hjcp"
+                              class="MuiBox-root css-1bi5h41"
                               data-testid="better-direction-indicator"
                             >
                               Lower is better
@@ -6060,7 +6060,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
          dhtml.html
       </strong>
       <span
-        class="MuiBox-root css-1b0hjcp"
+        class="MuiBox-root css-1bi5h41"
         data-testid="better-direction-indicator"
       >
         Lower is better
@@ -6625,7 +6625,7 @@ exports[`Results Table should render different blocks when rendering several rev
          dhtml.html
       </strong>
       <span
-        class="MuiBox-root css-1b0hjcp"
+        class="MuiBox-root css-1bi5h41"
         data-testid="better-direction-indicator"
       >
         Lower is better

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Results View Should display Base, New and Common graphs with replicates
 <section
   aria-label="Revision Row Details"
   class="MuiBox-root css-13s8wtg"
-  id="_r_c4_"
+  id="_r_c8_"
 >
   <div
     class="MuiStack-root css-1714cpj-MuiStack-root"
@@ -549,7 +549,7 @@ exports[`Results View Should display Base, New and Common graphs with tooltips 1
 <section
   aria-label="Revision Row Details"
   class="MuiBox-root css-13s8wtg"
-  id="_r_ag_"
+  id="_r_ak_"
 >
   <div
     class="MuiStack-root css-1714cpj-MuiStack-root"
@@ -1806,7 +1806,7 @@ exports[`Results View The table should match snapshot and other elements should 
               class="revision-header fh103jg"
             >
               <div
-                class="f195ysgj"
+                class="fnf9lyn"
               >
                 <strong>
                   <a
@@ -1856,6 +1856,12 @@ exports[`Results View The table should match snapshot and other elements should 
                     </button>
                   </span>
                 </div>
+                <span
+                  class="MuiBox-root css-1b0hjcp"
+                  data-testid="better-direction-indicator"
+                >
+                  Lower is better
+                </span>
               </div>
               <div
                 class="MuiBox-root css-56tgmi"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -1857,7 +1857,7 @@ exports[`Results View The table should match snapshot and other elements should 
                   </span>
                 </div>
                 <span
-                  class="MuiBox-root css-1b0hjcp"
+                  class="MuiBox-root css-1bi5h41"
                   data-testid="better-direction-indicator"
                 >
                   Lower is better

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -2655,7 +2655,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                           aria-invalid="false"
                           aria-label="Search by title"
                           class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-3v3un6-MuiInputBase-input-MuiOutlinedInput-input"
-                          id="_r_sf_"
+                          id="_r_sl_"
                           placeholder="Filter results"
                           type="search"
                           value=""
@@ -3165,7 +3165,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_sl_"
+                    aria-controls="_r_sr_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -3341,7 +3341,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_so_"
+                    aria-controls="_r_su_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -3504,7 +3504,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_sr_"
+                    aria-controls="_r_t1_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -3667,7 +3667,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_su_"
+                    aria-controls="_r_t4_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -3830,7 +3830,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_t1_"
+                    aria-controls="_r_t7_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -4257,7 +4257,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                           aria-invalid="false"
                           aria-label="Search by title"
                           class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-3v3un6-MuiInputBase-input-MuiOutlinedInput-input"
-                          id="_r_pn_"
+                          id="_r_ps_"
                           placeholder="Filter results"
                           type="search"
                           value=""
@@ -4767,7 +4767,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_pt_"
+                    aria-controls="_r_q2_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -4943,7 +4943,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_q0_"
+                    aria-controls="_r_q5_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -5106,7 +5106,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_q3_"
+                    aria-controls="_r_q8_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -5269,7 +5269,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_q6_"
+                    aria-controls="_r_qb_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -5432,7 +5432,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_q9_"
+                    aria-controls="_r_qe_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -5859,7 +5859,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                           aria-invalid="false"
                           aria-label="Search by title"
                           class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-3v3un6-MuiInputBase-input-MuiOutlinedInput-input"
-                          id="_r_g3_"
+                          id="_r_g6_"
                           placeholder="Filter results"
                           type="search"
                           value=""
@@ -6369,7 +6369,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_g9_"
+                    aria-controls="_r_gc_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -6545,7 +6545,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_gc_"
+                    aria-controls="_r_gf_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -6708,7 +6708,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_gf_"
+                    aria-controls="_r_gi_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -6871,7 +6871,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_gi_"
+                    aria-controls="_r_gl_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -7034,7 +7034,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_gl_"
+                    aria-controls="_r_go_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -7461,7 +7461,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                           aria-invalid="false"
                           aria-label="Search by title"
                           class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-3v3un6-MuiInputBase-input-MuiOutlinedInput-input"
-                          id="_r_db_"
+                          id="_r_dd_"
                           placeholder="Filter results"
                           type="search"
                           value=""
@@ -7969,7 +7969,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_dh_"
+                    aria-controls="_r_dj_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -8117,7 +8117,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_dk_"
+                    aria-controls="_r_dm_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -8265,7 +8265,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_dn_"
+                    aria-controls="_r_dp_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -8413,7 +8413,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_dq_"
+                    aria-controls="_r_ds_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -8561,7 +8561,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_dt_"
+                    aria-controls="_r_dv_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -621,6 +621,12 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                       a11yr
                     </a>
                   </strong>
+                  <span
+                    class="MuiBox-root css-1b0hjcp"
+                    data-testid="better-direction-indicator"
+                  >
+                    Lower is better
+                  </span>
                    |
                    Base (mozilla-central) 
                   <a
@@ -2534,6 +2540,12 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                       a11yr
                     </a>
                   </strong>
+                  <span
+                    class="MuiBox-root css-1b0hjcp"
+                    data-testid="better-direction-indicator"
+                  >
+                    Lower is better
+                  </span>
                    |
                    Base (mozilla-central) Last day 
                    - New (mozilla-central) 
@@ -2643,7 +2655,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                           aria-invalid="false"
                           aria-label="Search by title"
                           class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-3v3un6-MuiInputBase-input-MuiOutlinedInput-input"
-                          id="_r_r9_"
+                          id="_r_sf_"
                           placeholder="Filter results"
                           type="search"
                           value=""
@@ -3153,7 +3165,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_rf_"
+                    aria-controls="_r_sl_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -3329,7 +3341,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_ri_"
+                    aria-controls="_r_so_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -3492,7 +3504,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_rl_"
+                    aria-controls="_r_sr_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -3655,7 +3667,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_ro_"
+                    aria-controls="_r_su_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -3818,7 +3830,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_rr_"
+                    aria-controls="_r_t1_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -4130,6 +4142,12 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                       a11yr
                     </a>
                   </strong>
+                  <span
+                    class="MuiBox-root css-1b0hjcp"
+                    data-testid="better-direction-indicator"
+                  >
+                    Lower is better
+                  </span>
                    |
                    Base (mozilla-central) Last day 
                    - New (mozilla-central) 
@@ -4239,7 +4257,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                           aria-invalid="false"
                           aria-label="Search by title"
                           class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-3v3un6-MuiInputBase-input-MuiOutlinedInput-input"
-                          id="_r_og_"
+                          id="_r_pn_"
                           placeholder="Filter results"
                           type="search"
                           value=""
@@ -4749,7 +4767,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_om_"
+                    aria-controls="_r_pt_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -4925,7 +4943,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_op_"
+                    aria-controls="_r_q0_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -5088,7 +5106,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_os_"
+                    aria-controls="_r_q3_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -5251,7 +5269,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_ov_"
+                    aria-controls="_r_q6_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -5414,7 +5432,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_p2_"
+                    aria-controls="_r_q9_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -5726,6 +5744,12 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                       a11yr
                     </a>
                   </strong>
+                  <span
+                    class="MuiBox-root css-1b0hjcp"
+                    data-testid="better-direction-indicator"
+                  >
+                    Lower is better
+                  </span>
                    |
                    Base (mozilla-central) Last day 
                    - New (mozilla-central) 
@@ -5835,7 +5859,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                           aria-invalid="false"
                           aria-label="Search by title"
                           class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-3v3un6-MuiInputBase-input-MuiOutlinedInput-input"
-                          id="_r_eq_"
+                          id="_r_g3_"
                           placeholder="Filter results"
                           type="search"
                           value=""
@@ -6345,7 +6369,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_f0_"
+                    aria-controls="_r_g9_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -6521,7 +6545,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_f3_"
+                    aria-controls="_r_gc_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -6684,7 +6708,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_f6_"
+                    aria-controls="_r_gf_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -6847,7 +6871,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_f9_"
+                    aria-controls="_r_gi_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -7010,7 +7034,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_fc_"
+                    aria-controls="_r_gl_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -7322,6 +7346,12 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                       a11yr
                     </a>
                   </strong>
+                  <span
+                    class="MuiBox-root css-1b0hjcp"
+                    data-testid="better-direction-indicator"
+                  >
+                    Lower is better
+                  </span>
                    |
                    Base (mozilla-central) Last day 
                    - New (mozilla-central) 
@@ -7431,7 +7461,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                           aria-invalid="false"
                           aria-label="Search by title"
                           class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-3v3un6-MuiInputBase-input-MuiOutlinedInput-input"
-                          id="_r_c1_"
+                          id="_r_db_"
                           placeholder="Filter results"
                           type="search"
                           value=""
@@ -7939,7 +7969,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_c7_"
+                    aria-controls="_r_dh_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -8087,7 +8117,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_ca_"
+                    aria-controls="_r_dk_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -8235,7 +8265,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_cd_"
+                    aria-controls="_r_dn_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -8383,7 +8413,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_cg_"
+                    aria-controls="_r_dq_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -8531,7 +8561,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_cj_"
+                    aria-controls="_r_dt_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -622,7 +622,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                     </a>
                   </strong>
                   <span
-                    class="MuiBox-root css-1b0hjcp"
+                    class="MuiBox-root css-1bi5h41"
                     data-testid="better-direction-indicator"
                   >
                     Lower is better
@@ -2541,7 +2541,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                     </a>
                   </strong>
                   <span
-                    class="MuiBox-root css-1b0hjcp"
+                    class="MuiBox-root css-1bi5h41"
                     data-testid="better-direction-indicator"
                   >
                     Lower is better
@@ -4143,7 +4143,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                     </a>
                   </strong>
                   <span
-                    class="MuiBox-root css-1b0hjcp"
+                    class="MuiBox-root css-1bi5h41"
                     data-testid="better-direction-indicator"
                   >
                     Lower is better
@@ -5745,7 +5745,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                     </a>
                   </strong>
                   <span
-                    class="MuiBox-root css-1b0hjcp"
+                    class="MuiBox-root css-1bi5h41"
                     data-testid="better-direction-indicator"
                   >
                     Lower is better
@@ -7347,7 +7347,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                     </a>
                   </strong>
                   <span
-                    class="MuiBox-root css-1b0hjcp"
+                    class="MuiBox-root css-1bi5h41"
                     data-testid="better-direction-indicator"
                   >
                     Lower is better

--- a/src/components/CompareResults/BetterDirectionIndicator.tsx
+++ b/src/components/CompareResults/BetterDirectionIndicator.tsx
@@ -1,0 +1,40 @@
+import Box from '@mui/material/Box';
+
+import { Strings } from '../../resources/Strings';
+import { FontSizeRaw, Spacing } from '../../styles';
+
+interface BetterDirectionIndicatorProps {
+  lowerIsBetter: boolean | null | undefined;
+}
+
+// The direction comes from the result's
+// `lower_is_better` field. When that field is unknown (it can be null for
+// Mann-Whitney results), we render nothing rather than a misleading label.
+function BetterDirectionIndicator({
+  lowerIsBetter,
+}: BetterDirectionIndicatorProps) {
+  if (lowerIsBetter === null || lowerIsBetter === undefined) {
+    return null;
+  }
+
+  const label = lowerIsBetter
+    ? Strings.components.betterDirection.lower
+    : Strings.components.betterDirection.higher;
+
+  return (
+    <Box
+      component='span'
+      data-testid='better-direction-indicator'
+      sx={{
+        color: 'text.secondary',
+        fontSize: FontSizeRaw.Small.fontSize,
+        whiteSpace: 'nowrap',
+        marginInline: `${Spacing.xSmall}px`,
+      }}
+    >
+      {label}
+    </Box>
+  );
+}
+
+export default BetterDirectionIndicator;

--- a/src/components/CompareResults/BetterDirectionIndicator.tsx
+++ b/src/components/CompareResults/BetterDirectionIndicator.tsx
@@ -27,7 +27,7 @@ function BetterDirectionIndicator({
       data-testid='better-direction-indicator'
       sx={{
         color: 'text.secondary',
-        fontSize: FontSizeRaw.Small.fontSize,
+        fontSize: FontSizeRaw.Normal.fontSize,
         whiteSpace: 'nowrap',
         marginInline: `${Spacing.xSmall}px`,
       }}

--- a/src/components/CompareResults/SubtestsResults/SubtestsResultsMain.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsResultsMain.tsx
@@ -62,6 +62,7 @@ function SubtestsResultsHeader({
     base_parent_signature: loadedResults[0].base_parent_signature,
     new_parent_signature: loadedResults[0].base_parent_signature,
     platform: loadedResults[0].platform,
+    lower_is_better: loadedResults[0].lower_is_better,
   };
 
   return (

--- a/src/components/CompareResults/SubtestsResults/SubtestsRevisionHeader.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsRevisionHeader.tsx
@@ -31,6 +31,7 @@ import {
 import AndroidIcon from '../../Shared/Icons/AndroidIcon';
 import LinuxIcon from '../../Shared/Icons/LinuxIcon';
 import WindowsIcon from '../../Shared/Icons/WindowsIcon';
+import BetterDirectionIndicator from '../BetterDirectionIndicator';
 import { LoaderReturnValue as OvertimeLoaderReturnValue } from '../subtestsOverTimeLoader';
 
 const styles = {
@@ -158,7 +159,8 @@ function SubtestsRevisionHeader(props: SubtestsRevisionHeaderProps) {
   return (
     <div className={styles.revisionHeader}>
       <div className={styles.typography}>
-        <strong>{getSuite(header, docsURL, isLinkSupported)}</strong> |
+        <strong>{getSuite(header, docsURL, isLinkSupported)}</strong>
+        <BetterDirectionIndicator lowerIsBetter={header.lower_is_better} /> |
         {baseInfo}
         {getRevLink(header.new_rev, header.new_repo, '- New')} | {framework} |{' '}
         <Tooltip

--- a/src/components/CompareResults/TestHeader.tsx
+++ b/src/components/CompareResults/TestHeader.tsx
@@ -1,10 +1,11 @@
 import { Box, Link } from '@mui/material';
 import { style } from 'typestyle';
 
+import BetterDirectionIndicator from './BetterDirectionIndicator';
 import LinkToRevision from './LinkToRevision';
 import { Strings } from '../../resources/Strings';
 import { Colors, Spacing } from '../../styles';
-import type { CompareResultsItem } from '../../types/state';
+import type { CombinedResultsItemType } from '../../types/state';
 import { getDocsURL } from '../../utils/helpers';
 
 const styles = {
@@ -54,12 +55,16 @@ const styles = {
     flexWrap: 'wrap',
     fontFamily: 'SF Pro',
     display: 'flex',
+    // Baseline so the larger suite title and the smaller better-direction label
+    // share one text baseline (otherwise the label rides up at the top of the
+    // line and looks superscript).
+    alignItems: 'baseline',
     gap: '4px',
   }),
 };
 
 type HeaderProperties = Pick<
-  CompareResultsItem,
+  CombinedResultsItemType,
   | 'extra_options'
   | 'framework_id'
   | 'option_name'
@@ -67,6 +72,7 @@ type HeaderProperties = Pick<
   | 'test'
   | 'new_repository_name'
   | 'new_rev'
+  | 'lower_is_better'
 >;
 
 function createTitle(
@@ -117,6 +123,7 @@ export default function TestHeader(props: TestHeaderProps) {
             <LinkToRevision result={result} />
           </>
         )}
+        <BetterDirectionIndicator lowerIsBetter={result.lower_is_better} />
       </div>
       <Box
         sx={{

--- a/src/components/CompareResults/TestHeader.tsx
+++ b/src/components/CompareResults/TestHeader.tsx
@@ -55,9 +55,6 @@ const styles = {
     flexWrap: 'wrap',
     fontFamily: 'SF Pro',
     display: 'flex',
-    // Baseline so the larger suite title and the smaller better-direction label
-    // share one text baseline (otherwise the label rides up at the top of the
-    // line and looks superscript).
     alignItems: 'baseline',
     gap: '4px',
   }),

--- a/src/resources/Strings.tsx
+++ b/src/resources/Strings.tsx
@@ -128,6 +128,10 @@ export const Strings = {
         suiteLink: 'Link to suite documentation  ',
       },
     },
+    betterDirection: {
+      lower: 'Lower is better',
+      higher: 'Higher is better',
+    },
     expandableRow: {
       title: {
         expand: 'expand this row',

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -51,6 +51,7 @@ export type SubtestsRevisionsHeader = {
   base_parent_signature: number | null;
   new_parent_signature: number | null;
   platform: Platform;
+  lower_is_better: boolean;
 };
 
 export type CompareResultsItem = {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1855186
## Show whether lower or higher is "better" for each metric

  ### Problem

  Fixes **"Rows do not show if 'lower' or 'higher' metrics are better."** Results carry a `lower_is_better` flag, but it was used only for sorting and never shown — so a reader couldn't tell from the numbers whether a delta was an improvement or a regression. The old Treeherder view had a "Better: Lower/Higher" column; this restores that signal.

  ### What changed

  A muted inline label — **"Lower is better" / "Higher is better"** — now appears next to the metric name:

  - **Main results table:** once per test, in the test header (`TestHeader`).
  - **Subtests view:** once in the subtests header (`SubtestsRevisionHeader`), next to the suite name.

  New `BetterDirectionIndicator` component renders the label from `lower_is_better`, and renders nothing when it's `null`/`undefined` (Mann-Whitney can be null) instead of a misleading direction. Display-only — no loader/API/data-model changes; works in both Student's-t and Mann-Whitney U views.

### Screenshots

 | Results view (Multiple Revisions) | Results view (Single Revision) |
  | --- | --- |
  | <img width="1861" height="822" alt="image" src="https://github.com/user-attachments/assets/ff8257e6-500d-4b90-9522-a1db7b5f5964" /> | <img width="1373" height="469" alt="image" src="https://github.com/user-attachments/assets/b73581ac-0d62-4307-9c82-7c24b8802aa9" /> |

| Subtests view |
  | --- |
  | <img width="1481" height="561" alt="Screenshot 2026-06-11 094730" src="https://github.com/user-attachments/assets/713f25f2-edef-4881-a3bd-96a4c65416aa"/> |

  ### Key decisions

  - **Shown once per group, never per row.** `lower_is_better` is a suite/metric property, so it's identical across rows. A per-row version was redundant and (being `nowrap`) widened the "Subtests" grid column and pushed others right. Header placement fixes both and matches `TestHeader`.
  - **No new column / no grid changes.** The label is inline in existing header markup; column widths are untouched.
  - **Status column left as-is** — it already covers "scan for regressions"; this adds only the direction signal.
  - **Typing.** `HeaderProperties` picks from `CombinedResultsItemType`, so `lower_is_better` resolves to `boolean | null` automatically (no intersection workaround); `SubtestsRevisionsHeader` is built from `CompareResultsItem`, so it stays `boolean`.
  - **Design tokens used** — `FontSizeRaw.Small` and `Spacing.xSmall` from `src/styles`.

  ### Testing

  `summarizeVisibleRows` strips the label from title parsing so the ~60 filtering/sorting expectations stay focused on row data; the label itself is covered by a dedicated assertion and snapshots.