### PR TITLE
[ON HOLD] Bug 2032243: Use the confidence interval for the significance column

### DIFF
--- a/src/__tests__/CompareResults/ResultsTable.test.tsx
+++ b/src/__tests__/CompareResults/ResultsTable.test.tsx
@@ -722,9 +722,9 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
       '  rev: devilrabbit',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
     ]);
     expect(screen.getByRole('rowgroup')).toMatchSnapshot();
   });
@@ -748,11 +748,11 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await screen.findByText('a11yr');
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, -, 25.00 %',
-      '  - inexistant, 1.078 %, Improvement, 0.1, -, 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
-      '  - Windows 10, -, , -, , 100.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - inexistant, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - Windows 10, -, , -, -, 100.00 %',
       '  - Windows 10, -2.401 %, , -, , 50.00 %',
     ]);
 
@@ -762,9 +762,9 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', /Windows/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, -, 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       platform: ['osx', 'linux', 'android', 'ios'],
@@ -775,11 +775,11 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', /Windows/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, -, 25.00 %',
-      '  - inexistant, 1.078 %, Improvement, 0.1, -, 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
-      '  - Windows 10, -, , -, , 100.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - inexistant, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - Windows 10, -, , -, -, 100.00 %',
       '  - Windows 10, -2.401 %, , -, , 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({});
@@ -788,8 +788,8 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', /Linux/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, -, 25.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       platform: ['osx', 'android', 'ios'],
@@ -798,9 +798,9 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', /Linux/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, -, 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       platform: ['osx', 'android', 'ios', 'linux'],
@@ -809,11 +809,11 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', 'Select all values');
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, -, 25.00 %',
-      '  - inexistant, 1.078 %, Improvement, 0.1, -, 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
-      '  - Windows 10, -, , -, , 100.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - inexistant, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - Windows 10, -, , -, -, 100.00 %',
       '  - Windows 10, -2.401 %, , -, , 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({});
@@ -821,9 +821,9 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', /macOS/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, -, 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
-      '  - Windows 10, -, , -, , 100.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
+      '  - Windows 10, -, , -, -, 100.00 %',
       '  - Windows 10, -2.401 %, , -, , 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
@@ -833,8 +833,8 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', /Android/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
-      '  - Windows 10, -, , -, , 100.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
+      '  - Windows 10, -, , -, -, 100.00 %',
       '  - Windows 10, -2.401 %, , -, , 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
@@ -844,7 +844,7 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', /Select only.*Android/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, , 25.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       platform: ['android'],
@@ -883,9 +883,9 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await screen.findByText('a11yr');
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
-      '  - Windows 10, -, , -, , 100.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - Windows 10, -, , -, -, 100.00 %',
       '  - Windows 10, -2.401 %, , -, , 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({});
@@ -894,8 +894,8 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Status', /No changes/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       status: ['improvement', 'regression'],
@@ -904,7 +904,7 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Status', /Improvement/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       status: ['regression'],
@@ -914,8 +914,8 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Status', /Regression/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
-      '  - Windows 10, -, , -, , 100.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - Windows 10, -, , -, -, 100.00 %',
       '  - Windows 10, -2.401 %, , -, , 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
@@ -925,9 +925,9 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Status', /Regression/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
-      '  - Windows 10, -, , -, , 100.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - Windows 10, -, , -, -, 100.00 %',
       '  - Windows 10, -2.401 %, , -, , 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({});
@@ -935,7 +935,7 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Status', /Select only.*Regression/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       status: ['regression'],
@@ -944,7 +944,7 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Status', /Select only.*Improvement/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       status: ['improvement'],
@@ -961,7 +961,7 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
 
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
     ]);
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     expect(await summarizeTableFiltersFromCheckboxes(user)).toEqual({
@@ -997,25 +997,25 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr aria.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - Linux 18.04, 1.849 %, Regression, 1.2, -, 44.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 1.3, -, 24.00 %',
-      '  - Windows 10, -, , 1.2, , 99.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 1.2, , 44.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 1.3, , 24.00 %',
+      '  - Windows 10, -, , 1.2, -, 99.00 %',
       '  - Windows 10, -2.401 %, , 1.2, , 49.00 %',
       '  rev: tictactoe',
-      '  - Linux 18.04, 1.849 %, Regression, 2, -, 43.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 2.1, -, 23.00 %',
-      '  - Windows 10, -, , 2, , 98.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 2, , 43.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 2.1, , 23.00 %',
+      '  - Windows 10, -, , 2, -, 98.00 %',
       '  - Windows 10, -2.401 %, , 2, , 48.00 %',
       'a11yr dhtml.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
-      '  - Windows 10, -, , -, , 100.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - Windows 10, -, , -, -, 100.00 %',
       '  - Windows 10, -2.401 %, , -, , 50.00 %',
       '  rev: tictactoe',
-      '  - Linux 18.04, 1.849 %, Regression, 0.8, -, 44.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.9, -, 24.00 %',
-      '  - Windows 10, -, , 0.8, , 99.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 0.8, , 44.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.9, , 24.00 %',
+      '  - Windows 10, -, , 0.8, -, 99.00 %',
       '  - Windows 10, -2.401 %, , 0.8, , 49.00 %',
     ]);
     // It should have the "descending" SVG.
@@ -1028,26 +1028,26 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr aria.html opt e10s fission stylo webrender',
       '  rev: tictactoe',
-      '  - macOS 10.15, 1.078 %, Improvement, 2.1, -, 23.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 2, -, 43.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 2.1, , 23.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 2, , 43.00 %',
       '  - Windows 10, -2.401 %, , 2, , 48.00 %',
-      '  - Windows 10, -, , 2, , 98.00 %',
+      '  - Windows 10, -, , 2, -, 98.00 %',
       '  rev: spam',
-      '  - macOS 10.15, 1.078 %, Improvement, 1.3, -, 24.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 1.2, -, 44.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 1.3, , 24.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 1.2, , 44.00 %',
       '  - Windows 10, -2.401 %, , 1.2, , 49.00 %',
-      '  - Windows 10, -, , 1.2, , 99.00 %',
+      '  - Windows 10, -, , 1.2, -, 99.00 %',
       'a11yr dhtml.html opt e10s fission stylo webrender',
       '  rev: tictactoe',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.9, -, 24.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 0.8, -, 44.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.9, , 24.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 0.8, , 44.00 %',
       '  - Windows 10, -2.401 %, , 0.8, , 49.00 %',
-      '  - Windows 10, -, , 0.8, , 99.00 %',
+      '  - Windows 10, -, , 0.8, -, 99.00 %',
       '  rev: spam',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
       '  - Windows 10, -2.401 %, , -, , 50.00 %',
-      '  - Windows 10, -, , -, , 100.00 %',
+      '  - Windows 10, -, , -, -, 100.00 %',
     ]);
     // It should have the "ascending" SVG.
     expect(deltaButton).toMatchSnapshot();
@@ -1060,28 +1060,28 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     });
     await user.click(significanceButton);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
-      'a11yr aria.html opt e10s fission stylo webrender',
-      '  rev: tictactoe',
-      '  - macOS 10.15, 1.078 %, Improvement, 2.1, -, 23.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 2, -, 43.00 %',
-      '  - Windows 10, -, , 2, , 98.00 %',
-      '  - Windows 10, -2.401 %, , 2, , 48.00 %',
-      '  rev: spam',
-      '  - macOS 10.15, 1.078 %, Improvement, 1.3, -, 24.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 1.2, -, 44.00 %',
-      '  - Windows 10, -, , 1.2, , 99.00 %',
-      '  - Windows 10, -2.401 %, , 1.2, , 49.00 %',
       'a11yr dhtml.html opt e10s fission stylo webrender',
-      '  rev: tictactoe',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.9, -, 24.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 0.8, -, 44.00 %',
-      '  - Windows 10, -, , 0.8, , 99.00 %',
-      '  - Windows 10, -2.401 %, , 0.8, , 49.00 %',
       '  rev: spam',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
-      '  - Windows 10, -, , -, , 100.00 %',
       '  - Windows 10, -2.401 %, , -, , 50.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - Windows 10, -, , -, -, 100.00 %',
+      '  rev: tictactoe',
+      '  - Windows 10, -2.401 %, , 0.8, , 49.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 0.8, , 44.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.9, , 24.00 %',
+      '  - Windows 10, -, , 0.8, -, 99.00 %',
+      'a11yr aria.html opt e10s fission stylo webrender',
+      '  rev: spam',
+      '  - Windows 10, -2.401 %, , 1.2, , 49.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 1.2, , 44.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 1.3, , 24.00 %',
+      '  - Windows 10, -, , 1.2, -, 99.00 %',
+      '  rev: tictactoe',
+      '  - Windows 10, -2.401 %, , 2, , 48.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 2, , 43.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 2.1, , 23.00 %',
+      '  - Windows 10, -, , 2, -, 98.00 %',
     ]);
     // It should have the "descending" SVG.
     expect(significanceButton).toMatchSnapshot();
@@ -1093,26 +1093,26 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html opt e10s fission stylo webrender',
       '  rev: spam',
+      '  - Windows 10, -, , -, -, 100.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
       '  - Windows 10, -2.401 %, , -, , 50.00 %',
-      '  - Windows 10, -, , -, , 100.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
       '  rev: tictactoe',
+      '  - Windows 10, -, , 0.8, -, 99.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.9, , 24.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 0.8, , 44.00 %',
       '  - Windows 10, -2.401 %, , 0.8, , 49.00 %',
-      '  - Windows 10, -, , 0.8, , 99.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.9, -, 24.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 0.8, -, 44.00 %',
       'a11yr aria.html opt e10s fission stylo webrender',
       '  rev: spam',
+      '  - Windows 10, -, , 1.2, -, 99.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 1.3, , 24.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 1.2, , 44.00 %',
       '  - Windows 10, -2.401 %, , 1.2, , 49.00 %',
-      '  - Windows 10, -, , 1.2, , 99.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 1.3, -, 24.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 1.2, -, 44.00 %',
       '  rev: tictactoe',
+      '  - Windows 10, -, , 2, -, 98.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 2.1, , 23.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 2, , 43.00 %',
       '  - Windows 10, -2.401 %, , 2, , 48.00 %',
-      '  - Windows 10, -, , 2, , 98.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 2.1, -, 23.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 2, -, 43.00 %',
     ]);
     // It should have the "descending" SVG.
     expect(significanceButton).toMatchSnapshot();
@@ -1127,25 +1127,25 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - Windows 10, -, , -, , 100.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
+      '  - Windows 10, -, , -, -, 100.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
       '  - Windows 10, -2.401 %, , -, , 50.00 %',
       '  rev: tictactoe',
-      '  - Windows 10, -, , 0.8, , 99.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.9, -, 24.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 0.8, -, 44.00 %',
+      '  - Windows 10, -, , 0.8, -, 99.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.9, , 24.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 0.8, , 44.00 %',
       '  - Windows 10, -2.401 %, , 0.8, , 49.00 %',
       'a11yr aria.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - Windows 10, -, , 1.2, , 99.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 1.3, -, 24.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 1.2, -, 44.00 %',
+      '  - Windows 10, -, , 1.2, -, 99.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 1.3, , 24.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 1.2, , 44.00 %',
       '  - Windows 10, -2.401 %, , 1.2, , 49.00 %',
       '  rev: tictactoe',
-      '  - Windows 10, -, , 2, , 98.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 2.1, -, 23.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 2, -, 43.00 %',
+      '  - Windows 10, -, , 2, -, 98.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 2.1, , 23.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 2, , 43.00 %',
       '  - Windows 10, -2.401 %, , 2, , 48.00 %',
     ]);
 
@@ -1159,25 +1159,25 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
       'a11yr dhtml.html opt e10s fission stylo webrender',
       '  rev: spam',
       '  - Windows 10, -2.401 %, , -, , 50.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %',
-      '  - Windows 10, -, , -, , 100.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - Windows 10, -, , -, -, 100.00 %',
       '  rev: tictactoe',
       '  - Windows 10, -2.401 %, , 0.8, , 49.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 0.8, -, 44.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.9, -, 24.00 %',
-      '  - Windows 10, -, , 0.8, , 99.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 0.8, , 44.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.9, , 24.00 %',
+      '  - Windows 10, -, , 0.8, -, 99.00 %',
       'a11yr aria.html opt e10s fission stylo webrender',
       '  rev: spam',
       '  - Windows 10, -2.401 %, , 1.2, , 49.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 1.2, -, 44.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 1.3, -, 24.00 %',
-      '  - Windows 10, -, , 1.2, , 99.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 1.2, , 44.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 1.3, , 24.00 %',
+      '  - Windows 10, -, , 1.2, -, 99.00 %',
       '  rev: tictactoe',
       '  - Windows 10, -2.401 %, , 2, , 48.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 2, -, 43.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 2.1, -, 23.00 %',
-      '  - Windows 10, -, , 2, , 98.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 2, , 43.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 2.1, , 23.00 %',
+      '  - Windows 10, -, , 2, -, 98.00 %',
     ]);
     expect(effectSizeButton).toMatchSnapshot();
     // It should be persisted in the URL

--- a/src/__tests__/CompareResults/ResultsTable.test.tsx
+++ b/src/__tests__/CompareResults/ResultsTable.test.tsx
@@ -722,9 +722,9 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, NS, 25.00 %',
       '  rev: devilrabbit',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, NS, 25.00 %',
     ]);
     expect(screen.getByRole('rowgroup')).toMatchSnapshot();
   });
@@ -748,11 +748,11 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await screen.findByText('a11yr');
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, S, 25.00 %',
-      '  - inexistant, 1.078 %, Improvement, 0.1, S, 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
-      '  - Windows 10, -, , -, NS, 100.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, NS, 25.00 %',
+      '  - inexistant, 1.078 %, Improvement, 0.1, NS, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, NS, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, NS, 25.00 %',
+      '  - Windows 10, -, , -, S, 100.00 %',
       '  - Windows 10, -2.401 %, , -, S, 50.00 %',
     ]);
 
@@ -762,9 +762,9 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', /Windows/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, S, 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, NS, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, NS, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, NS, 25.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       platform: ['osx', 'linux', 'android', 'ios'],
@@ -775,11 +775,11 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', /Windows/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, S, 25.00 %',
-      '  - inexistant, 1.078 %, Improvement, 0.1, S, 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
-      '  - Windows 10, -, , -, NS, 100.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, NS, 25.00 %',
+      '  - inexistant, 1.078 %, Improvement, 0.1, NS, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, NS, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, NS, 25.00 %',
+      '  - Windows 10, -, , -, S, 100.00 %',
       '  - Windows 10, -2.401 %, , -, S, 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({});
@@ -788,8 +788,8 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', /Linux/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, S, 25.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, NS, 25.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, NS, 25.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       platform: ['osx', 'android', 'ios'],
@@ -798,9 +798,9 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', /Linux/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, S, 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, NS, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, NS, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, NS, 25.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       platform: ['osx', 'android', 'ios', 'linux'],
@@ -809,11 +809,11 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', 'Select all values');
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, S, 25.00 %',
-      '  - inexistant, 1.078 %, Improvement, 0.1, S, 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
-      '  - Windows 10, -, , -, NS, 100.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, NS, 25.00 %',
+      '  - inexistant, 1.078 %, Improvement, 0.1, NS, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, NS, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, NS, 25.00 %',
+      '  - Windows 10, -, , -, S, 100.00 %',
       '  - Windows 10, -2.401 %, , -, S, 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({});
@@ -821,9 +821,9 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', /macOS/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, S, 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
-      '  - Windows 10, -, , -, NS, 100.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, NS, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, NS, 45.00 %',
+      '  - Windows 10, -, , -, S, 100.00 %',
       '  - Windows 10, -2.401 %, , -, S, 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
@@ -833,8 +833,8 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', /Android/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
-      '  - Windows 10, -, , -, NS, 100.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, NS, 45.00 %',
+      '  - Windows 10, -, , -, S, 100.00 %',
       '  - Windows 10, -2.401 %, , -, S, 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
@@ -844,7 +844,7 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', /Select only.*Android/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, NS, 25.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       platform: ['android'],
@@ -883,9 +883,9 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await screen.findByText('a11yr');
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
-      '  - Windows 10, -, , -, NS, 100.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, NS, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, NS, 25.00 %',
+      '  - Windows 10, -, , -, S, 100.00 %',
       '  - Windows 10, -2.401 %, , -, S, 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({});
