### PR TITLE
 Bug 2037556: simplify wording of tooltip text for CD and CLES; fix dark mode links in tooltips

### DIFF
--- a/src/common/testVersions/mannWhitney.tsx
+++ b/src/common/testVersions/mannWhitney.tsx
@@ -35,40 +35,35 @@ import {
 
 const tooltipCliffsDelta = (
   <span>
+    Cliff&apos;s Delta (CD) shows how different the New and Base results are. A
+    score near 0 means little difference. A score above 0.47 or below -0.47
+    means a large difference. A negative score means New values are usually
+    higher. See the{' '}
     <a
-      href='https://en.wikipedia.org/wiki/Effect_size#Effect_size_for_ordinal_data'
+      href='https://firefox-source-docs.mozilla.org/testing/perfdocs/perfcompare.html#cliffs-delta'
       target='_blank'
       rel='noreferrer'
     >
-      Cliff&apos;s Delta
+      documentation
     </a>{' '}
-    quantifies the magnitude of the difference between Base and New values.
-    Anything beyond ±0.47 is considered a large difference while anything below
-    ±0.15 is negligible. A negative value means a New value is consistently
-    larger than a Base value.
+    for more information on how to interpret the Cliff’s Delta score.
   </span>
 );
 
 const tooltipEffectSize = (
   <span>
+    The Common Language Effect Size (CLES) shows the chance that a New value is
+    lower than a Base value. A score near 50% means New and Base are about
+    equally likely to be higher. The farther the score is from 50%, the clearer
+    the difference. See the{' '}
     <a
-      href='https://en.wikipedia.org/wiki/Probability_of_superiority'
+      href='https://firefox-source-docs.mozilla.org/testing/perfdocs/perfcompare.html#cliffs-delta'
       target='_blank'
       rel='noreferrer'
     >
-      The Common Language Effect Size (CLES)
+      documentation
     </a>{' '}
-    is a percentage, from 0% to 100%, providing a clearer indication of how
-    large or meaningful the change is. An improvement or regression being shown
-    here means that the effect size is meaningful. If the effect size is close
-    to 50%, the distributions are probably identical, if not, they probably
-    differ. The sign of the Cliff&apos;s delta is also important, as it
-    indicates the direction of the change. If shifted to the left, it&apos;s
-    negative; to the right, it&apos;s positive. Pair this with higher is better
-    or lower is better to understand whether the change is an improvement or
-    regression. For example, given a Cliff&apos;s delta of 0.54 and CLES of 77%,
-    there&apos;s a 77% chance a value from new is lower than a value from old
-    (lower is better).
+    for more information on how to interpret the CLES score.
   </span>
 );
 

--- a/src/theme/components.js
+++ b/src/theme/components.js
@@ -1,6 +1,13 @@
 import { green, red } from '@mui/material/colors';
 
-import { Spacing, FontsRaw, FontSizeRaw, TooltipRaw, Select } from '../styles';
+import {
+  Spacing,
+  FontsRaw,
+  FontSizeRaw,
+  TooltipRaw,
+  Select,
+  Colors,
+} from '../styles';
 import android from './img/android.svg';
 import high from './img/high.svg';
 import linux from './img/linux.svg';
@@ -237,8 +244,12 @@ const components = {
   MuiTooltip: {
     styleOverrides: {
       tooltip: [
-        TooltipRaw.Light,
-        ({ theme }) => theme.applyStyles('dark', TooltipRaw.Dark),
+        { ...TooltipRaw.Light, '& a': { color: Colors.LinkText } },
+        ({ theme }) =>
+          theme.applyStyles('dark', {
+            ...TooltipRaw.Dark,
+            '& a': { color: Colors.LinkTextDark },
+          }),
       ],
     },
   },


### PR DESCRIPTION
This is a quick PR to [simplify the wording of the tooltips](https://bugzilla.mozilla.org/show_bug.cgi?id=2037556) for Cliff's Delta and CLES, Common Language Effect Size. I also fixed a bug here with the links' color in dark mode: [Bug 2030512](https://bugzilla.mozilla.org/show_bug.cgi?id=2030512). 

**New text for Cliff's Delta**:  Cliff's Delta (CD) shows how different the New and Base results are. A score near 0 means little difference. A score above 0.47 or below -0.47 means a large difference. A negative score means New values are usually  higher. See the [documentation ](https://firefox-source-docs.mozilla.org/testing/perfdocs/perfcompare.html#cliffs-delta) for more information on how to interpret the Cliff’s Delta score.

**New text for CLES**:  The Common Language Effect Size (CLES) shows the chance that a New value is lower than a Base value. A score near 50% means New and Base are about equally likely to be higher. The farther the score is from 50%, the clearer the difference. See the [documentation](https://firefox-source-docs.mozilla.org/testing/perfdocs/perfcompare.html#cliffs-delta') for more information on how to interpret the CLES score.

[Deploy link](https://deploy-preview-1067--mozilla-perfcompare.netlify.app/compare-results?baseRev=97985f89971df618dde4ce4061627bd51a946fdf&baseRepo=mozilla-central&newRev=1daac5fa8f141c84f56464c0c4171763bbef5880&newRepo=mozilla-central&framework=1&sort=effects%7Cdesc&filter_status=improvement%2Cregression)
 