### PR TITLE
[bug-2021092] Update light/dark toggle wording to be less ambiguous

### DIFF
--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -96,10 +96,12 @@ describe('App', () => {
     });
 
     await user.click(darkModeButton);
-    expect(screen.getByLabelText('Light mode')).toBeInTheDocument();
+    expect(screen.getByLabelText('Switch to Light mode')).toBeInTheDocument();
 
     await user.click(darkModeButton);
-    expect(screen.queryByLabelText('Light mode')).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('Switch to Light mode'),
+    ).not.toBeInTheDocument();
   });
 
   describe('CompareResults or CompareOverTime loader', () => {

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`Results Table Should match snapshot 1`] = `
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-n290n7-MuiTypography-root"
                 >
-                  Dark mode
+                  Switch to Dark mode
                 </span>
               </label>
             </div>
@@ -2930,7 +2930,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-n290n7-MuiTypography-root"
                 >
-                  Dark mode
+                  Switch to Dark mode
                 </span>
               </label>
             </div>

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -387,7 +387,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-n290n7-MuiTypography-root"
                 >
-                  Dark mode
+                  Switch to Dark mode
                 </span>
               </label>
             </div>
@@ -2306,7 +2306,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-n290n7-MuiTypography-root"
                 >
-                  Dark mode
+                  Switch to Dark mode
                 </span>
               </label>
             </div>
@@ -3908,7 +3908,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-n290n7-MuiTypography-root"
                 >
-                  Dark mode
+                  Switch to Dark mode
                 </span>
               </label>
             </div>
@@ -5510,7 +5510,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-n290n7-MuiTypography-root"
                 >
-                  Dark mode
+                  Switch to Dark mode
                 </span>
               </label>
             </div>
@@ -7112,7 +7112,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-n290n7-MuiTypography-root"
                 >
-                  Dark mode
+                  Switch to Dark mode
                 </span>
               </label>
             </div>

--- a/src/__tests__/Search/SearchResultsList.test.tsx
+++ b/src/__tests__/Search/SearchResultsList.test.tsx
@@ -192,7 +192,7 @@ describe('SearchResultsList', () => {
     });
 
     await user.click(darkModeToggle);
-    expect(screen.getByLabelText('Light mode')).toBeInTheDocument();
+    expect(screen.getByLabelText('Switch to Light mode')).toBeInTheDocument();
     const autocomplete = screen.getAllByTestId('autocomplete')[0];
 
     // open dropdown using keyboard arrow down

--- a/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/CompareWithBase.test.tsx.snap
@@ -4296,7 +4296,7 @@ exports[`Compare With Base should remove the checked revision once X button is c
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-n290n7-MuiTypography-root"
                 >
-                  Dark mode
+                  Switch to Dark mode
                 </span>
               </label>
             </div>

--- a/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchResultsList.test.tsx.snap
@@ -847,7 +847,7 @@ exports[`SearchResultsList should match snapshot 1`] = `
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-n290n7-MuiTypography-root"
                 >
-                  Dark mode
+                  Switch to Dark mode
                 </span>
               </label>
             </div>

--- a/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
+++ b/src/__tests__/Search/__snapshots__/SearchView.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`Search View renders correctly when there are no results 1`] = `
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-n290n7-MuiTypography-root"
                 >
-                  Dark mode
+                  Switch to Dark mode
                 </span>
               </label>
             </div>

--- a/src/__tests__/__snapshots__/App.test.tsx.snap
+++ b/src/__tests__/__snapshots__/App.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-n290n7-MuiTypography-root"
                 >
-                  Dark mode
+                  Switch to Dark mode
                 </span>
               </label>
             </div>
@@ -353,7 +353,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-n290n7-MuiTypography-root"
                 >
-                  Dark mode
+                  Switch to Dark mode
                 </span>
               </label>
             </div>
@@ -550,7 +550,7 @@ exports[`App CompareResults or CompareOverTime loader Should render an error pag
                 <span
                   class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-n290n7-MuiTypography-root"
                 >
-                  Dark mode
+                  Switch to Dark mode
                 </span>
               </label>
             </div>

--- a/src/components/Shared/ToggleDarkModeButton.tsx
+++ b/src/components/Shared/ToggleDarkModeButton.tsx
@@ -57,7 +57,7 @@ function ToggleDarkMode() {
               id={theme == 'light' ? strings.darkMode : strings.lightMode}
             />
           }
-          label={theme == 'light' ? strings.darkMode : strings.lightMode}
+          label={`Switch to ${theme == 'light' ? strings.darkMode : strings.lightMode}`}
         />
       </FormGroup>
     </Box>


### PR DESCRIPTION
Update the wording From "X Mode [toggle]" to "Switch to X Mode [toggle]" to be less confusing as user mentioned in bug ticket.

Fixes [Bug-2021092](https://bugzilla.mozilla.org/show_bug.cgi?id=2021092)