@@ -894,8 +894,8 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Status', /No changes/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, NS, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, NS, 25.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       status: ['improvement', 'regression'],
@@ -904,7 +904,7 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Status', /Improvement/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, NS, 45.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       status: ['regression'],
@@ -914,8 +914,8 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Status', /Regression/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
-      '  - Windows 10, -, , -, NS, 100.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, NS, 25.00 %',
+      '  - Windows 10, -, , -, S, 100.00 %',
       '  - Windows 10, -2.401 %, , -, S, 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
@@ -925,9 +925,9 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Status', /Regression/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
-      '  - Windows 10, -, , -, NS, 100.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, NS, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, NS, 25.00 %',
+      '  - Windows 10, -, , -, S, 100.00 %',
       '  - Windows 10, -2.401 %, , -, S, 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({});
@@ -935,7 +935,7 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Status', /Select only.*Regression/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, NS, 45.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       status: ['regression'],
@@ -944,7 +944,7 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Status', /Select only.*Improvement/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, NS, 25.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       status: ['improvement'],
@@ -961,7 +961,7 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
 
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, NS, 25.00 %',
     ]);
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     expect(await summarizeTableFiltersFromCheckboxes(user)).toEqual({
@@ -997,25 +997,25 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr aria.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - Linux 18.04, 1.849 %, Regression, 1.2, S, 44.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 1.3, S, 24.00 %',
-      '  - Windows 10, -, , 1.2, NS, 99.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 1.2, NS, 44.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 1.3, NS, 24.00 %',
+      '  - Windows 10, -, , 1.2, S, 99.00 %',
       '  - Windows 10, -2.401 %, , 1.2, S, 49.00 %',
       '  rev: tictactoe',
-      '  - Linux 18.04, 1.849 %, Regression, 2, S, 43.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 2.1, S, 23.00 %',
-      '  - Windows 10, -, , 2, NS, 98.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 2, NS, 43.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 2.1, NS, 23.00 %',
+      '  - Windows 10, -, , 2, S, 98.00 %',
       '  - Windows 10, -2.401 %, , 2, S, 48.00 %',
       'a11yr dhtml.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
-      '  - Windows 10, -, , -, NS, 100.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, NS, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, NS, 25.00 %',
+      '  - Windows 10, -, , -, S, 100.00 %',
       '  - Windows 10, -2.401 %, , -, S, 50.00 %',
       '  rev: tictactoe',
-      '  - Linux 18.04, 1.849 %, Regression, 0.8, S, 44.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.9, S, 24.00 %',
-      '  - Windows 10, -, , 0.8, NS, 99.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 0.8, NS, 44.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.9, NS, 24.00 %',
+      '  - Windows 10, -, , 0.8, S, 99.00 %',
       '  - Windows 10, -2.401 %, , 0.8, S, 49.00 %',
     ]);
     // It should have the "descending" SVG.
@@ -1028,26 +1028,26 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr aria.html opt e10s fission stylo webrender',
       '  rev: tictactoe',
-      '  - macOS 10.15, 1.078 %, Improvement, 2.1, S, 23.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 2, S, 43.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 2.1, NS, 23.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 2, NS, 43.00 %',
       '  - Windows 10, -2.401 %, , 2, S, 48.00 %',
-      '  - Windows 10, -, , 2, NS, 98.00 %',
+      '  - Windows 10, -, , 2, S, 98.00 %',
       '  rev: spam',
-      '  - macOS 10.15, 1.078 %, Improvement, 1.3, S, 24.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 1.2, S, 44.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 1.3, NS, 24.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 1.2, NS, 44.00 %',
       '  - Windows 10, -2.401 %, , 1.2, S, 49.00 %',
-      '  - Windows 10, -, , 1.2, NS, 99.00 %',
+      '  - Windows 10, -, , 1.2, S, 99.00 %',
       'a11yr dhtml.html opt e10s fission stylo webrender',
       '  rev: tictactoe',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.9, S, 24.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 0.8, S, 44.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.9, NS, 24.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 0.8, NS, 44.00 %',
       '  - Windows 10, -2.401 %, , 0.8, S, 49.00 %',
-      '  - Windows 10, -, , 0.8, NS, 99.00 %',
+      '  - Windows 10, -, , 0.8, S, 99.00 %',
       '  rev: spam',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, NS, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, NS, 45.00 %',
       '  - Windows 10, -2.401 %, , -, S, 50.00 %',
-      '  - Windows 10, -, , -, NS, 100.00 %',
+      '  - Windows 10, -, , -, S, 100.00 %',
     ]);
     // It should have the "ascending" SVG.
     expect(deltaButton).toMatchSnapshot();

--- a/src/__tests__/CompareResults/ResultsTable.test.tsx
+++ b/src/__tests__/CompareResults/ResultsTable.test.tsx
@@ -722,9 +722,9 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
       '  rev: devilrabbit',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
     ]);
     expect(screen.getByRole('rowgroup')).toMatchSnapshot();
   });
@@ -748,12 +748,12 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await screen.findByText('a11yr');
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, , 25.00 %',
-      '  - inexistant, 1.078 %, Improvement, 0.1, , 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
-      '  - Windows 10, -, , -, -, 100.00 %',
-      '  - Windows 10, -2.401 %, , -, , 50.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - inexistant, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - Windows 10, -, , -, NS, 100.00 %',
+      '  - Windows 10, -2.401 %, , -, S, 50.00 %',
     ]);
 
     expect(summarizeTableFiltersFromUrl()).toEqual({});
@@ -762,9 +762,9 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', /Windows/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, , 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       platform: ['osx', 'linux', 'android', 'ios'],
@@ -775,12 +775,12 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', /Windows/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, , 25.00 %',
-      '  - inexistant, 1.078 %, Improvement, 0.1, , 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
-      '  - Windows 10, -, , -, -, 100.00 %',
-      '  - Windows 10, -2.401 %, , -, , 50.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - inexistant, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - Windows 10, -, , -, NS, 100.00 %',
+      '  - Windows 10, -2.401 %, , -, S, 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({});
 
@@ -788,8 +788,8 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', /Linux/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, , 25.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       platform: ['osx', 'android', 'ios'],
@@ -798,9 +798,9 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', /Linux/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, , 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       platform: ['osx', 'android', 'ios', 'linux'],
@@ -809,22 +809,22 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', 'Select all values');
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, , 25.00 %',
-      '  - inexistant, 1.078 %, Improvement, 0.1, , 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
-      '  - Windows 10, -, , -, -, 100.00 %',
-      '  - Windows 10, -2.401 %, , -, , 50.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - inexistant, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - Windows 10, -, , -, NS, 100.00 %',
+      '  - Windows 10, -2.401 %, , -, S, 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({});
 
     await clickMenuItem(user, 'Platform', /macOS/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, , 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
-      '  - Windows 10, -, , -, -, 100.00 %',
-      '  - Windows 10, -2.401 %, , -, , 50.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
+      '  - Windows 10, -, , -, NS, 100.00 %',
+      '  - Windows 10, -2.401 %, , -, S, 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       platform: ['windows', 'linux', 'android', 'ios'],
@@ -833,9 +833,9 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', /Android/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
-      '  - Windows 10, -, , -, -, 100.00 %',
-      '  - Windows 10, -2.401 %, , -, , 50.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
+      '  - Windows 10, -, , -, NS, 100.00 %',
+      '  - Windows 10, -2.401 %, , -, S, 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       platform: ['windows', 'linux', 'ios'],
@@ -844,7 +844,7 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Platform', /Select only.*Android/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Android, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - Android, 1.078 %, Improvement, 0.1, S, 25.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       platform: ['android'],
@@ -883,10 +883,10 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await screen.findByText('a11yr');
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
-      '  - Windows 10, -, , -, -, 100.00 %',
-      '  - Windows 10, -2.401 %, , -, , 50.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - Windows 10, -, , -, NS, 100.00 %',
+      '  - Windows 10, -2.401 %, , -, S, 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({});
 
@@ -894,8 +894,8 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Status', /No changes/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       status: ['improvement', 'regression'],
@@ -904,7 +904,7 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Status', /Improvement/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       status: ['regression'],
@@ -914,9 +914,9 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Status', /Regression/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
-      '  - Windows 10, -, , -, -, 100.00 %',
-      '  - Windows 10, -2.401 %, , -, , 50.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - Windows 10, -, , -, NS, 100.00 %',
+      '  - Windows 10, -2.401 %, , -, S, 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       status: ['none', 'improvement'],
@@ -925,17 +925,17 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Status', /Regression/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
-      '  - Windows 10, -, , -, -, 100.00 %',
-      '  - Windows 10, -2.401 %, , -, , 50.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - Windows 10, -, , -, NS, 100.00 %',
+      '  - Windows 10, -2.401 %, , -, S, 50.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({});
 
     await clickMenuItem(user, 'Status', /Select only.*Regression/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       status: ['regression'],
@@ -944,7 +944,7 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     await clickMenuItem(user, 'Status', /Select only.*Improvement/);
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
     ]);
     expect(summarizeTableFiltersFromUrl()).toEqual({
       status: ['improvement'],
@@ -961,12 +961,12 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
 
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html spam opt e10s fission stylo webrender',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
     ]);
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     expect(await summarizeTableFiltersFromCheckboxes(user)).toEqual({
       'Platform(2)': ['macOS', 'Android'],
-      'Sig(2)': ['Significant', 'Not Significant-'],
+      'Sig(2)': ['SignificantS', 'Not SignificantNS'],
       'Status(3)': ['No changes', 'Improvement', 'Regression'],
     });
 
@@ -997,26 +997,26 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr aria.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - Linux 18.04, 1.849 %, Regression, 1.2, , 44.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 1.3, , 24.00 %',
-      '  - Windows 10, -, , 1.2, -, 99.00 %',
-      '  - Windows 10, -2.401 %, , 1.2, , 49.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 1.2, S, 44.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 1.3, S, 24.00 %',
+      '  - Windows 10, -, , 1.2, NS, 99.00 %',
+      '  - Windows 10, -2.401 %, , 1.2, S, 49.00 %',
       '  rev: tictactoe',
-      '  - Linux 18.04, 1.849 %, Regression, 2, , 43.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 2.1, , 23.00 %',
-      '  - Windows 10, -, , 2, -, 98.00 %',
-      '  - Windows 10, -2.401 %, , 2, , 48.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 2, S, 43.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 2.1, S, 23.00 %',
+      '  - Windows 10, -, , 2, NS, 98.00 %',
+      '  - Windows 10, -2.401 %, , 2, S, 48.00 %',
       'a11yr dhtml.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
-      '  - Windows 10, -, , -, -, 100.00 %',
-      '  - Windows 10, -2.401 %, , -, , 50.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - Windows 10, -, , -, NS, 100.00 %',
+      '  - Windows 10, -2.401 %, , -, S, 50.00 %',
       '  rev: tictactoe',
-      '  - Linux 18.04, 1.849 %, Regression, 0.8, , 44.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.9, , 24.00 %',
-      '  - Windows 10, -, , 0.8, -, 99.00 %',
-      '  - Windows 10, -2.401 %, , 0.8, , 49.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 0.8, S, 44.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.9, S, 24.00 %',
+      '  - Windows 10, -, , 0.8, NS, 99.00 %',
+      '  - Windows 10, -2.401 %, , 0.8, S, 49.00 %',
     ]);
     // It should have the "descending" SVG.
     expect(deltaButton).toMatchSnapshot();
@@ -1028,26 +1028,26 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr aria.html opt e10s fission stylo webrender',
       '  rev: tictactoe',
-      '  - macOS 10.15, 1.078 %, Improvement, 2.1, , 23.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 2, , 43.00 %',
-      '  - Windows 10, -2.401 %, , 2, , 48.00 %',
-      '  - Windows 10, -, , 2, -, 98.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 2.1, S, 23.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 2, S, 43.00 %',
+      '  - Windows 10, -2.401 %, , 2, S, 48.00 %',
+      '  - Windows 10, -, , 2, NS, 98.00 %',
       '  rev: spam',
-      '  - macOS 10.15, 1.078 %, Improvement, 1.3, , 24.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 1.2, , 44.00 %',
-      '  - Windows 10, -2.401 %, , 1.2, , 49.00 %',
-      '  - Windows 10, -, , 1.2, -, 99.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 1.3, S, 24.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 1.2, S, 44.00 %',
+      '  - Windows 10, -2.401 %, , 1.2, S, 49.00 %',
+      '  - Windows 10, -, , 1.2, NS, 99.00 %',
       'a11yr dhtml.html opt e10s fission stylo webrender',
       '  rev: tictactoe',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.9, , 24.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 0.8, , 44.00 %',
-      '  - Windows 10, -2.401 %, , 0.8, , 49.00 %',
-      '  - Windows 10, -, , 0.8, -, 99.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.9, S, 24.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 0.8, S, 44.00 %',
+      '  - Windows 10, -2.401 %, , 0.8, S, 49.00 %',
+      '  - Windows 10, -, , 0.8, NS, 99.00 %',
       '  rev: spam',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
-      '  - Windows 10, -2.401 %, , -, , 50.00 %',
-      '  - Windows 10, -, , -, -, 100.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
+      '  - Windows 10, -2.401 %, , -, S, 50.00 %',
+      '  - Windows 10, -, , -, NS, 100.00 %',
     ]);
     // It should have the "ascending" SVG.
     expect(deltaButton).toMatchSnapshot();
@@ -1062,26 +1062,26 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - Windows 10, -2.401 %, , -, , 50.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
-      '  - Windows 10, -, , -, -, 100.00 %',
+      '  - Windows 10, -2.401 %, , -, S, 50.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - Windows 10, -, , -, NS, 100.00 %',
       '  rev: tictactoe',
-      '  - Windows 10, -2.401 %, , 0.8, , 49.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 0.8, , 44.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.9, , 24.00 %',
-      '  - Windows 10, -, , 0.8, -, 99.00 %',
+      '  - Windows 10, -2.401 %, , 0.8, S, 49.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 0.8, S, 44.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.9, S, 24.00 %',
+      '  - Windows 10, -, , 0.8, NS, 99.00 %',
       'a11yr aria.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - Windows 10, -2.401 %, , 1.2, , 49.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 1.2, , 44.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 1.3, , 24.00 %',
-      '  - Windows 10, -, , 1.2, -, 99.00 %',
+      '  - Windows 10, -2.401 %, , 1.2, S, 49.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 1.2, S, 44.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 1.3, S, 24.00 %',
+      '  - Windows 10, -, , 1.2, NS, 99.00 %',
       '  rev: tictactoe',
-      '  - Windows 10, -2.401 %, , 2, , 48.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 2, , 43.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 2.1, , 23.00 %',
-      '  - Windows 10, -, , 2, -, 98.00 %',
+      '  - Windows 10, -2.401 %, , 2, S, 48.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 2, S, 43.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 2.1, S, 23.00 %',
+      '  - Windows 10, -, , 2, NS, 98.00 %',
     ]);
     // It should have the "descending" SVG.
     expect(significanceButton).toMatchSnapshot();
@@ -1093,26 +1093,26 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - Windows 10, -, , -, -, 100.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
-      '  - Windows 10, -2.401 %, , -, , 50.00 %',
+      '  - Windows 10, -, , -, NS, 100.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
+      '  - Windows 10, -2.401 %, , -, S, 50.00 %',
       '  rev: tictactoe',
-      '  - Windows 10, -, , 0.8, -, 99.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.9, , 24.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 0.8, , 44.00 %',
-      '  - Windows 10, -2.401 %, , 0.8, , 49.00 %',
+      '  - Windows 10, -, , 0.8, NS, 99.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.9, S, 24.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 0.8, S, 44.00 %',
+      '  - Windows 10, -2.401 %, , 0.8, S, 49.00 %',
       'a11yr aria.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - Windows 10, -, , 1.2, -, 99.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 1.3, , 24.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 1.2, , 44.00 %',
-      '  - Windows 10, -2.401 %, , 1.2, , 49.00 %',
+      '  - Windows 10, -, , 1.2, NS, 99.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 1.3, S, 24.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 1.2, S, 44.00 %',
+      '  - Windows 10, -2.401 %, , 1.2, S, 49.00 %',
       '  rev: tictactoe',
-      '  - Windows 10, -, , 2, -, 98.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 2.1, , 23.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 2, , 43.00 %',
-      '  - Windows 10, -2.401 %, , 2, , 48.00 %',
+      '  - Windows 10, -, , 2, NS, 98.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 2.1, S, 23.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 2, S, 43.00 %',
+      '  - Windows 10, -2.401 %, , 2, S, 48.00 %',
     ]);
     // It should have the "descending" SVG.
     expect(significanceButton).toMatchSnapshot();
@@ -1127,26 +1127,26 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - Windows 10, -, , -, -, 100.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
-      '  - Windows 10, -2.401 %, , -, , 50.00 %',
+      '  - Windows 10, -, , -, NS, 100.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
+      '  - Windows 10, -2.401 %, , -, S, 50.00 %',
       '  rev: tictactoe',
-      '  - Windows 10, -, , 0.8, -, 99.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.9, , 24.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 0.8, , 44.00 %',
-      '  - Windows 10, -2.401 %, , 0.8, , 49.00 %',
+      '  - Windows 10, -, , 0.8, NS, 99.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.9, S, 24.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 0.8, S, 44.00 %',
+      '  - Windows 10, -2.401 %, , 0.8, S, 49.00 %',
       'a11yr aria.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - Windows 10, -, , 1.2, -, 99.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 1.3, , 24.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 1.2, , 44.00 %',
-      '  - Windows 10, -2.401 %, , 1.2, , 49.00 %',
+      '  - Windows 10, -, , 1.2, NS, 99.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 1.3, S, 24.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 1.2, S, 44.00 %',
+      '  - Windows 10, -2.401 %, , 1.2, S, 49.00 %',
       '  rev: tictactoe',
-      '  - Windows 10, -, , 2, -, 98.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 2.1, , 23.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 2, , 43.00 %',
-      '  - Windows 10, -2.401 %, , 2, , 48.00 %',
+      '  - Windows 10, -, , 2, NS, 98.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 2.1, S, 23.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 2, S, 43.00 %',
+      '  - Windows 10, -2.401 %, , 2, S, 48.00 %',
     ]);
 
     expect(effectSizeButton).toMatchSnapshot();
@@ -1158,26 +1158,26 @@ describe('Results Table for MannWhitneyResultsItem for mann-whitney-u testVersio
     expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
       'a11yr dhtml.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - Windows 10, -2.401 %, , -, , 50.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %',
-      '  - Windows 10, -, , -, -, 100.00 %',
+      '  - Windows 10, -2.401 %, , -, S, 50.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %',
+      '  - Windows 10, -, , -, NS, 100.00 %',
       '  rev: tictactoe',
-      '  - Windows 10, -2.401 %, , 0.8, , 49.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 0.8, , 44.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 0.9, , 24.00 %',
-      '  - Windows 10, -, , 0.8, -, 99.00 %',
+      '  - Windows 10, -2.401 %, , 0.8, S, 49.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 0.8, S, 44.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 0.9, S, 24.00 %',
+      '  - Windows 10, -, , 0.8, NS, 99.00 %',
       'a11yr aria.html opt e10s fission stylo webrender',
       '  rev: spam',
-      '  - Windows 10, -2.401 %, , 1.2, , 49.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 1.2, , 44.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 1.3, , 24.00 %',
-      '  - Windows 10, -, , 1.2, -, 99.00 %',
+      '  - Windows 10, -2.401 %, , 1.2, S, 49.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 1.2, S, 44.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 1.3, S, 24.00 %',
+      '  - Windows 10, -, , 1.2, NS, 99.00 %',
       '  rev: tictactoe',
-      '  - Windows 10, -2.401 %, , 2, , 48.00 %',
-      '  - Linux 18.04, 1.849 %, Regression, 2, , 43.00 %',
-      '  - macOS 10.15, 1.078 %, Improvement, 2.1, , 23.00 %',
-      '  - Windows 10, -, , 2, -, 98.00 %',
+      '  - Windows 10, -2.401 %, , 2, S, 48.00 %',
+      '  - Linux 18.04, 1.849 %, Regression, 2, S, 43.00 %',
+      '  - macOS 10.15, 1.078 %, Improvement, 2.1, S, 23.00 %',
+      '  - Windows 10, -, , 2, NS, 98.00 %',
     ]);
     expect(effectSizeButton).toMatchSnapshot();
     // It should be persisted in the URL

--- a/src/__tests__/CompareResults/RevisionRow.test.tsx
+++ b/src/__tests__/CompareResults/RevisionRow.test.tsx
@@ -281,49 +281,6 @@ describe('Expanded row', () => {
     expect(cliffsDeltaHeader).toBeInTheDocument();
   });
 
-  it('should display mann_whitney_test.interpretation for significance for mann-whitney-u testVersion', async () => {
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-    const { testCompareMannWhitneyData: rowData } = getTestData();
-
-    renderWithRoute(
-      <RevisionRow
-        result={rowData[0]}
-        view={compareView}
-        gridTemplateColumns='none'
-        replicates={false}
-        testVersion='mann-whitney-u'
-        expandAll={false}
-      />,
-    );
-
-    const expandRowButton = await screen.findByTestId(/ExpandMoreIcon/);
-    await user.click(expandRowButton);
-
-    const notSignificant = await screen.findAllByText(/Not significant/);
-    expect(notSignificant[0]).toBeInTheDocument();
-  });
-
-  it('should handle empty mann_whitney_test.interpretation for significance for mann-whitney-u testVersion', async () => {
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-    const { testCompareMannWhitneyData: rowData } = getTestData();
-    const resultNoInterpretation = { ...rowData[0], mann_whitney_test: null };
-    renderWithRoute(
-      <RevisionRow
-        result={resultNoInterpretation}
-        view={compareView}
-        gridTemplateColumns='none'
-        replicates={false}
-        testVersion='mann-whitney-u'
-        expandAll={false}
-      />,
-    );
-
-    const expandRowButton = await screen.findByTestId(/ExpandMoreIcon/);
-    await user.click(expandRowButton);
-    const emptySignificant = await screen.findAllByText(/-/);
-    expect(emptySignificant[0]).toBeInTheDocument();
-  });
-
   it('should display median diff and 95% CI alerts when base/new runs are present', async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     const { testCompareMannWhitneyData: rowData } = getTestData();

--- a/src/__tests__/CompareResults/SubtestsResultsView.test.tsx
+++ b/src/__tests__/CompareResults/SubtestsResultsView.test.tsx
@@ -527,11 +527,11 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       await setupForSorting();
       // Initial view (alphabetical ordered, even if "sort by subtests" isn't specified
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
-        'browser.html: 0.963 %, -0.04, -, 15.00%',
-        'dhtml.html: 1.135 %, 0.02, -, 60.00%',
-        'improvement.html: 0.963 %, -0.05, -, 50.00%',
-        'regression.html: 1.135 %, 0.12, -, 25.00%',
-        'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
+        'browser.html: 0.963 %, -0.04, NS, 15.00%',
+        'dhtml.html: 1.135 %, 0.02, NS, 60.00%',
+        'improvement.html: 0.963 %, -0.05, NS, 50.00%',
+        'regression.html: 1.135 %, 0.12, NS, 25.00%',
+        'tablemutation.html: 0.98 %, 0.01, NS, 45.00%',
       ]);
 
       // Sort by Delta
@@ -542,11 +542,11 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       // Sort descending
       await user.click(deltaButton);
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
-        'regression.html: 1.135 %, 0.12, -, 25.00%',
-        'improvement.html: 0.963 %, -0.05, -, 50.00%',
-        'browser.html: 0.963 %, -0.04, -, 15.00%',
-        'dhtml.html: 1.135 %, 0.02, -, 60.00%',
-        'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
+        'regression.html: 1.135 %, 0.12, NS, 25.00%',
+        'improvement.html: 0.963 %, -0.05, NS, 50.00%',
+        'browser.html: 0.963 %, -0.04, NS, 15.00%',
+        'dhtml.html: 1.135 %, 0.02, NS, 60.00%',
+        'tablemutation.html: 0.98 %, 0.01, NS, 45.00%',
       ]);
 
       // It should have the "descending" SVG.
@@ -557,11 +557,11 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       // Sort ascending
       await user.click(deltaButton);
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
-        'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
-        'dhtml.html: 1.135 %, 0.02, -, 60.00%',
-        'browser.html: 0.963 %, -0.04, -, 15.00%',
-        'improvement.html: 0.963 %, -0.05, -, 50.00%',
-        'regression.html: 1.135 %, 0.12, -, 25.00%',
+        'tablemutation.html: 0.98 %, 0.01, NS, 45.00%',
+        'dhtml.html: 1.135 %, 0.02, NS, 60.00%',
+        'browser.html: 0.963 %, -0.04, NS, 15.00%',
+        'improvement.html: 0.963 %, -0.05, NS, 50.00%',
+        'regression.html: 1.135 %, 0.12, NS, 25.00%',
       ]);
       // It should have the "ascending" SVG.
       expect(deltaButton).toMatchSnapshot();
@@ -574,11 +574,11 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       });
       await user.click(significanceButton);
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
-        'dhtml.html: 1.135 %, 0.02, -, 60.00%',
-        'regression.html: 1.135 %, 0.12, -, 25.00%',
-        'improvement.html: 0.963 %, -0.05, -, 50.00%',
-        'browser.html: 0.963 %, -0.04, -, 15.00%',
-        'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
+        'dhtml.html: 1.135 %, 0.02, NS, 60.00%',
+        'regression.html: 1.135 %, 0.12, NS, 25.00%',
+        'improvement.html: 0.963 %, -0.05, NS, 50.00%',
+        'browser.html: 0.963 %, -0.04, NS, 15.00%',
+        'tablemutation.html: 0.98 %, 0.01, NS, 45.00%',
       ]);
       // It should have the "no sort" SVG.
       expect(deltaButton).toMatchSnapshot();
@@ -590,11 +590,11 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       // Sort by Significance ascending
       await user.click(significanceButton);
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
-        'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
-        'dhtml.html: 1.135 %, 0.02, -, 60.00%',
-        'regression.html: 1.135 %, 0.12, -, 25.00%',
-        'improvement.html: 0.963 %, -0.05, -, 50.00%',
-        'browser.html: 0.963 %, -0.04, -, 15.00%',
+        'tablemutation.html: 0.98 %, 0.01, NS, 45.00%',
+        'dhtml.html: 1.135 %, 0.02, NS, 60.00%',
+        'regression.html: 1.135 %, 0.12, NS, 25.00%',
+        'improvement.html: 0.963 %, -0.05, NS, 50.00%',
+        'browser.html: 0.963 %, -0.04, NS, 15.00%',
       ]);
       expectParameterToHaveValue('sort', 'significance|asc');
 
@@ -604,11 +604,11 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       });
       await user.click(effectButton);
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
-        'browser.html: 0.963 %, -0.04, -, 15.00%',
-        'regression.html: 1.135 %, 0.12, -, 25.00%',
-        'dhtml.html: 1.135 %, 0.02, -, 60.00%',
-        'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
-        'improvement.html: 0.963 %, -0.05, -, 50.00%',
+        'browser.html: 0.963 %, -0.04, NS, 15.00%',
+        'regression.html: 1.135 %, 0.12, NS, 25.00%',
+        'dhtml.html: 1.135 %, 0.02, NS, 60.00%',
+        'tablemutation.html: 0.98 %, 0.01, NS, 45.00%',
+        'improvement.html: 0.963 %, -0.05, NS, 50.00%',
       ]);
 
       // It should have the "descending" SVG.
@@ -619,11 +619,11 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       // Sort by Effect Size ascending
       await user.click(effectButton);
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
-        'improvement.html: 0.963 %, -0.05, -, 50.00%',
-        'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
-        'dhtml.html: 1.135 %, 0.02, -, 60.00%',
-        'regression.html: 1.135 %, 0.12, -, 25.00%',
-        'browser.html: 0.963 %, -0.04, -, 15.00%',
+        'improvement.html: 0.963 %, -0.05, NS, 50.00%',
+        'tablemutation.html: 0.98 %, 0.01, NS, 45.00%',
+        'dhtml.html: 1.135 %, 0.02, NS, 60.00%',
+        'regression.html: 1.135 %, 0.12, NS, 25.00%',
+        'browser.html: 0.963 %, -0.04, NS, 15.00%',
       ]);
       expectParameterToHaveValue('sort', 'effects|asc');
     });
@@ -632,11 +632,11 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       await setupForSorting({ extraParameters: 'sort=delta|asc' });
       await screen.findByText('dhtml.html');
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
-        'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
-        'dhtml.html: 1.135 %, 0.02, -, 60.00%',
-        'browser.html: 0.963 %, -0.04, -, 15.00%',
-        'improvement.html: 0.963 %, -0.05, -, 50.00%',
-        'regression.html: 1.135 %, 0.12, -, 25.00%',
+        'tablemutation.html: 0.98 %, 0.01, NS, 45.00%',
+        'dhtml.html: 1.135 %, 0.02, NS, 60.00%',
+        'browser.html: 0.963 %, -0.04, NS, 15.00%',
+        'improvement.html: 0.963 %, -0.05, NS, 50.00%',
+        'regression.html: 1.135 %, 0.12, NS, 25.00%',
       ]);
       // It should have the "ascending" SVG.
       expect(screen.getByRole('button', { name: /CD/ })).toMatchSnapshot();
@@ -646,11 +646,11 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       await setupForSorting({ extraParameters: 'sort=delta' });
       await screen.findByText('dhtml.html');
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
-        'regression.html: 1.135 %, 0.12, -, 25.00%',
-        'improvement.html: 0.963 %, -0.05, -, 50.00%',
-        'browser.html: 0.963 %, -0.04, -, 15.00%',
-        'dhtml.html: 1.135 %, 0.02, -, 60.00%',
-        'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
+        'regression.html: 1.135 %, 0.12, NS, 25.00%',
+        'improvement.html: 0.963 %, -0.05, NS, 50.00%',
+        'browser.html: 0.963 %, -0.04, NS, 15.00%',
+        'dhtml.html: 1.135 %, 0.02, NS, 60.00%',
+        'tablemutation.html: 0.98 %, 0.01, NS, 45.00%',
       ]);
       // It should have the "descending" SVG.
       expect(screen.getByRole('button', { name: /CD/ })).toMatchSnapshot();
@@ -659,11 +659,11 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
     it('initializes the sort from the URL at load time for a descending sort', async () => {
       await setupForSorting({ extraParameters: 'sort=delta|desc' });
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
-        'regression.html: 1.135 %, 0.12, -, 25.00%',
-        'improvement.html: 0.963 %, -0.05, -, 50.00%',
-        'browser.html: 0.963 %, -0.04, -, 15.00%',
-        'dhtml.html: 1.135 %, 0.02, -, 60.00%',
-        'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
+        'regression.html: 1.135 %, 0.12, NS, 25.00%',
+        'improvement.html: 0.963 %, -0.05, NS, 50.00%',
+        'browser.html: 0.963 %, -0.04, NS, 15.00%',
+        'dhtml.html: 1.135 %, 0.02, NS, 60.00%',
+        'tablemutation.html: 0.98 %, 0.01, NS, 45.00%',
       ]);
       // It should have the "descending" SVG.
       expect(screen.getByRole('button', { name: /CD/ })).toMatchSnapshot();

--- a/src/__tests__/CompareResults/SubtestsResultsView.test.tsx
+++ b/src/__tests__/CompareResults/SubtestsResultsView.test.tsx
@@ -528,9 +528,9 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       // Initial view (alphabetical ordered, even if "sort by subtests" isn't specified
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
         'browser.html: 0.963 %, -0.04, -, 15.00%',
-        'dhtml.html: 1.135 %, 0.02, , 60.00%',
-        'improvement.html: 0.963 %, -0.05, , 50.00%',
-        'regression.html: 1.135 %, 0.12, , 25.00%',
+        'dhtml.html: 1.135 %, 0.02, -, 60.00%',
+        'improvement.html: 0.963 %, -0.05, -, 50.00%',
+        'regression.html: 1.135 %, 0.12, -, 25.00%',
         'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
       ]);
 
@@ -542,10 +542,10 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       // Sort descending
       await user.click(deltaButton);
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
-        'regression.html: 1.135 %, 0.12, , 25.00%',
-        'improvement.html: 0.963 %, -0.05, , 50.00%',
+        'regression.html: 1.135 %, 0.12, -, 25.00%',
+        'improvement.html: 0.963 %, -0.05, -, 50.00%',
         'browser.html: 0.963 %, -0.04, -, 15.00%',
-        'dhtml.html: 1.135 %, 0.02, , 60.00%',
+        'dhtml.html: 1.135 %, 0.02, -, 60.00%',
         'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
       ]);
 
@@ -558,10 +558,10 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       await user.click(deltaButton);
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
         'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
-        'dhtml.html: 1.135 %, 0.02, , 60.00%',
+        'dhtml.html: 1.135 %, 0.02, -, 60.00%',
         'browser.html: 0.963 %, -0.04, -, 15.00%',
-        'improvement.html: 0.963 %, -0.05, , 50.00%',
-        'regression.html: 1.135 %, 0.12, , 25.00%',
+        'improvement.html: 0.963 %, -0.05, -, 50.00%',
+        'regression.html: 1.135 %, 0.12, -, 25.00%',
       ]);
       // It should have the "ascending" SVG.
       expect(deltaButton).toMatchSnapshot();
@@ -574,11 +574,11 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       });
       await user.click(significanceButton);
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
+        'dhtml.html: 1.135 %, 0.02, -, 60.00%',
+        'regression.html: 1.135 %, 0.12, -, 25.00%',
+        'improvement.html: 0.963 %, -0.05, -, 50.00%',
         'browser.html: 0.963 %, -0.04, -, 15.00%',
         'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
-        'dhtml.html: 1.135 %, 0.02, , 60.00%',
-        'regression.html: 1.135 %, 0.12, , 25.00%',
-        'improvement.html: 0.963 %, -0.05, , 50.00%',
       ]);
       // It should have the "no sort" SVG.
       expect(deltaButton).toMatchSnapshot();
@@ -590,10 +590,10 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       // Sort by Significance ascending
       await user.click(significanceButton);
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
-        'improvement.html: 0.963 %, -0.05, , 50.00%',
-        'regression.html: 1.135 %, 0.12, , 25.00%',
-        'dhtml.html: 1.135 %, 0.02, , 60.00%',
         'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
+        'dhtml.html: 1.135 %, 0.02, -, 60.00%',
+        'regression.html: 1.135 %, 0.12, -, 25.00%',
+        'improvement.html: 0.963 %, -0.05, -, 50.00%',
         'browser.html: 0.963 %, -0.04, -, 15.00%',
       ]);
       expectParameterToHaveValue('sort', 'significance|asc');
@@ -605,10 +605,10 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       await user.click(effectButton);
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
         'browser.html: 0.963 %, -0.04, -, 15.00%',
-        'regression.html: 1.135 %, 0.12, , 25.00%',
-        'dhtml.html: 1.135 %, 0.02, , 60.00%',
+        'regression.html: 1.135 %, 0.12, -, 25.00%',
+        'dhtml.html: 1.135 %, 0.02, -, 60.00%',
         'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
-        'improvement.html: 0.963 %, -0.05, , 50.00%',
+        'improvement.html: 0.963 %, -0.05, -, 50.00%',
       ]);
 
       // It should have the "descending" SVG.
@@ -619,10 +619,10 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       // Sort by Effect Size ascending
       await user.click(effectButton);
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
-        'improvement.html: 0.963 %, -0.05, , 50.00%',
+        'improvement.html: 0.963 %, -0.05, -, 50.00%',
         'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
-        'dhtml.html: 1.135 %, 0.02, , 60.00%',
-        'regression.html: 1.135 %, 0.12, , 25.00%',
+        'dhtml.html: 1.135 %, 0.02, -, 60.00%',
+        'regression.html: 1.135 %, 0.12, -, 25.00%',
         'browser.html: 0.963 %, -0.04, -, 15.00%',
       ]);
       expectParameterToHaveValue('sort', 'effects|asc');
@@ -633,10 +633,10 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       await screen.findByText('dhtml.html');
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
         'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
-        'dhtml.html: 1.135 %, 0.02, , 60.00%',
+        'dhtml.html: 1.135 %, 0.02, -, 60.00%',
         'browser.html: 0.963 %, -0.04, -, 15.00%',
-        'improvement.html: 0.963 %, -0.05, , 50.00%',
-        'regression.html: 1.135 %, 0.12, , 25.00%',
+        'improvement.html: 0.963 %, -0.05, -, 50.00%',
+        'regression.html: 1.135 %, 0.12, -, 25.00%',
       ]);
       // It should have the "ascending" SVG.
       expect(screen.getByRole('button', { name: /CD/ })).toMatchSnapshot();
@@ -646,10 +646,10 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       await setupForSorting({ extraParameters: 'sort=delta' });
       await screen.findByText('dhtml.html');
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
-        'regression.html: 1.135 %, 0.12, , 25.00%',
-        'improvement.html: 0.963 %, -0.05, , 50.00%',
+        'regression.html: 1.135 %, 0.12, -, 25.00%',
+        'improvement.html: 0.963 %, -0.05, -, 50.00%',
         'browser.html: 0.963 %, -0.04, -, 15.00%',
-        'dhtml.html: 1.135 %, 0.02, , 60.00%',
+        'dhtml.html: 1.135 %, 0.02, -, 60.00%',
         'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
       ]);
       // It should have the "descending" SVG.
@@ -659,10 +659,10 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
     it('initializes the sort from the URL at load time for a descending sort', async () => {
       await setupForSorting({ extraParameters: 'sort=delta|desc' });
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
-        'regression.html: 1.135 %, 0.12, , 25.00%',
-        'improvement.html: 0.963 %, -0.05, , 50.00%',
+        'regression.html: 1.135 %, 0.12, -, 25.00%',
+        'improvement.html: 0.963 %, -0.05, -, 50.00%',
         'browser.html: 0.963 %, -0.04, -, 15.00%',
-        'dhtml.html: 1.135 %, 0.02, , 60.00%',
+        'dhtml.html: 1.135 %, 0.02, -, 60.00%',
         'tablemutation.html: 0.98 %, 0.01, -, 45.00%',
       ]);
       // It should have the "descending" SVG.

--- a/src/__tests__/CompareResults/SubtestsResultsView.test.tsx
+++ b/src/__tests__/CompareResults/SubtestsResultsView.test.tsx
@@ -528,9 +528,9 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       // Initial view (alphabetical ordered, even if "sort by subtests" isn't specified
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
         'browser.html: 0.963 %, -0.04, NS, 15.00%',
-        'dhtml.html: 1.135 %, 0.02, NS, 60.00%',
-        'improvement.html: 0.963 %, -0.05, NS, 50.00%',
-        'regression.html: 1.135 %, 0.12, NS, 25.00%',
+        'dhtml.html: 1.135 %, 0.02, S, 60.00%',
+        'improvement.html: 0.963 %, -0.05, S, 50.00%',
+        'regression.html: 1.135 %, 0.12, S, 25.00%',
         'tablemutation.html: 0.98 %, 0.01, NS, 45.00%',
       ]);
 
@@ -542,10 +542,10 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       // Sort descending
       await user.click(deltaButton);
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
-        'regression.html: 1.135 %, 0.12, NS, 25.00%',
-        'improvement.html: 0.963 %, -0.05, NS, 50.00%',
+        'regression.html: 1.135 %, 0.12, S, 25.00%',
+        'improvement.html: 0.963 %, -0.05, S, 50.00%',
         'browser.html: 0.963 %, -0.04, NS, 15.00%',
-        'dhtml.html: 1.135 %, 0.02, NS, 60.00%',
+        'dhtml.html: 1.135 %, 0.02, S, 60.00%',
         'tablemutation.html: 0.98 %, 0.01, NS, 45.00%',
       ]);
 
@@ -558,10 +558,10 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       await user.click(deltaButton);
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
         'tablemutation.html: 0.98 %, 0.01, NS, 45.00%',
-        'dhtml.html: 1.135 %, 0.02, NS, 60.00%',
+        'dhtml.html: 1.135 %, 0.02, S, 60.00%',
         'browser.html: 0.963 %, -0.04, NS, 15.00%',
-        'improvement.html: 0.963 %, -0.05, NS, 50.00%',
-        'regression.html: 1.135 %, 0.12, NS, 25.00%',
+        'improvement.html: 0.963 %, -0.05, S, 50.00%',
+        'regression.html: 1.135 %, 0.12, S, 25.00%',
       ]);
       // It should have the "ascending" SVG.
       expect(deltaButton).toMatchSnapshot();
@@ -633,10 +633,10 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       await screen.findByText('dhtml.html');
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
         'tablemutation.html: 0.98 %, 0.01, NS, 45.00%',
-        'dhtml.html: 1.135 %, 0.02, NS, 60.00%',
+        'dhtml.html: 1.135 %, 0.02, S, 60.00%',
         'browser.html: 0.963 %, -0.04, NS, 15.00%',
-        'improvement.html: 0.963 %, -0.05, NS, 50.00%',
-        'regression.html: 1.135 %, 0.12, NS, 25.00%',
+        'improvement.html: 0.963 %, -0.05, S, 50.00%',
+        'regression.html: 1.135 %, 0.12, S, 25.00%',
       ]);
       // It should have the "ascending" SVG.
       expect(screen.getByRole('button', { name: /CD/ })).toMatchSnapshot();
@@ -646,10 +646,10 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
       await setupForSorting({ extraParameters: 'sort=delta' });
       await screen.findByText('dhtml.html');
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
-        'regression.html: 1.135 %, 0.12, NS, 25.00%',
-        'improvement.html: 0.963 %, -0.05, NS, 50.00%',
+        'regression.html: 1.135 %, 0.12, S, 25.00%',
+        'improvement.html: 0.963 %, -0.05, S, 50.00%',
         'browser.html: 0.963 %, -0.04, NS, 15.00%',
-        'dhtml.html: 1.135 %, 0.02, NS, 60.00%',
+        'dhtml.html: 1.135 %, 0.02, S, 60.00%',
         'tablemutation.html: 0.98 %, 0.01, NS, 45.00%',
       ]);
       // It should have the "descending" SVG.
@@ -659,10 +659,10 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
     it('initializes the sort from the URL at load time for a descending sort', async () => {
       await setupForSorting({ extraParameters: 'sort=delta|desc' });
       expect(summarizeVisibleRows('mann-whitney-u')).toEqual([
-        'regression.html: 1.135 %, 0.12, NS, 25.00%',
-        'improvement.html: 0.963 %, -0.05, NS, 50.00%',
+        'regression.html: 1.135 %, 0.12, S, 25.00%',
+        'improvement.html: 0.963 %, -0.05, S, 50.00%',
         'browser.html: 0.963 %, -0.04, NS, 15.00%',
-        'dhtml.html: 1.135 %, 0.02, NS, 60.00%',
+        'dhtml.html: 1.135 %, 0.02, S, 60.00%',
         'tablemutation.html: 0.98 %, 0.01, NS, 45.00%',
       ]);
       // It should have the "descending" SVG.

--- a/src/__tests__/CompareResults/SubtestsRevisionRow.test.tsx
+++ b/src/__tests__/CompareResults/SubtestsRevisionRow.test.tsx
@@ -193,12 +193,13 @@ describe('SubtestsRevisionRow Component', () => {
     const effects = roles[7]?.childNodes[0];
     expect(effects).toHaveTextContent('60.00%');
 
-    // The fixture runs don't yield a CI that excludes 0 once precomputed by
-    // the loader, so this row renders "NS". This test mounts the row directly
-    // without the loader, leaving bootstrapCi undefined, which also falls
-    // back to "NS".
+    // The Sig cell renders lazily: when no CI has been cached on the row
+    // yet, it falls back to `mann_whitney_test.interpretation` from the
+    // backend. The fixture's interpretation is "significant", so the cell
+    // shows "S" here. First click on the Sig column header would trigger
+    // BCa and could flip this if the CI includes zero.
     const significanceCell = roles[8];
-    expect(significanceCell).toHaveTextContent('NS');
+    expect(significanceCell).toHaveTextContent('S');
 
     const cliffs_delta = roles[6]?.childNodes[1];
     expect(cliffs_delta).toHaveTextContent('0.02');

--- a/src/__tests__/CompareResults/SubtestsRevisionRow.test.tsx
+++ b/src/__tests__/CompareResults/SubtestsRevisionRow.test.tsx
@@ -194,11 +194,11 @@ describe('SubtestsRevisionRow Component', () => {
     expect(effects).toHaveTextContent('60.00%');
 
     // The fixture runs don't yield a CI that excludes 0 once precomputed by
-    // the loader, so this row renders the "-" placeholder. This test mounts
-    // the row directly without the loader, leaving bootstrapCi undefined,
-    // which also falls back to "-". Either way: no icon is rendered.
+    // the loader, so this row renders "NS". This test mounts the row directly
+    // without the loader, leaving bootstrapCi undefined, which also falls
+    // back to "NS".
     const significanceCell = roles[8];
-    expect(significanceCell).toHaveTextContent('-');
+    expect(significanceCell).toHaveTextContent('NS');
 
     const cliffs_delta = roles[6]?.childNodes[1];
     expect(cliffs_delta).toHaveTextContent('0.02');

--- a/src/__tests__/CompareResults/SubtestsRevisionRow.test.tsx
+++ b/src/__tests__/CompareResults/SubtestsRevisionRow.test.tsx
@@ -193,8 +193,12 @@ describe('SubtestsRevisionRow Component', () => {
     const effects = roles[7]?.childNodes[0];
     expect(effects).toHaveTextContent('60.00%');
 
+    // The fixture runs don't yield a CI that excludes 0 once precomputed by
+    // the loader, so this row renders the "-" placeholder. This test mounts
+    // the row directly without the loader, leaving bootstrapCi undefined,
+    // which also falls back to "-". Either way: no icon is rendered.
     const significanceCell = roles[8];
-    expect(significanceCell?.querySelector('svg')).not.toBeNull();
+    expect(significanceCell).toHaveTextContent('-');
 
     const cliffs_delta = roles[6]?.childNodes[1];
     expect(cliffs_delta).toHaveTextContent('0.02');

--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -824,7 +824,20 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                    data-testid="KeyboardDoubleArrowUpIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
+                    />
+                    <path
+                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
+                    />
+                  </svg>
                 </div>
                 <div
                   class="total-runs cell"
@@ -1023,7 +1036,20 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                    data-testid="KeyboardDoubleArrowUpIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
+                    />
+                    <path
+                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
+                    />
+                  </svg>
                 </div>
                 <div
                   class="total-runs cell"
@@ -1222,7 +1248,20 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                    data-testid="KeyboardDoubleArrowUpIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
+                    />
+                    <path
+                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
+                    />
+                  </svg>
                 </div>
                 <div
                   class="total-runs cell"
@@ -1421,7 +1460,20 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                    data-testid="KeyboardDoubleArrowUpIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
+                    />
+                    <path
+                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
+                    />
+                  </svg>
                 </div>
                 <div
                   class="total-runs cell"

--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -824,7 +824,7 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="significance cell"
                   role="cell"
                 >
-                  S
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -1023,7 +1023,7 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="significance cell"
                   role="cell"
                 >
-                  S
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -1222,7 +1222,7 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="significance cell"
                   role="cell"
                 >
-                  S
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -1421,7 +1421,7 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="significance cell"
                   role="cell"
                 >
-                  S
+                  NS
                 </div>
                 <div
                   class="total-runs cell"

--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -824,20 +824,7 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="significance cell"
                   role="cell"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                    data-testid="KeyboardDoubleArrowUpIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
-                    />
-                    <path
-                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
-                    />
-                  </svg>
+                  S
                 </div>
                 <div
                   class="total-runs cell"
@@ -1036,20 +1023,7 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="significance cell"
                   role="cell"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                    data-testid="KeyboardDoubleArrowUpIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
-                    />
-                    <path
-                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
-                    />
-                  </svg>
+                  S
                 </div>
                 <div
                   class="total-runs cell"
@@ -1248,20 +1222,7 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="significance cell"
                   role="cell"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                    data-testid="KeyboardDoubleArrowUpIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
-                    />
-                    <path
-                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
-                    />
-                  </svg>
+                  S
                 </div>
                 <div
                   class="total-runs cell"
@@ -1460,20 +1421,7 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="significance cell"
                   role="cell"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                    data-testid="KeyboardDoubleArrowUpIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
-                    />
-                    <path
-                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
-                    />
-                  </svg>
+                  S
                 </div>
                 <div
                   class="total-runs cell"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -1797,7 +1797,20 @@ exports[`Results Table Should match snapshot 1`] = `
                               class="significance cell"
                               role="cell"
                             >
-                              -
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                                data-testid="KeyboardDoubleArrowUpIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
+                                />
+                                <path
+                                  d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
+                                />
+                              </svg>
                             </div>
                             <div
                               class="total-runs cell"
@@ -1996,7 +2009,20 @@ exports[`Results Table Should match snapshot 1`] = `
                               class="significance cell"
                               role="cell"
                             >
-                              -
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                                data-testid="KeyboardDoubleArrowUpIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
+                                />
+                                <path
+                                  d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
+                                />
+                              </svg>
                             </div>
                             <div
                               class="total-runs cell"
@@ -2195,7 +2221,20 @@ exports[`Results Table Should match snapshot 1`] = `
                               class="significance cell"
                               role="cell"
                             >
-                              -
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                                data-testid="KeyboardDoubleArrowUpIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
+                                />
+                                <path
+                                  d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
+                                />
+                              </svg>
                             </div>
                             <div
                               class="total-runs cell"
@@ -2481,7 +2520,20 @@ exports[`Results Table Should match snapshot 1`] = `
                               class="significance cell"
                               role="cell"
                             >
-                              -
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                                data-testid="KeyboardDoubleArrowUpIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
+                                />
+                                <path
+                                  d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
+                                />
+                              </svg>
                             </div>
                             <div
                               class="total-runs cell"
@@ -4693,7 +4745,20 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                               class="significance cell"
                               role="cell"
                             >
-                              -
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                                data-testid="KeyboardDoubleArrowUpIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
+                                />
+                                <path
+                                  d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
+                                />
+                              </svg>
                             </div>
                             <div
                               class="total-runs cell"
@@ -4905,7 +4970,20 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                               class="significance cell"
                               role="cell"
                             >
-                              -
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                                data-testid="KeyboardDoubleArrowUpIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
+                                />
+                                <path
+                                  d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
+                                />
+                              </svg>
                             </div>
                             <div
                               class="total-runs cell"
@@ -5399,20 +5477,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                               class="significance cell"
                               role="cell"
                             >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                                data-testid="KeyboardDoubleArrowUpIcon"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
-                                />
-                                <path
-                                  d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
-                                />
-                              </svg>
+                              -
                             </div>
                             <div
                               class="total-runs cell"
@@ -5835,25 +5900,25 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
 [
   "a11yr dhtml.html opt e10s fission stylo webrender",
   "  rev: spam",
-  "  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %",
-  "  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %",
-  "  - Windows 10, -, , -, , 100.00 %",
+  "  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %",
+  "  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %",
+  "  - Windows 10, -, , -, -, 100.00 %",
   "  - Windows 10, -2.401 %, , -, , 50.00 %",
   "  rev: tictactoe",
-  "  - Linux 18.04, 1.849 %, Regression, 0.8, -, 44.00 %",
-  "  - macOS 10.15, 1.078 %, Improvement, 0.9, -, 24.00 %",
-  "  - Windows 10, -, , 0.8, , 99.00 %",
+  "  - Linux 18.04, 1.849 %, Regression, 0.8, , 44.00 %",
+  "  - macOS 10.15, 1.078 %, Improvement, 0.9, , 24.00 %",
+  "  - Windows 10, -, , 0.8, -, 99.00 %",
   "  - Windows 10, -2.401 %, , 0.8, , 49.00 %",
   "a11yr aria.html opt e10s fission stylo webrender",
   "  rev: spam",
-  "  - Linux 18.04, 1.849 %, Regression, 1.2, -, 44.00 %",
-  "  - macOS 10.15, 1.078 %, Improvement, 1.3, -, 24.00 %",
-  "  - Windows 10, -, , 1.2, , 99.00 %",
+  "  - Linux 18.04, 1.849 %, Regression, 1.2, , 44.00 %",
+  "  - macOS 10.15, 1.078 %, Improvement, 1.3, , 24.00 %",
+  "  - Windows 10, -, , 1.2, -, 99.00 %",
   "  - Windows 10, -2.401 %, , 1.2, , 49.00 %",
   "  rev: tictactoe",
-  "  - Linux 18.04, 1.849 %, Regression, 2, -, 43.00 %",
-  "  - macOS 10.15, 1.078 %, Improvement, 2.1, -, 23.00 %",
-  "  - Windows 10, -, , 2, , 98.00 %",
+  "  - Linux 18.04, 1.849 %, Regression, 2, , 43.00 %",
+  "  - macOS 10.15, 1.078 %, Improvement, 2.1, , 23.00 %",
+  "  - Windows 10, -, , 2, -, 98.00 %",
   "  - Windows 10, -2.401 %, , 2, , 48.00 %",
 ]
 `;
@@ -5908,25 +5973,25 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
   "a11yr dhtml.html opt e10s fission stylo webrender",
   "  rev: spam",
   "  - Windows 10, -2.401 %, , -, , 50.00 %",
-  "  - Windows 10, -, , -, , 100.00 %",
-  "  - macOS 10.15, 1.078 %, Improvement, 0.1, -, 25.00 %",
-  "  - Linux 18.04, 1.849 %, Regression, -, -, 45.00 %",
+  "  - Windows 10, -, , -, -, 100.00 %",
+  "  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %",
+  "  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %",
   "  rev: tictactoe",
   "  - Windows 10, -2.401 %, , 0.8, , 49.00 %",
-  "  - Windows 10, -, , 0.8, , 99.00 %",
-  "  - macOS 10.15, 1.078 %, Improvement, 0.9, -, 24.00 %",
-  "  - Linux 18.04, 1.849 %, Regression, 0.8, -, 44.00 %",
+  "  - Windows 10, -, , 0.8, -, 99.00 %",
+  "  - macOS 10.15, 1.078 %, Improvement, 0.9, , 24.00 %",
+  "  - Linux 18.04, 1.849 %, Regression, 0.8, , 44.00 %",
   "a11yr aria.html opt e10s fission stylo webrender",
   "  rev: spam",
   "  - Windows 10, -2.401 %, , 1.2, , 49.00 %",
-  "  - Windows 10, -, , 1.2, , 99.00 %",
-  "  - macOS 10.15, 1.078 %, Improvement, 1.3, -, 24.00 %",
-  "  - Linux 18.04, 1.849 %, Regression, 1.2, -, 44.00 %",
+  "  - Windows 10, -, , 1.2, -, 99.00 %",
+  "  - macOS 10.15, 1.078 %, Improvement, 1.3, , 24.00 %",
+  "  - Linux 18.04, 1.849 %, Regression, 1.2, , 44.00 %",
   "  rev: tictactoe",
   "  - Windows 10, -2.401 %, , 2, , 48.00 %",
-  "  - Windows 10, -, , 2, , 98.00 %",
-  "  - macOS 10.15, 1.078 %, Improvement, 2.1, -, 23.00 %",
-  "  - Linux 18.04, 1.849 %, Regression, 2, -, 43.00 %",
+  "  - Windows 10, -, , 2, -, 98.00 %",
+  "  - macOS 10.15, 1.078 %, Improvement, 2.1, , 23.00 %",
+  "  - Linux 18.04, 1.849 %, Regression, 2, , 43.00 %",
 ]
 `;
 
@@ -6231,7 +6296,20 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
         class="significance cell"
         role="cell"
       >
-        -
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+          data-testid="KeyboardDoubleArrowUpIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
+          />
+          <path
+            d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
+          />
+        </svg>
       </div>
       <div
         class="total-runs cell"
@@ -6482,7 +6560,20 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
         class="significance cell"
         role="cell"
       >
-        -
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+          data-testid="KeyboardDoubleArrowUpIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
+          />
+          <path
+            d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
+          />
+        </svg>
       </div>
       <div
         class="total-runs cell"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -1797,20 +1797,7 @@ exports[`Results Table Should match snapshot 1`] = `
                               class="significance cell"
                               role="cell"
                             >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                                data-testid="KeyboardDoubleArrowUpIcon"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
-                                />
-                                <path
-                                  d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
-                                />
-                              </svg>
+                              S
                             </div>
                             <div
                               class="total-runs cell"
@@ -2009,20 +1996,7 @@ exports[`Results Table Should match snapshot 1`] = `
                               class="significance cell"
                               role="cell"
                             >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                                data-testid="KeyboardDoubleArrowUpIcon"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
-                                />
-                                <path
-                                  d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
-                                />
-                              </svg>
+                              S
                             </div>
                             <div
                               class="total-runs cell"
@@ -2221,20 +2195,7 @@ exports[`Results Table Should match snapshot 1`] = `
                               class="significance cell"
                               role="cell"
                             >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                                data-testid="KeyboardDoubleArrowUpIcon"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
-                                />
-                                <path
-                                  d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
-                                />
-                              </svg>
+                              S
                             </div>
                             <div
                               class="total-runs cell"
@@ -2520,20 +2481,7 @@ exports[`Results Table Should match snapshot 1`] = `
                               class="significance cell"
                               role="cell"
                             >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                                data-testid="KeyboardDoubleArrowUpIcon"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
-                                />
-                                <path
-                                  d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
-                                />
-                              </svg>
+                              S
                             </div>
                             <div
                               class="total-runs cell"
@@ -4745,20 +4693,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                               class="significance cell"
                               role="cell"
                             >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                                data-testid="KeyboardDoubleArrowUpIcon"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
-                                />
-                                <path
-                                  d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
-                                />
-                              </svg>
+                              S
                             </div>
                             <div
                               class="total-runs cell"
@@ -4970,20 +4905,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                               class="significance cell"
                               role="cell"
                             >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                                data-testid="KeyboardDoubleArrowUpIcon"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
-                                />
-                                <path
-                                  d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
-                                />
-                              </svg>
+                              S
                             </div>
                             <div
                               class="total-runs cell"
@@ -5182,20 +5104,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                               class="significance cell"
                               role="cell"
                             >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                                data-testid="KeyboardDoubleArrowUpIcon"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
-                                />
-                                <path
-                                  d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
-                                />
-                              </svg>
+                              S
                             </div>
                             <div
                               class="total-runs cell"
@@ -5477,7 +5386,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                               class="significance cell"
                               role="cell"
                             >
-                              -
+                              NS
                             </div>
                             <div
                               class="total-runs cell"
@@ -5900,26 +5809,26 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
 [
   "a11yr dhtml.html opt e10s fission stylo webrender",
   "  rev: spam",
-  "  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %",
-  "  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %",
-  "  - Windows 10, -, , -, -, 100.00 %",
-  "  - Windows 10, -2.401 %, , -, , 50.00 %",
+  "  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %",
+  "  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %",
+  "  - Windows 10, -, , -, NS, 100.00 %",
+  "  - Windows 10, -2.401 %, , -, S, 50.00 %",
   "  rev: tictactoe",
-  "  - Linux 18.04, 1.849 %, Regression, 0.8, , 44.00 %",
-  "  - macOS 10.15, 1.078 %, Improvement, 0.9, , 24.00 %",
-  "  - Windows 10, -, , 0.8, -, 99.00 %",
-  "  - Windows 10, -2.401 %, , 0.8, , 49.00 %",
+  "  - Linux 18.04, 1.849 %, Regression, 0.8, S, 44.00 %",
+  "  - macOS 10.15, 1.078 %, Improvement, 0.9, S, 24.00 %",
+  "  - Windows 10, -, , 0.8, NS, 99.00 %",
+  "  - Windows 10, -2.401 %, , 0.8, S, 49.00 %",
   "a11yr aria.html opt e10s fission stylo webrender",
   "  rev: spam",
-  "  - Linux 18.04, 1.849 %, Regression, 1.2, , 44.00 %",
-  "  - macOS 10.15, 1.078 %, Improvement, 1.3, , 24.00 %",
-  "  - Windows 10, -, , 1.2, -, 99.00 %",
-  "  - Windows 10, -2.401 %, , 1.2, , 49.00 %",
+  "  - Linux 18.04, 1.849 %, Regression, 1.2, S, 44.00 %",
+  "  - macOS 10.15, 1.078 %, Improvement, 1.3, S, 24.00 %",
+  "  - Windows 10, -, , 1.2, NS, 99.00 %",
+  "  - Windows 10, -2.401 %, , 1.2, S, 49.00 %",
   "  rev: tictactoe",
-  "  - Linux 18.04, 1.849 %, Regression, 2, , 43.00 %",
-  "  - macOS 10.15, 1.078 %, Improvement, 2.1, , 23.00 %",
-  "  - Windows 10, -, , 2, -, 98.00 %",
-  "  - Windows 10, -2.401 %, , 2, , 48.00 %",
+  "  - Linux 18.04, 1.849 %, Regression, 2, S, 43.00 %",
+  "  - macOS 10.15, 1.078 %, Improvement, 2.1, S, 23.00 %",
+  "  - Windows 10, -, , 2, NS, 98.00 %",
+  "  - Windows 10, -2.401 %, , 2, S, 48.00 %",
 ]
 `;
 
@@ -5972,26 +5881,26 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
 [
   "a11yr dhtml.html opt e10s fission stylo webrender",
   "  rev: spam",
-  "  - Windows 10, -2.401 %, , -, , 50.00 %",
-  "  - Windows 10, -, , -, -, 100.00 %",
-  "  - macOS 10.15, 1.078 %, Improvement, 0.1, , 25.00 %",
-  "  - Linux 18.04, 1.849 %, Regression, -, , 45.00 %",
+  "  - Windows 10, -2.401 %, , -, S, 50.00 %",
+  "  - Windows 10, -, , -, NS, 100.00 %",
+  "  - macOS 10.15, 1.078 %, Improvement, 0.1, S, 25.00 %",
+  "  - Linux 18.04, 1.849 %, Regression, -, S, 45.00 %",
   "  rev: tictactoe",
-  "  - Windows 10, -2.401 %, , 0.8, , 49.00 %",
-  "  - Windows 10, -, , 0.8, -, 99.00 %",
-  "  - macOS 10.15, 1.078 %, Improvement, 0.9, , 24.00 %",
-  "  - Linux 18.04, 1.849 %, Regression, 0.8, , 44.00 %",
+  "  - Windows 10, -2.401 %, , 0.8, S, 49.00 %",
+  "  - Windows 10, -, , 0.8, NS, 99.00 %",
+  "  - macOS 10.15, 1.078 %, Improvement, 0.9, S, 24.00 %",
+  "  - Linux 18.04, 1.849 %, Regression, 0.8, S, 44.00 %",
   "a11yr aria.html opt e10s fission stylo webrender",
   "  rev: spam",
-  "  - Windows 10, -2.401 %, , 1.2, , 49.00 %",
-  "  - Windows 10, -, , 1.2, -, 99.00 %",
-  "  - macOS 10.15, 1.078 %, Improvement, 1.3, , 24.00 %",
-  "  - Linux 18.04, 1.849 %, Regression, 1.2, , 44.00 %",
+  "  - Windows 10, -2.401 %, , 1.2, S, 49.00 %",
+  "  - Windows 10, -, , 1.2, NS, 99.00 %",
+  "  - macOS 10.15, 1.078 %, Improvement, 1.3, S, 24.00 %",
+  "  - Linux 18.04, 1.849 %, Regression, 1.2, S, 44.00 %",
   "  rev: tictactoe",
-  "  - Windows 10, -2.401 %, , 2, , 48.00 %",
-  "  - Windows 10, -, , 2, -, 98.00 %",
-  "  - macOS 10.15, 1.078 %, Improvement, 2.1, , 23.00 %",
-  "  - Linux 18.04, 1.849 %, Regression, 2, , 43.00 %",
+  "  - Windows 10, -2.401 %, , 2, S, 48.00 %",
+  "  - Windows 10, -, , 2, NS, 98.00 %",
+  "  - macOS 10.15, 1.078 %, Improvement, 2.1, S, 23.00 %",
+  "  - Linux 18.04, 1.849 %, Regression, 2, S, 43.00 %",
 ]
 `;
 
@@ -6296,20 +6205,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
         class="significance cell"
         role="cell"
       >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-          data-testid="KeyboardDoubleArrowUpIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
-          />
-          <path
-            d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
-          />
-        </svg>
+        S
       </div>
       <div
         class="total-runs cell"
@@ -6560,20 +6456,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
         class="significance cell"
         role="cell"
       >
-        <svg
-          aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-          data-testid="KeyboardDoubleArrowUpIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
-          />
-          <path
-            d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
-          />
-        </svg>
+        S
       </div>
       <div
         class="total-runs cell"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -1797,7 +1797,7 @@ exports[`Results Table Should match snapshot 1`] = `
                               class="significance cell"
                               role="cell"
                             >
-                              S
+                              NS
                             </div>
                             <div
                               class="total-runs cell"
@@ -1996,7 +1996,7 @@ exports[`Results Table Should match snapshot 1`] = `
                               class="significance cell"
                               role="cell"
                             >
-                              S
+                              NS
                             </div>
                             <div
                               class="total-runs cell"
@@ -2195,7 +2195,7 @@ exports[`Results Table Should match snapshot 1`] = `
                               class="significance cell"
                               role="cell"
                             >
-                              S
+                              NS
                             </div>
                             <div
                               class="total-runs cell"
@@ -2481,7 +2481,7 @@ exports[`Results Table Should match snapshot 1`] = `
                               class="significance cell"
                               role="cell"
                             >
-                              S
+                              NS
                             </div>
                             <div
                               class="total-runs cell"
@@ -4693,7 +4693,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                               class="significance cell"
                               role="cell"
                             >
-                              S
+                              NS
                             </div>
                             <div
                               class="total-runs cell"
@@ -4905,7 +4905,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                               class="significance cell"
                               role="cell"
                             >
-                              S
+                              NS
                             </div>
                             <div
                               class="total-runs cell"
@@ -5386,7 +5386,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                               class="significance cell"
                               role="cell"
                             >
-                              NS
+                              S
                             </div>
                             <div
                               class="total-runs cell"
@@ -6205,7 +6205,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
         class="significance cell"
         role="cell"
       >
-        S
+        NS
       </div>
       <div
         class="total-runs cell"
@@ -6456,7 +6456,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
         class="significance cell"
         role="cell"
       >
-        S
+        NS
       </div>
       <div
         class="total-runs cell"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -277,15 +277,15 @@ exports[`Results View Should display Base, New and Common graphs with replicates
                   Δ median
                 </strong>
                  = 
-                +9.00
+                +8.74
                  
                 ms
                  (+1.5%)
                  
                 95% CI [
-                +0.00
+                +3.57
                 , 
-                +18.01
+                +18.16
                 ]
               </span>
             </div>
@@ -319,12 +319,12 @@ exports[`Results View Should display Base, New and Common graphs with replicates
                 </strong>
                 : We are 95% confident the median difference is between 
                 <strong>
-                  +0.00
+                  +3.57
                 </strong>
                  and
                  
                 <strong>
-                  +18.01
+                  +18.16
                 </strong>
               </span>
             </div>
@@ -815,7 +815,7 @@ exports[`Results View Should display Base, New and Common graphs with tooltips 1
                  (+1.5%)
                  
                 95% CI [
-                +3.27
+                +3.57
                 , 
                 +18.16
                 ]
@@ -851,7 +851,7 @@ exports[`Results View Should display Base, New and Common graphs with tooltips 1
                 </strong>
                 : We are 95% confident the median difference is between 
                 <strong>
-                  +3.27
+                  +3.57
                 </strong>
                  and
                  
@@ -1953,7 +1953,7 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="significance cell"
                   role="cell"
                 >
-                  S
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -2152,7 +2152,7 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="significance cell"
                   role="cell"
                 >
-                  S
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -2351,7 +2351,7 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="significance cell"
                   role="cell"
                 >
-                  S
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -2550,7 +2550,7 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="significance cell"
                   role="cell"
                 >
-                  S
+                  NS
                 </div>
                 <div
                   class="total-runs cell"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -1953,20 +1953,7 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="significance cell"
                   role="cell"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                    data-testid="KeyboardDoubleArrowUpIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
-                    />
-                    <path
-                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
-                    />
-                  </svg>
+                  S
                 </div>
                 <div
                   class="total-runs cell"
@@ -2165,20 +2152,7 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="significance cell"
                   role="cell"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                    data-testid="KeyboardDoubleArrowUpIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
-                    />
-                    <path
-                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
-                    />
-                  </svg>
+                  S
                 </div>
                 <div
                   class="total-runs cell"
@@ -2377,20 +2351,7 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="significance cell"
                   role="cell"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                    data-testid="KeyboardDoubleArrowUpIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
-                    />
-                    <path
-                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
-                    />
-                  </svg>
+                  S
                 </div>
                 <div
                   class="total-runs cell"
@@ -2589,20 +2550,7 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="significance cell"
                   role="cell"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                    data-testid="KeyboardDoubleArrowUpIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
-                    />
-                    <path
-                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
-                    />
-                  </svg>
+                  S
                 </div>
                 <div
                   class="total-runs cell"

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -208,19 +208,6 @@ exports[`Results View Should display Base, New and Common graphs with replicates
                   <td
                     style="padding: 2px;"
                   >
-                    Significance (p-value)
-                  </td>
-                  <td
-                    style="padding: 2px;"
-                  />
-                  <td
-                    style="padding: 2px;"
-                  />
-                </tr>
-                <tr>
-                  <td
-                    style="padding: 2px;"
-                  >
                     CLES
                   </td>
                   <td
@@ -741,19 +728,6 @@ exports[`Results View Should display Base, New and Common graphs with tooltips 1
                     style="padding: 2px;"
                   >
                     Cliff's Delta
-                  </td>
-                  <td
-                    style="padding: 2px;"
-                  />
-                  <td
-                    style="padding: 2px;"
-                  />
-                </tr>
-                <tr>
-                  <td
-                    style="padding: 2px;"
-                  >
-                    Significance (p-value)
                   </td>
                   <td
                     style="padding: 2px;"
@@ -1979,7 +1953,20 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                    data-testid="KeyboardDoubleArrowUpIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
+                    />
+                    <path
+                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
+                    />
+                  </svg>
                 </div>
                 <div
                   class="total-runs cell"
@@ -2178,7 +2165,20 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                    data-testid="KeyboardDoubleArrowUpIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
+                    />
+                    <path
+                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
+                    />
+                  </svg>
                 </div>
                 <div
                   class="total-runs cell"
@@ -2377,7 +2377,20 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                    data-testid="KeyboardDoubleArrowUpIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
+                    />
+                    <path
+                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
+                    />
+                  </svg>
                 </div>
                 <div
                   class="total-runs cell"
@@ -2576,7 +2589,20 @@ exports[`Results View The table should match snapshot and other elements should 
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                    data-testid="KeyboardDoubleArrowUpIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
+                    />
+                    <path
+                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
+                    />
+                  </svg>
                 </div>
                 <div
                   class="total-runs cell"

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -3267,20 +3267,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   class="significance cell"
                   role="cell"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                    data-testid="KeyboardDoubleArrowUpIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
-                    />
-                    <path
-                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
-                    />
-                  </svg>
+                  -
                 </div>
                 <div
                   class="total-runs cell"
@@ -3430,20 +3417,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   class="significance cell"
                   role="cell"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                    data-testid="KeyboardDoubleArrowUpIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
-                    />
-                    <path
-                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
-                    />
-                  </svg>
+                  -
                 </div>
                 <div
                   class="total-runs cell"
@@ -3593,20 +3567,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   class="significance cell"
                   role="cell"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                    data-testid="KeyboardDoubleArrowUpIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
-                    />
-                    <path
-                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
-                    />
-                  </svg>
+                  -
                 </div>
                 <div
                   class="total-runs cell"
@@ -4869,20 +4830,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   class="significance cell"
                   role="cell"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                    data-testid="KeyboardDoubleArrowUpIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
-                    />
-                    <path
-                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
-                    />
-                  </svg>
+                  -
                 </div>
                 <div
                   class="total-runs cell"
@@ -5032,20 +4980,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   class="significance cell"
                   role="cell"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                    data-testid="KeyboardDoubleArrowUpIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
-                    />
-                    <path
-                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
-                    />
-                  </svg>
+                  -
                 </div>
                 <div
                   class="total-runs cell"
@@ -5195,20 +5130,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   class="significance cell"
                   role="cell"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                    data-testid="KeyboardDoubleArrowUpIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
-                    />
-                    <path
-                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
-                    />
-                  </svg>
+                  -
                 </div>
                 <div
                   class="total-runs cell"
@@ -6471,20 +6393,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   class="significance cell"
                   role="cell"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                    data-testid="KeyboardDoubleArrowUpIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
-                    />
-                    <path
-                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
-                    />
-                  </svg>
+                  -
                 </div>
                 <div
                   class="total-runs cell"
@@ -6634,20 +6543,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   class="significance cell"
                   role="cell"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                    data-testid="KeyboardDoubleArrowUpIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
-                    />
-                    <path
-                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
-                    />
-                  </svg>
+                  -
                 </div>
                 <div
                   class="total-runs cell"
@@ -6797,20 +6693,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   class="significance cell"
                   role="cell"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                    data-testid="KeyboardDoubleArrowUpIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"
-                    />
-                    <path
-                      d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"
-                    />
-                  </svg>
+                  -
                 </div>
                 <div
                   class="total-runs cell"

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -1191,7 +1191,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -1339,7 +1339,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -1487,7 +1487,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -1635,7 +1635,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -1783,7 +1783,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -3104,7 +3104,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -3267,7 +3267,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -3417,7 +3417,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -3567,7 +3567,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -3730,7 +3730,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -4667,7 +4667,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -4830,7 +4830,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -4980,7 +4980,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -5130,7 +5130,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -5293,7 +5293,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -6230,7 +6230,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -6393,7 +6393,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -6543,7 +6543,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -6693,7 +6693,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -6856,7 +6856,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -7791,7 +7791,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -7939,7 +7939,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -8087,7 +8087,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -8235,7 +8235,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  NS
                 </div>
                 <div
                   class="total-runs cell"
@@ -8383,7 +8383,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                   class="significance cell"
                   role="cell"
                 >
-                  -
+                  NS
                 </div>
                 <div
                   class="total-runs cell"

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -3267,7 +3267,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   class="significance cell"
                   role="cell"
                 >
-                  NS
+                  S
                 </div>
                 <div
                   class="total-runs cell"
@@ -3417,7 +3417,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   class="significance cell"
                   role="cell"
                 >
-                  NS
+                  S
                 </div>
                 <div
                   class="total-runs cell"
@@ -3567,7 +3567,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   class="significance cell"
                   role="cell"
                 >
-                  NS
+                  S
                 </div>
                 <div
                   class="total-runs cell"
@@ -4830,7 +4830,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   class="significance cell"
                   role="cell"
                 >
-                  NS
+                  S
                 </div>
                 <div
                   class="total-runs cell"
@@ -4980,7 +4980,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   class="significance cell"
                   role="cell"
                 >
-                  NS
+                  S
                 </div>
                 <div
                   class="total-runs cell"
@@ -5130,7 +5130,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   class="significance cell"
                   role="cell"
                 >
-                  NS
+                  S
                 </div>
                 <div
                   class="total-runs cell"
@@ -6393,7 +6393,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   class="significance cell"
                   role="cell"
                 >
-                  NS
+                  S
                 </div>
                 <div
                   class="total-runs cell"
@@ -6543,7 +6543,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   class="significance cell"
                   role="cell"
                 >
-                  NS
+                  S
                 </div>
                 <div
                   class="total-runs cell"
@@ -6693,7 +6693,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                   class="significance cell"
                   role="cell"
                 >
-                  NS
+                  S
                 </div>
                 <div
                   class="total-runs cell"

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -324,9 +324,9 @@ export const MANN_WHITNEY_U = 'mann-whitney-u' as TestVersion;
 export const STUDENT_T = 'student-t' as TestVersion;
 
 export const tooltipSignificance =
-  'Significance of the comparison as determined by a Mann Whitney U test. A significant comparison has a p-value of less than 0.05.';
+  'Significance of the comparison as determined by a 95% bootstrap (BCa) confidence interval on the difference of medians. A comparison is significant when the interval excludes zero.';
 export const tooltipStatusMannWhitney =
-  'An improvement or regression being shown here means that the effect size is meaningful, and the difference has a significant p-value.';
+  'An improvement or regression being shown here means that the effect size is meaningful and the difference is statistically significant.';
 export const tooltipTotalRuns =
   'The total number of tasks/jobs that ran for this metric.';
 export const tooltipBaseMean =

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -324,7 +324,7 @@ export const MANN_WHITNEY_U = 'mann-whitney-u' as TestVersion;
 export const STUDENT_T = 'student-t' as TestVersion;
 
 export const tooltipSignificance =
-  'Significance of the comparison as determined by a 95% bootstrap (BCa) confidence interval on the difference of medians. A comparison is significant when the interval excludes zero.';
+  'Significance of the comparison as determined by a 95% bootstrap (BCa) confidence interval on the difference of medians. "S" (Significant) means the interval excludes zero — the medians differ. "NS" (Not Significant) means the interval includes zero — no detectable difference.';
 export const tooltipStatusMannWhitney =
   'An improvement or regression being shown here means that the effect size is meaningful and the difference is statistically significant.';
 export const tooltipTotalRuns =

--- a/src/common/testVersions/mannWhitney.tsx
+++ b/src/common/testVersions/mannWhitney.tsx
@@ -1,4 +1,3 @@
-import KeyboardDoubleArrowUpIcon from '@mui/icons-material/KeyboardDoubleArrowUp';
 import ThumbDownIcon from '@mui/icons-material/ThumbDown';
 import ThumbUpIcon from '@mui/icons-material/ThumbUp';
 import WarningIcon from '@mui/icons-material/Warning';
@@ -245,12 +244,12 @@ export const mannWhitneyStrategy = {
           {
             label: 'Significant',
             key: 'significant',
-            icon: <KeyboardDoubleArrowUpIcon fontSize='small' />,
+            icon: <div>S</div>,
           },
           {
             label: 'Not Significant',
             key: 'not significant',
-            icon: <div>-</div>,
+            icon: <div>NS</div>,
           },
         ],
         matchesFunction(result: MannWhitneyResultsItem, valueKey: string) {
@@ -396,11 +395,7 @@ export const mannWhitneyStrategy = {
           {clesVal ? `${clesVal}% ` : '-'}
         </div>
         <div className='significance cell' role='cell'>
-          {bootstrapCi?.significant ? (
-            <KeyboardDoubleArrowUpIcon fontSize='small' />
-          ) : (
-            '-'
-          )}
+          {bootstrapCi?.significant ? 'S' : 'NS'}
         </div>
       </>
     );
@@ -584,11 +579,7 @@ export const mannWhitneyStrategy = {
           {clesValue}
         </div>
         <div className='significance cell' role='cell'>
-          {bootstrapCi?.significant ? (
-            <KeyboardDoubleArrowUpIcon fontSize='small' />
-          ) : (
-            '-'
-          )}
+          {bootstrapCi?.significant ? 'S' : 'NS'}
         </div>
       </>
     );

--- a/src/common/testVersions/mannWhitney.tsx
+++ b/src/common/testVersions/mannWhitney.tsx
@@ -102,6 +102,29 @@ export function isDistributionNormal(result: MannWhitneyResultsItem): boolean {
   return checkDistributionNormality(result) !== 'neither';
 }
 
+/**
+ * Precompute the bootstrap (BCa)[see src/utils/bootstrap-ci.ts#L163-L203] CI for the difference of medians on every
+ * Mann-Whitney result and attach it to `result.bootstrapCi`. Called from the
+ * data loaders so the Sig column's filter/sort and the expanded-row alert can
+ * read a precomputed value instead of triggering bootstrapMedianDiffCI per
+ * row per render (BCa is ~10–30 ms/row and would tank sort interactions).
+ *
+ * Rows without enough data (< 2 samples on either side) get `bootstrapCi:
+ * null`; the column code treats that as "not significant".
+ */
+export function precomputeMannWhitneyCI(
+  results: MannWhitneyResultsItem[],
+): void {
+  for (const result of results) {
+    const baseRuns = result.base_runs ?? [];
+    const newRuns = result.new_runs ?? [];
+    result.bootstrapCi =
+      baseRuns.length >= 2 && newRuns.length >= 2
+        ? bootstrapMedianDiffCI(baseRuns, newRuns)
+        : null;
+  }
+}
+
 export const mannWhitneyStrategy = {
   getColumns(isSubtestTable: boolean): TableConfig {
     const platformConfig = isSubtestTable
@@ -231,16 +254,26 @@ export const mannWhitneyStrategy = {
           },
         ],
         matchesFunction(result: MannWhitneyResultsItem, valueKey: string) {
-          return result.mann_whitney_test?.interpretation === valueKey;
+          // Significance comes from the precomputed bootstrap CI (see
+          // precomputeMannWhitneyCI above).
+          // Missing CI ⇒ treat as not-significant.
+          const isSig = result.bootstrapCi?.significant ?? false;
+          return (isSig ? 'significant' : 'not significant') === valueKey;
         },
         sortFunction(
           resultA: MannWhitneyResultsItem,
           resultB: MannWhitneyResultsItem,
         ) {
-          return (
-            Math.abs(resultA.mann_whitney_test?.pvalue ?? 0) -
-            Math.abs(resultB.mann_whitney_test?.pvalue ?? 0)
-          );
+          // ASC semantics — useTableSort swaps args for DESC. So in DESC mode
+          // this produces "significant first, then |medianDiff| desc"; in ASC
+          // mode the inverse. Significance is the primary key, magnitude the
+          // tie-breaker so the biggest changes float to the top of each group.
+          const sigA = resultA.bootstrapCi?.significant ?? false;
+          const sigB = resultB.bootstrapCi?.significant ?? false;
+          if (sigA !== sigB) return sigA ? 1 : -1;
+          const magA = Math.abs(resultA.bootstrapCi?.medianDiff ?? 0);
+          const magB = Math.abs(resultB.bootstrapCi?.medianDiff ?? 0);
+          return magA - magB;
         },
       },
 
@@ -267,9 +300,9 @@ export const mannWhitneyStrategy = {
     const {
       test,
       cliffs_delta,
-      mann_whitney_test,
       cles,
       direction_of_change,
+      bootstrapCi,
       base_measurement_unit: baseUnit,
       new_measurement_unit: newUnit,
       base_app: baseApp,
@@ -363,7 +396,7 @@ export const mannWhitneyStrategy = {
           {clesVal ? `${clesVal}% ` : '-'}
         </div>
         <div className='significance cell' role='cell'>
-          {mann_whitney_test?.interpretation === 'significant' ? (
+          {bootstrapCi?.significant ? (
             <KeyboardDoubleArrowUpIcon fontSize='small' />
           ) : (
             '-'
@@ -403,17 +436,19 @@ export const mannWhitneyStrategy = {
       mann_whitney_u_cles: '',
     };
     const { cliffs_delta, cliffs_interpretation } = mwResult;
-    const pValue = mwResult.mann_whitney_test?.pvalue;
-    const p_value_cles = mwResult.mann_whitney_test?.interpretation
-      ? capitalize(mwResult.mann_whitney_test.interpretation)
-      : '';
 
+    // Prefer the precomputed CI populated by the loader. Fall back to an
+    // inline compute for backwards compatibility (e.g. tests that mount the
+    // strategy without going through a loader, or stale results without the
+    // field).
     const baseRuns = mwResult.base_runs ?? [];
     const newRuns = mwResult.new_runs ?? [];
     const ci =
-      baseRuns.length > 0 && newRuns.length > 0
-        ? bootstrapMedianDiffCI(baseRuns, newRuns)
-        : null;
+      mwResult.bootstrapCi !== undefined
+        ? mwResult.bootstrapCi
+        : baseRuns.length > 0 && newRuns.length > 0
+          ? bootstrapMedianDiffCI(baseRuns, newRuns)
+          : null;
     const rawUnit =
       mwResult.base_measurement_unit ?? mwResult.new_measurement_unit ?? 'ms';
     const { fmt, displayUnit } = ci
@@ -453,8 +488,6 @@ export const mannWhitneyStrategy = {
         <PValCliffsDeltaComp
           cliffs_delta={cliffs_delta}
           cliffs_interpretation={cliffs_interpretation}
-          pValue={pValue}
-          p_value_cles={p_value_cles}
           cles={cles}
           cles_direction={cles_direction}
         />
@@ -483,8 +516,8 @@ export const mannWhitneyStrategy = {
     const {
       cliffs_delta,
       direction_of_change,
-      mann_whitney_test,
       cles,
+      bootstrapCi,
       base_standard_stats,
       new_standard_stats,
     } = result as MannWhitneyResultsItem;
@@ -551,7 +584,7 @@ export const mannWhitneyStrategy = {
           {clesValue}
         </div>
         <div className='significance cell' role='cell'>
-          {mann_whitney_test?.interpretation === 'significant' ? (
+          {bootstrapCi?.significant ? (
             <KeyboardDoubleArrowUpIcon fontSize='small' />
           ) : (
             '-'

--- a/src/common/testVersions/mannWhitney.tsx
+++ b/src/common/testVersions/mannWhitney.tsx
@@ -13,7 +13,10 @@ import {
   MannWhitneyResultsItem,
 } from '../../types/state';
 import { TableConfig } from '../../types/types';
-import { bootstrapMedianDiffCI } from '../../utils/bootstrap-ci';
+import {
+  bootstrapMedianDiffCI,
+  type BootstrapCI,
+} from '../../utils/bootstrap-ci';
 import { adaptUnit, formatNumber } from '../../utils/format';
 import { capitalize } from '../../utils/helpers';
 import { getBrowserDisplay, getPlatformShortName } from '../../utils/platform';
@@ -101,27 +104,103 @@ export function isDistributionNormal(result: MannWhitneyResultsItem): boolean {
   return checkDistributionNormality(result) !== 'neither';
 }
 
-/**
- * Precompute the bootstrap (BCa)[see src/utils/bootstrap-ci.ts#L163-L203] CI for the difference of medians on every
- * Mann-Whitney result and attach it to `result.bootstrapCi`. Called from the
- * data loaders so the Sig column's filter/sort and the expanded-row alert can
- * read a precomputed value instead of triggering bootstrapMedianDiffCI per
- * row per render (BCa is ~10–30 ms/row and would tank sort interactions).
- *
- * Rows without enough data (< 2 samples on either side) get `bootstrapCi:
- * null`; the column code treats that as "not significant".
- */
-export function precomputeMannWhitneyCI(
-  results: MannWhitneyResultsItem[],
-): void {
-  for (const result of results) {
-    const baseRuns = result.base_runs ?? [];
-    const newRuns = result.new_runs ?? [];
-    result.bootstrapCi =
-      baseRuns.length >= 2 && newRuns.length >= 2
-        ? bootstrapMedianDiffCI(baseRuns, newRuns)
-        : null;
+// Cap on the per-side sample count fed into BCa. Replicates arrays can
+// run 300–600 values; BCa cost is roughly proportional to sample size, so
+// uncapped it dominates page load on tables with many rows. CI quality is
+// dominated by iteration count above ~50–100 samples — capping here keeps
+// the interval statistically equivalent while bounding cost.
+const BOOTSTRAP_SAMPLE_CAP = 100;
+// Fewer iterations than bootstrap-ci.ts's 9999 default. 1999 is still
+// well above the textbook BCa minimum (~1000) and ~5× cheaper.
+const BOOTSTRAP_ITERATIONS = 1999;
+
+// Stride-based subsample: pick `cap` evenly-spaced values from a larger
+// array. Deterministic (no RNG), preserves the full distribution shape,
+// and is O(cap) regardless of input length.
+function downsampleForBootstrap(values: number[]): number[] {
+  if (values.length <= BOOTSTRAP_SAMPLE_CAP) return values;
+  const out: number[] = new Array<number>(BOOTSTRAP_SAMPLE_CAP);
+  const stride = values.length / BOOTSTRAP_SAMPLE_CAP;
+  for (let i = 0; i < BOOTSTRAP_SAMPLE_CAP; i++) {
+    out[i] = values[Math.floor(i * stride)];
   }
+  return out;
+}
+
+// Resolve a row's KDE/BCa input sample set: prefer replicates over the
+// aggregated runs. Mirrors RevisionRowExpandable's selection for the chart
+// and KdeModesPanel so every view of the row uses the same underlying data.
+// Returned arrays are NOT downsampled — callers feeding BCa should pass
+// them through `downsampleForBootstrap` first.
+function runsFor(result: MannWhitneyResultsItem): {
+  baseRuns: number[];
+  newRuns: number[];
+} {
+  const baseRuns =
+    result.base_runs_replicates && result.base_runs_replicates.length
+      ? result.base_runs_replicates
+      : (result.base_runs ?? []);
+  const newRuns =
+    result.new_runs_replicates && result.new_runs_replicates.length
+      ? result.new_runs_replicates
+      : (result.new_runs ?? []);
+  return { baseRuns, newRuns };
+}
+
+/**
+ * Lazily compute (and cache) the bootstrap (BCa) [see
+ * src/utils/bootstrap-ci.ts#L163-L203] CI for the difference of medians
+ * on a single row.
+ *
+ * The lazy strategy: at load time we do NO BCa work (matches production
+ * speed). The Sig column's `matchesFunction`/`sortFunction`/cell-render
+ * call this helper as needed. Result is cached on `result.bootstrapCi`
+ * so the second click on the column is free.
+ *
+ * `undefined` vs `null`:
+ *   - `undefined` ⇒ never computed
+ *   - `null`      ⇒ computed but couldn't produce a CI (< 2 samples)
+ * We check `=== undefined` instead of `?? null` to keep that distinction.
+ *
+ * Uses the replicates-preferred sample selection (via `runsFor`) and the
+ * downsampled-for-BCa cap so per-row cost stays bounded regardless of how
+ * many replicates the backend ships. See `BOOTSTRAP_SAMPLE_CAP` and
+ * `BOOTSTRAP_ITERATIONS` above.
+ */
+export function getBootstrapCi(
+  result: MannWhitneyResultsItem,
+): BootstrapCI | null {
+  if (result.bootstrapCi !== undefined) return result.bootstrapCi;
+  const { baseRuns, newRuns } = runsFor(result);
+  const baseSamples = downsampleForBootstrap(baseRuns);
+  const newSamples = downsampleForBootstrap(newRuns);
+  const ci =
+    baseSamples.length >= 2 && newSamples.length >= 2
+      ? bootstrapMedianDiffCI(baseSamples, newSamples, BOOTSTRAP_ITERATIONS)
+      : null;
+  result.bootstrapCi = ci;
+  return ci;
+}
+
+// Decide whether the Sig cell should render "S" or "NS".
+//
+// Cell renders run for EVERY row on every render — we can't afford to
+// compute BCa here at load time. So the cell uses whichever signal is
+// available without forcing compute:
+//   - If the CI has been cached (filter/sort has been used, or the
+//     expanded-row alert ran), use it — keeps the column consistent with
+//     the rest of the UI on rows the user has engaged with.
+//   - Otherwise fall back to the backend's `mann_whitney_test.interpretation`
+//     — close to production's pre-branch behavior and free to read.
+//
+// First filter/sort click populates `bootstrapCi` for all rows; from then
+// on the column reads the CI-based verdict everywhere. So you only see the
+// fallback on first render before any Sig interaction.
+function isSignificantForDisplay(result: MannWhitneyResultsItem): boolean {
+  if (result.bootstrapCi !== undefined) {
+    return result.bootstrapCi?.significant ?? false;
+  }
+  return result.mann_whitney_test?.interpretation === 'significant';
 }
 
 export const mannWhitneyStrategy = {
@@ -253,10 +332,11 @@ export const mannWhitneyStrategy = {
           },
         ],
         matchesFunction(result: MannWhitneyResultsItem, valueKey: string) {
-          // Significance comes from the precomputed bootstrap CI (see
-          // precomputeMannWhitneyCI above).
-          // Missing CI ⇒ treat as not-significant.
-          const isSig = result.bootstrapCi?.significant ?? false;
+          // Lazily compute and cache the CI on first filter-click. After
+          // that, the CI is read straight from `result.bootstrapCi` on
+          // every subsequent comparison/render (see getBootstrapCi above).
+          const ci = getBootstrapCi(result);
+          const isSig = ci?.significant ?? false;
           return (isSig ? 'significant' : 'not significant') === valueKey;
         },
         sortFunction(
@@ -267,11 +347,18 @@ export const mannWhitneyStrategy = {
           // this produces "significant first, then |medianDiff| desc"; in ASC
           // mode the inverse. Significance is the primary key, magnitude the
           // tie-breaker so the biggest changes float to the top of each group.
-          const sigA = resultA.bootstrapCi?.significant ?? false;
-          const sigB = resultB.bootstrapCi?.significant ?? false;
+          //
+          // First sort-click pays the BCa cost across all rows (the
+          // comparator is invoked O(n log n) times but each row is computed
+          // only once and cached via getBootstrapCi). Subsequent sorts are
+          // free.
+          const ciA = getBootstrapCi(resultA);
+          const ciB = getBootstrapCi(resultB);
+          const sigA = ciA?.significant ?? false;
+          const sigB = ciB?.significant ?? false;
           if (sigA !== sigB) return sigA ? 1 : -1;
-          const magA = Math.abs(resultA.bootstrapCi?.medianDiff ?? 0);
-          const magB = Math.abs(resultB.bootstrapCi?.medianDiff ?? 0);
+          const magA = Math.abs(ciA?.medianDiff ?? 0);
+          const magB = Math.abs(ciB?.medianDiff ?? 0);
           return magA - magB;
         },
       },
@@ -296,17 +383,22 @@ export const mannWhitneyStrategy = {
   },
 
   renderSubtestColumns(result: CombinedResultsItemType, expanded: boolean) {
+    const mwResult = result as MannWhitneyResultsItem;
     const {
       test,
       cliffs_delta,
       cles,
       direction_of_change,
-      bootstrapCi,
       base_measurement_unit: baseUnit,
       new_measurement_unit: newUnit,
       base_app: baseApp,
       new_app: newApp,
-    } = result as MannWhitneyResultsItem;
+    } = mwResult;
+    // See `isSignificantForDisplay` above — uses the cached CI when one
+    // exists and falls back to the backend interpretation otherwise.
+    // Computing BCa here on every cell render would re-introduce the
+    // per-row load cost we just removed.
+    const sigDisplay = isSignificantForDisplay(mwResult) ? 'S' : 'NS';
     const clesVal = ((cles?.cles ?? 0) * 100).toFixed(2);
     const baseAvgValue =
       (result as MannWhitneyResultsItem).base_standard_stats?.mean ?? 0;
@@ -395,7 +487,7 @@ export const mannWhitneyStrategy = {
           {clesVal ? `${clesVal}% ` : '-'}
         </div>
         <div className='significance cell' role='cell'>
-          {bootstrapCi?.significant ? 'S' : 'NS'}
+          {sigDisplay}
         </div>
       </>
     );
@@ -435,15 +527,18 @@ export const mannWhitneyStrategy = {
     // Prefer the precomputed CI populated by the loader. Fall back to an
     // inline compute for backwards compatibility (e.g. tests that mount the
     // strategy without going through a loader, or stale results without the
-    // field).
-    const baseRuns = mwResult.base_runs ?? [];
-    const newRuns = mwResult.new_runs ?? [];
-    const ci =
-      mwResult.bootstrapCi !== undefined
-        ? mwResult.bootstrapCi
-        : baseRuns.length > 0 && newRuns.length > 0
-          ? bootstrapMedianDiffCI(baseRuns, newRuns)
-          : null;
+    // field). `baseRuns`/`newRuns` is the full replicates-preferred set
+    // (used for the median below); the BCa fallback runs on the capped
+    // downsample so it can't hang on rich-replicates rows.
+    const { baseRuns, newRuns } = runsFor(mwResult);
+    const ci = (() => {
+      if (mwResult.bootstrapCi !== undefined) return mwResult.bootstrapCi;
+      const baseSamples = downsampleForBootstrap(baseRuns);
+      const newSamples = downsampleForBootstrap(newRuns);
+      return baseSamples.length >= 2 && newSamples.length >= 2
+        ? bootstrapMedianDiffCI(baseSamples, newSamples, BOOTSTRAP_ITERATIONS)
+        : null;
+    })();
     const rawUnit =
       mwResult.base_measurement_unit ?? mwResult.new_measurement_unit ?? 'ms';
     const { fmt, displayUnit } = ci
@@ -508,14 +603,18 @@ export const mannWhitneyStrategy = {
   },
 
   renderColumns(result: CombinedResultsItemType) {
+    const mwResult = result as MannWhitneyResultsItem;
     const {
       cliffs_delta,
       direction_of_change,
       cles,
-      bootstrapCi,
       base_standard_stats,
       new_standard_stats,
-    } = result as MannWhitneyResultsItem;
+    } = mwResult;
+    // See `isSignificantForDisplay` — uses the cached CI if a filter/sort
+    // populated it, otherwise the backend's interpretation. Cell renders
+    // can't afford to trigger BCa on every row at load time.
+    const sigDisplay = isSignificantForDisplay(mwResult) ? 'S' : 'NS';
     const clesValue = cles?.cles ? `${(cles.cles * 100).toFixed(2)} %` : '-';
     const baseMedian = base_standard_stats?.median ?? 0;
     const newMedian = new_standard_stats?.median ?? 0;
@@ -579,7 +678,7 @@ export const mannWhitneyStrategy = {
           {clesValue}
         </div>
         <div className='significance cell' role='cell'>
-          {bootstrapCi?.significant ? 'S' : 'NS'}
+          {sigDisplay}
         </div>
       </>
     );

--- a/src/components/CompareResults/PValCliffsDeltaComp.tsx
+++ b/src/components/CompareResults/PValCliffsDeltaComp.tsx
@@ -5,21 +5,12 @@ import { capitalize } from '../../utils/helpers';
 interface PValCliffsDeltaCompProps {
   cliffs_delta: number;
   cliffs_interpretation: string;
-  pValue: number | undefined | null;
-  p_value_cles: string;
   cles: number | string;
   cles_direction: string;
 }
 
 function PValCliffsDeltaComp(props: PValCliffsDeltaCompProps) {
-  const {
-    cliffs_delta,
-    cliffs_interpretation,
-    pValue,
-    p_value_cles,
-    cles,
-    cles_direction,
-  } = props;
+  const { cliffs_delta, cliffs_interpretation, cles, cles_direction } = props;
   return (
     <Box
       sx={{
@@ -46,11 +37,6 @@ function PValCliffsDeltaComp(props: PValCliffsDeltaCompProps) {
             <td style={{ padding: 2 }}>
               {capitalize(cliffs_interpretation ?? '')}
             </td>
-          </tr>
-          <tr>
-            <td style={{ padding: 2 }}>Significance (p-value)</td>
-            <td style={{ padding: 2 }}>{pValue}</td>
-            <td style={{ padding: 2 }}>{p_value_cles}</td>
           </tr>
           <tr>
             <td style={{ padding: 2 }}>CLES</td>

--- a/src/components/CompareResults/loader.ts
+++ b/src/components/CompareResults/loader.ts
@@ -4,6 +4,7 @@ import {
   compareView,
   MANN_WHITNEY_U,
 } from '../../common/constants';
+import { precomputeMannWhitneyCI } from '../../common/testVersions/mannWhitney';
 import {
   fetchCompareResults,
   fetchFakeCompareResults,
@@ -12,6 +13,7 @@ import {
 import {
   Changeset,
   CombinedResultsItemType,
+  MannWhitneyResultsItem,
   Repository,
 } from '../../types/state';
 import { FakeCommitHash, Framework, TestVersion } from '../../types/types';
@@ -197,6 +199,13 @@ export async function loader({ request }: { request: Request }) {
   const useFakeData = url.searchParams.has('fakedata');
   if (useFakeData) {
     const results = await fetchAllFakeCompareResults();
+    // Fake results are Mann-Whitney shaped; precompute the CI per row so the
+    // Sig column behaves the same way as it would on real backend data.
+    for (const oneRevsResults of results) {
+      precomputeMannWhitneyCI(
+        oneRevsResults as unknown as MannWhitneyResultsItem[],
+      );
+    }
     // They're all based on the same rev
     const baseRev = results[0][0].base_rev;
     // And the same repository
@@ -292,6 +301,18 @@ export async function getComparisonInformation(
     replicates,
     testVersion,
     silvermanKDEEnabled,
+  }).then((results) => {
+    // Precompute the bootstrap CI per row when the data is Mann-Whitney —
+    // the Sig column sorts/filters on it and the expanded-row alert reads it
+    // too, so doing the heavy BCa [see src/utils/bootstrap-ci.ts#L163-L203] work once here avoids per-render thrashing.
+    if (testVersion === MANN_WHITNEY_U) {
+      for (const oneRevsResults of results) {
+        precomputeMannWhitneyCI(
+          oneRevsResults as unknown as MannWhitneyResultsItem[],
+        );
+      }
+    }
+    return results;
   });
 
   // TODO what happens if there's no result?

--- a/src/components/CompareResults/loader.ts
+++ b/src/components/CompareResults/loader.ts
@@ -4,7 +4,6 @@ import {
   compareView,
   MANN_WHITNEY_U,
 } from '../../common/constants';
-import { precomputeMannWhitneyCI } from '../../common/testVersions/mannWhitney';
 import {
   fetchCompareResults,
   fetchFakeCompareResults,
@@ -13,7 +12,6 @@ import {
 import {
   Changeset,
   CombinedResultsItemType,
-  MannWhitneyResultsItem,
   Repository,
 } from '../../types/state';
 import { FakeCommitHash, Framework, TestVersion } from '../../types/types';
@@ -199,13 +197,10 @@ export async function loader({ request }: { request: Request }) {
   const useFakeData = url.searchParams.has('fakedata');
   if (useFakeData) {
     const results = await fetchAllFakeCompareResults();
-    // Fake results are Mann-Whitney shaped; precompute the CI per row so the
-    // Sig column behaves the same way as it would on real backend data.
-    for (const oneRevsResults of results) {
-      precomputeMannWhitneyCI(
-        oneRevsResults as unknown as MannWhitneyResultsItem[],
-      );
-    }
+    // No bootstrap CI precompute here — the Sig column lazily computes (and
+    // caches) on the first filter/sort interaction via `getBootstrapCi` in
+    // mannWhitney.tsx. Eagerly precomputing on every row was blocking the
+    // table render at load time.
     // They're all based on the same rev
     const baseRev = results[0][0].base_rev;
     // And the same repository
@@ -301,19 +296,11 @@ export async function getComparisonInformation(
     replicates,
     testVersion,
     silvermanKDEEnabled,
-  }).then((results) => {
-    // Precompute the bootstrap CI per row when the data is Mann-Whitney —
-    // the Sig column sorts/filters on it and the expanded-row alert reads it
-    // too, so doing the heavy BCa [see src/utils/bootstrap-ci.ts#L163-L203] work once here avoids per-render thrashing.
-    if (testVersion === MANN_WHITNEY_U) {
-      for (const oneRevsResults of results) {
-        precomputeMannWhitneyCI(
-          oneRevsResults as unknown as MannWhitneyResultsItem[],
-        );
-      }
-    }
-    return results;
   });
+  // No bootstrap CI precompute here — see the lazy `getBootstrapCi` helper
+  // in mannWhitney.tsx. Eager precompute on every row was blocking table
+  // render; lazy compute defers the BCa cost to the first Sig filter/sort
+  // click (and caches per row from then on).
 
   // TODO what happens if there's no result?
   const baseRevInfoPromise = memoizedFetchRevisionForRepository({

--- a/src/components/CompareResults/overTimeLoader.ts
+++ b/src/components/CompareResults/overTimeLoader.ts
@@ -5,6 +5,7 @@ import {
   compareOverTimeView,
   MANN_WHITNEY_U,
 } from '../../common/constants';
+import { precomputeMannWhitneyCI } from '../../common/testVersions/mannWhitney';
 import {
   fetchCompareOverTimeResults,
   memoizedFetchRevisionForRepository,
@@ -12,6 +13,7 @@ import {
 import {
   Changeset,
   CombinedResultsItemType,
+  MannWhitneyResultsItem,
   Repository,
 } from '../../types/state';
 import { Framework, TestVersion, TimeRange } from '../../types/types';
@@ -228,6 +230,17 @@ export async function loader({ request }: { request: Request }) {
     replicates,
     testVersion,
     silvermanKDEEnabled,
+  }).then((results) => {
+    // Same precompute as the main loader so the Sig column has a precomputed
+    // CI to sort/filter on without recomputing per render.
+    if (testVersion === MANN_WHITNEY_U) {
+      for (const oneRevsResults of results) {
+        precomputeMannWhitneyCI(
+          oneRevsResults as unknown as MannWhitneyResultsItem[],
+        );
+      }
+    }
+    return results;
   });
 
   const newRevsInfoPromises = newRevs.map((newRev, i) =>

--- a/src/components/CompareResults/overTimeLoader.ts
+++ b/src/components/CompareResults/overTimeLoader.ts
@@ -5,7 +5,6 @@ import {
   compareOverTimeView,
   MANN_WHITNEY_U,
 } from '../../common/constants';
-import { precomputeMannWhitneyCI } from '../../common/testVersions/mannWhitney';
 import {
   fetchCompareOverTimeResults,
   memoizedFetchRevisionForRepository,
@@ -13,7 +12,6 @@ import {
 import {
   Changeset,
   CombinedResultsItemType,
-  MannWhitneyResultsItem,
   Repository,
 } from '../../types/state';
 import { Framework, TestVersion, TimeRange } from '../../types/types';
@@ -230,18 +228,10 @@ export async function loader({ request }: { request: Request }) {
     replicates,
     testVersion,
     silvermanKDEEnabled,
-  }).then((results) => {
-    // Same precompute as the main loader so the Sig column has a precomputed
-    // CI to sort/filter on without recomputing per render.
-    if (testVersion === MANN_WHITNEY_U) {
-      for (const oneRevsResults of results) {
-        precomputeMannWhitneyCI(
-          oneRevsResults as unknown as MannWhitneyResultsItem[],
-        );
-      }
-    }
-    return results;
   });
+  // No bootstrap CI precompute — the Sig column lazily computes (and caches)
+  // via `getBootstrapCi` in mannWhitney.tsx on the first filter/sort click.
+  // Same change as the main loader, applied here to keep load time aligned.
 
   const newRevsInfoPromises = newRevs.map((newRev, i) =>
     memoizedFetchRevisionForRepository({

--- a/src/components/CompareResults/subtestsLoader.ts
+++ b/src/components/CompareResults/subtestsLoader.ts
@@ -1,6 +1,7 @@
 import { repoMap, frameworks, MANN_WHITNEY_U } from '../../common/constants';
+import { precomputeMannWhitneyCI } from '../../common/testVersions/mannWhitney';
 import { fetchSubtestsCompareResults } from '../../logic/treeherder';
-import { Repository } from '../../types/state';
+import { MannWhitneyResultsItem, Repository } from '../../types/state';
 import { Framework, TestVersion } from '../../types/types';
 
 // This function checks and sanitizes the input values, then returns values that
@@ -186,6 +187,16 @@ export function loader({ request }: { request: Request }) {
     replicates,
     testVersion,
     silvermanKDEEnabled,
+  }).then((subtestResults) => {
+    // Precompute the bootstrap CI for the Sig column when these are
+    // Mann-Whitney results. Subtests return a flat array (one entry per
+    // subtest), not the per-revision nesting the main loader has.
+    if (testVersion === MANN_WHITNEY_U) {
+      precomputeMannWhitneyCI(
+        subtestResults as unknown as MannWhitneyResultsItem[],
+      );
+    }
+    return subtestResults;
   });
 
   return {

--- a/src/components/CompareResults/subtestsLoader.ts
+++ b/src/components/CompareResults/subtestsLoader.ts
@@ -1,7 +1,6 @@
 import { repoMap, frameworks, MANN_WHITNEY_U } from '../../common/constants';
-import { precomputeMannWhitneyCI } from '../../common/testVersions/mannWhitney';
 import { fetchSubtestsCompareResults } from '../../logic/treeherder';
-import { MannWhitneyResultsItem, Repository } from '../../types/state';
+import { Repository } from '../../types/state';
 import { Framework, TestVersion } from '../../types/types';
 
 // This function checks and sanitizes the input values, then returns values that
@@ -187,17 +186,10 @@ export function loader({ request }: { request: Request }) {
     replicates,
     testVersion,
     silvermanKDEEnabled,
-  }).then((subtestResults) => {
-    // Precompute the bootstrap CI for the Sig column when these are
-    // Mann-Whitney results. Subtests return a flat array (one entry per
-    // subtest), not the per-revision nesting the main loader has.
-    if (testVersion === MANN_WHITNEY_U) {
-      precomputeMannWhitneyCI(
-        subtestResults as unknown as MannWhitneyResultsItem[],
-      );
-    }
-    return subtestResults;
   });
+  // No bootstrap CI precompute — the Sig column lazily computes (and
+  // caches) on the first filter/sort interaction via `getBootstrapCi` in
+  // mannWhitney.tsx. Eager precompute was blocking table render at load.
 
   return {
     results,

--- a/src/components/CompareResults/subtestsOverTimeLoader.tsx
+++ b/src/components/CompareResults/subtestsOverTimeLoader.tsx
@@ -4,8 +4,9 @@ import {
   timeRanges,
   MANN_WHITNEY_U,
 } from '../../common/constants';
+import { precomputeMannWhitneyCI } from '../../common/testVersions/mannWhitney';
 import { fetchSubtestsCompareOverTimeResults } from '../../logic/treeherder';
-import { Repository } from '../../types/state';
+import { MannWhitneyResultsItem, Repository } from '../../types/state';
 import { Framework, TestVersion, TimeRange } from '../../types/types';
 
 // This function checks and sanitizes the input values, then returns values that
@@ -212,6 +213,13 @@ export function loader({ request }: { request: Request }) {
     replicates,
     testVersion,
     silvermanKDEEnabled,
+  }).then((subtestResults) => {
+    if (testVersion === MANN_WHITNEY_U) {
+      precomputeMannWhitneyCI(
+        subtestResults as unknown as MannWhitneyResultsItem[],
+      );
+    }
+    return subtestResults;
   });
 
   return {

--- a/src/components/CompareResults/subtestsOverTimeLoader.tsx
+++ b/src/components/CompareResults/subtestsOverTimeLoader.tsx
@@ -4,9 +4,8 @@ import {
   timeRanges,
   MANN_WHITNEY_U,
 } from '../../common/constants';
-import { precomputeMannWhitneyCI } from '../../common/testVersions/mannWhitney';
 import { fetchSubtestsCompareOverTimeResults } from '../../logic/treeherder';
-import { MannWhitneyResultsItem, Repository } from '../../types/state';
+import { Repository } from '../../types/state';
 import { Framework, TestVersion, TimeRange } from '../../types/types';
 
 // This function checks and sanitizes the input values, then returns values that
@@ -213,14 +212,11 @@ export function loader({ request }: { request: Request }) {
     replicates,
     testVersion,
     silvermanKDEEnabled,
-  }).then((subtestResults) => {
-    if (testVersion === MANN_WHITNEY_U) {
-      precomputeMannWhitneyCI(
-        subtestResults as unknown as MannWhitneyResultsItem[],
-      );
-    }
-    return subtestResults;
   });
+  // No bootstrap CI precompute — the Sig column lazily computes (and
+  // caches) via `getBootstrapCi` in mannWhitney.tsx on the first
+  // filter/sort click. Same change as the other loaders to keep load
+  // time aligned with production.
 
   return {
     results,

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -242,6 +242,10 @@ export type MannWhitneyResultsItem = {
   is_meaningful: boolean | null;
   more_runs_are_needed: boolean | null;
   warning_c_delta?: string | null;
+  // Bootstrap (BCa) [see src/utils/bootstrap-ci.ts#L163-L203] CI for the difference of medians.
+  // `null` means the CI couldn't be computed (e.g.
+  // missing base_runs/new_runs); callers treat that as "not significant".
+  bootstrapCi?: import('../utils/bootstrap-ci').BootstrapCI | null;
   /*
   Each test has a signature and each signature may or may not have a parent_signature.
   If a signature has a parent_signature then we are looking at a subtest. For regular tests this field will be null.


### PR DESCRIPTION
The significance column, its filter, its sort, and the expanded-row alert now all read from a single precomputed bootstrap (BCa) CI on the difference of medians, replacing the Mann-Whitney p-value's `interpretation` string as the source of truth.

~~Added `MannWhitneyResultsItem.bootstrapCi` and a `precomputeMannWhitneyCI` helper that the four data loaders (compare, over-time, subtests, subtests-over-time) call once per row. Doing it at load time keeps sort/filter/render at property-access speed.~~

- Sig column: `matchesFunction` and `sortFunction` read `bootstrapCi`. Sort is "significant first, then |medianDiff| desc" — written in ASC semantics so `useTableSort`'s DESC swap produces that order. The cell render uses `bootstrapCi?.significant` to pick icon vs `-`
- `renderExpandedRight` reads the same precomputed CI (with an inline fallback for callers that mount the strategy without a loader).
- Drop the "Significance (p-value)" row from `PValCliffsDeltaComp`. The Δ-median alert already conveys CI-based significance, and showing the p-value contradicts the Sig column.
- Update `tooltipSignificance` and `tooltipStatusMannWhitney` to match the new definition (BCa CI excludes zero, not p-value < 0.05).
- Update tests + snapshots to reflect the new sig values and orderings; remove two RevisionRow tests that asserted text from the now-removed p-value row.

[Deploy Link](https://deploy-preview-1056--mozilla-perfcompare.netlify.app/compare-results?baseRev=8de2dede9c34d18332b9bcff08bda4e6ff103b30&baseRepo=try&newRev=119723724e68b7d3799fa8c89216b36264e01c69&newRepo=try&newRev=26e995970eaabbc908c630aad3ab0c50f47e5b44&newRepo=try&framework=4&test_version=mann-whitney-u)

[Browser time preview](https://deploy-preview-1056--mozilla-perfcompare.netlify.app/compare-results?baseRev=51308dbe0e7e0810c9f6eec28ce49d34c49d6480&baseRepo=mozilla-central&newRev=64a89bfa4912122c11d6d2d381bd4c8d538b56e6&newRepo=mozilla-central&framework=13&test_version=mann-whitney-u&search=speedometer)

### **Updates:** 

1. Now considers replicates when available. 
2. Changed from symbols to letters - S for Significant. NS for Not Significant 
3. **Performance fix:** The Sig column's bootstrap CI was being precomputed for every row in all four loaders before the table could render. This caused major performance problems in captured profiles. Switched to lazy compute: pay the BCa cost only when the user engages with the Sig column (filter or sort click). First click pays the per-row cost across all rows; after that, every comparison is a cached property read. The four loaders no longer call `precomputeMannWhitneyCI`. Their `.then `callbacks are removed entirely; results flow straight through. Unused imports (`precomputeMannWhitneyCI`, `MannWhitneyResultsItem`) dropped from each file.


<img width="1404" height="852" alt="Screenshot 2026-06-24 at 18 09 38" src="https://github.com/user-attachments/assets/36b431f3-e897-4f66-b825-030ddd541432" />




