### PR TITLE
Bug 2058240: Filters from cookies don't make it into the URL

### DIFF
--- a/src/__tests__/CompareResults/ResultsTable.test.tsx
+++ b/src/__tests__/CompareResults/ResultsTable.test.tsx
@@ -1365,3 +1365,65 @@ describe('Advanced-columns toggle for mann-whitney-u testVersion', () => {
     expect(advancedParam()).toBeNull();
   });
 });
+
+describe('cookie persistence vs. shareable URLs', () => {
+  it('seeds filters from cookies and marks the URL initialized on a fresh URL', async () => {
+    document.cookie = 'perfcompare_filter_status=regression; path=/';
+    const { testCompareData } = getTestData();
+    setupAndRender(testCompareData, 'test_version=student-t');
+
+    await screen.findByText('a11yr');
+
+    // The remembered cookie is applied to the view...
+    expect(summarizeVisibleRows()).toEqual([
+      'a11yr dhtml.html spam opt e10s fission stylo webrender',
+      '  - Linux 18.04, Regression, 1.85 %, Medium',
+    ]);
+    // ...and materialised into the URL, which is now marked initialized so the
+    // link reproduces this exact view for anyone.
+    expect(summarizeTableFiltersFromUrl()).toEqual({ status: ['regression'] });
+    expect(new URLSearchParams(window.location.search).get('initialized')).toBe(
+      '1',
+    );
+  });
+
+  it('ignores cookies when the URL is already initialized', async () => {
+    // A different viewer's cookie must not change what an initialized (shared)
+    // URL displays.
+    document.cookie = 'perfcompare_filter_status=regression; path=/';
+    const { testCompareData } = getTestData();
+    setupAndRender(testCompareData, 'test_version=student-t&initialized=1');
+
+    await screen.findByText('a11yr');
+
+    // Cookie is ignored: every status stays visible.
+    expect(summarizeVisibleRows()).toEqual([
+      'a11yr dhtml.html spam opt e10s fission stylo webrender',
+      '  - Linux 18.04, Regression, 1.85 %, Medium',
+      '  - macOS 10.15, Improvement, 1.08 %, Low',
+      '  - Windows 10, -, -24 %, -',
+      '  - Windows 10, -, -2.4 %, High',
+    ]);
+    // ...and the cookie is not written into the URL.
+    expect(summarizeTableFiltersFromUrl()).toEqual({});
+  });
+
+  it('keeps the initialized marker after toggling a filter', async () => {
+    const { testCompareData } = getTestData();
+    setupAndRender(testCompareData, 'test_version=student-t');
+
+    await screen.findByText('a11yr');
+
+    const user = userEvent.setup({
+      advanceTimers: jest.advanceTimersByTime,
+    });
+    await clickMenuItem(user, 'Status', /No changes/);
+
+    expect(summarizeTableFiltersFromUrl()).toEqual({
+      status: ['improvement', 'regression'],
+    });
+    expect(new URLSearchParams(window.location.search).get('initialized')).toBe(
+      '1',
+    );
+  });
+});

--- a/src/__tests__/CompareResults/ResultsTable.test.tsx
+++ b/src/__tests__/CompareResults/ResultsTable.test.tsx
@@ -1426,4 +1426,57 @@ describe('cookie persistence vs. shareable URLs', () => {
       '1',
     );
   });
+
+  it('keeps the initialized marker and seeded filters after a search-term change', async () => {
+    document.cookie = 'perfcompare_filter_status=regression; path=/';
+    const { testCompareData } = getTestData();
+    setupAndRender(testCompareData, 'test_version=student-t');
+
+    await screen.findByText('a11yr');
+
+    // Seeded from the cookie and marked initialized.
+    expect(summarizeTableFiltersFromUrl()).toEqual({ status: ['regression'] });
+    expect(new URLSearchParams(window.location.search).get('initialized')).toBe(
+      '1',
+    );
+
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    // Submit with Enter so the write happens immediately (bypasses the input's
+    // debounce, which fake timers don't flush after typing).
+    await user.type(screen.getByPlaceholderText('Filter results'), 'linux{Enter}');
+
+    // The search term is written, and the out-of-band params survive.
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get('search')).toBe('linux');
+    expect(params.get('initialized')).toBe('1');
+    expect(params.get('filter_status')).toBe('regression');
+  });
+
+  it('keeps the initialized marker and seeded filters after a test-version change', async () => {
+    document.cookie = 'perfcompare_filter_status=regression; path=/';
+    const { testCompareData } = getTestData();
+    setupAndRender(testCompareData, 'test_version=student-t');
+
+    await screen.findByText('a11yr');
+    expect(new URLSearchParams(window.location.search).get('initialized')).toBe(
+      '1',
+    );
+
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await user.click(
+      screen.getByRole('combobox', { name: 'Stats Test Version' }),
+    );
+    await user.click(
+      await screen.findByRole('option', { name: 'Mann-Whitney-U' }),
+    );
+
+    // The test version changes (a router navigation), and the marker + seeded
+    // filter ride along instead of being dropped.
+    await waitFor(() => {
+      const params = new URLSearchParams(window.location.search);
+      expect(params.get('test_version')).toBe('mann-whitney-u');
+      expect(params.get('initialized')).toBe('1');
+      expect(params.get('filter_status')).toBe('regression');
+    });
+  });
 });

--- a/src/__tests__/CompareResults/ResultsTable.test.tsx
+++ b/src/__tests__/CompareResults/ResultsTable.test.tsx
@@ -1443,7 +1443,10 @@ describe('cookie persistence vs. shareable URLs', () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     // Submit with Enter so the write happens immediately (bypasses the input's
     // debounce, which fake timers don't flush after typing).
-    await user.type(screen.getByPlaceholderText('Filter results'), 'linux{Enter}');
+    await user.type(
+      screen.getByPlaceholderText('Filter results'),
+      'linux{Enter}',
+    );
 
     // The search term is written, and the out-of-band params survive.
     const params = new URLSearchParams(window.location.search);

--- a/src/__tests__/CompareResults/SubtestsResultsView.test.tsx
+++ b/src/__tests__/CompareResults/SubtestsResultsView.test.tsx
@@ -748,3 +748,45 @@ describe('SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVers
     expect(document.body).toMatchSnapshot();
   });
 });
+
+describe('cookie persistence vs. shareable URLs (subtests)', () => {
+  it('keeps the initialized marker and seeded filters after a search-term change', async () => {
+    // Regression test: the subtests search handler must build its URL write
+    // from the live URL, otherwise the cookie-seeded filter/sort and the
+    // `initialized` marker (written out-of-band on mount) get clobbered.
+    document.cookie = 'perfcompare_filter_status=regression; path=/';
+    const { subtestsResult } = getTestData();
+    setup({
+      element: (
+        <SubtestsResultsView title={Strings.metaData.pageTitle.subtests} />
+      ),
+      route: '/subtests-compare-results/',
+      search:
+        '?baseRev=f49863193c13c1def4db2dd3ea9c5d6bd9d517a7&baseRepo=mozilla-central&newRev=2cb6128d7dca8c9a9266b3505d64d55ac1bcc8a8&newRepo=mozilla-central&framework=1&baseParentSignature=4774487&newParentSignature=4774487&test_version=student-t',
+      subtestsResult,
+    });
+
+    // Wait on filter-independent page chrome (the regression filter may hide
+    // every row, so don't key on a specific subtest).
+    await screen.findByText('All results');
+
+    // Seeded from the cookie and marked initialized on mount.
+    const seeded = new URLSearchParams(window.location.search);
+    expect(seeded.get('filter_status')).toBe('regression');
+    expect(seeded.get('initialized')).toBe('1');
+
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    // Submit with Enter so the write happens immediately (bypasses the input's
+    // debounce, which fake timers don't flush after typing).
+    await user.type(
+      screen.getByPlaceholderText('Filter results'),
+      'dhtml{Enter}',
+    );
+
+    // The search term is written, and the out-of-band params survive.
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get('search')).toBe('dhtml');
+    expect(params.get('initialized')).toBe('1');
+    expect(params.get('filter_status')).toBe('regression');
+  });
+});

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion tabl
       style="width: 2.8284271247461903px; height: 2.8284271247461903px; top: -1.4142135623730951px; left: -1.4142135623730951px;"
     >
       <span
-        class="MuiTouchRipple-child MuiTouchRipple-childLeaving"
+        class="MuiTouchRipple-child"
       />
     </span>
     <span
@@ -108,7 +108,7 @@ exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion tabl
       style="width: 1px; height: 1px; top: -0.5px; left: -0.5px;"
     >
       <span
-        class="MuiTouchRipple-child MuiTouchRipple-childLeaving MuiTouchRipple-childPulsate"
+        class="MuiTouchRipple-child MuiTouchRipple-childPulsate"
       />
     </span>
     <span
@@ -205,7 +205,7 @@ exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion tabl
       style="width: 2.8284271247461903px; height: 2.8284271247461903px; top: -1.4142135623730951px; left: -1.4142135623730951px;"
     >
       <span
-        class="MuiTouchRipple-child MuiTouchRipple-childLeaving"
+        class="MuiTouchRipple-child"
       />
     </span>
     <span
@@ -250,7 +250,7 @@ exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion tabl
       style="width: 2.8284271247461903px; height: 2.8284271247461903px; top: -1.4142135623730951px; left: -1.4142135623730951px;"
     >
       <span
-        class="MuiTouchRipple-child MuiTouchRipple-childLeaving"
+        class="MuiTouchRipple-child"
       />
     </span>
     <span
@@ -1878,7 +1878,7 @@ exports[`SubtestsResultsView Component Tests table sorting can sort the table an
       style="width: 2.8284271247461903px; height: 2.8284271247461903px; top: -1.4142135623730951px; left: -1.4142135623730951px;"
     >
       <span
-        class="MuiTouchRipple-child MuiTouchRipple-childLeaving"
+        class="MuiTouchRipple-child"
       />
     </span>
     <span
@@ -1931,7 +1931,7 @@ exports[`SubtestsResultsView Component Tests table sorting can sort the table an
       style="width: 1px; height: 1px; top: -0.5px; left: -0.5px;"
     >
       <span
-        class="MuiTouchRipple-child MuiTouchRipple-childLeaving MuiTouchRipple-childPulsate"
+        class="MuiTouchRipple-child MuiTouchRipple-childPulsate"
       />
     </span>
     <span
@@ -2028,7 +2028,7 @@ exports[`SubtestsResultsView Component Tests table sorting can sort the table an
       style="width: 2.8284271247461903px; height: 2.8284271247461903px; top: -1.4142135623730951px; left: -1.4142135623730951px;"
     >
       <span
-        class="MuiTouchRipple-child MuiTouchRipple-childLeaving"
+        class="MuiTouchRipple-child"
       />
     </span>
     <span
@@ -2117,7 +2117,7 @@ exports[`SubtestsResultsView Component Tests table sorting can sort the table an
       style="width: 2.8284271247461903px; height: 2.8284271247461903px; top: -1.4142135623730951px; left: -1.4142135623730951px;"
     >
       <span
-        class="MuiTouchRipple-child MuiTouchRipple-childLeaving"
+        class="MuiTouchRipple-child"
       />
     </span>
     <span

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion tabl
       style="width: 2.8284271247461903px; height: 2.8284271247461903px; top: -1.4142135623730951px; left: -1.4142135623730951px;"
     >
       <span
-        class="MuiTouchRipple-child MuiTouchRipple-childLeaving"
+        class="MuiTouchRipple-child"
       />
     </span>
     <span
@@ -108,7 +108,7 @@ exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion tabl
       style="width: 1px; height: 1px; top: -0.5px; left: -0.5px;"
     >
       <span
-        class="MuiTouchRipple-child MuiTouchRipple-childLeaving MuiTouchRipple-childPulsate"
+        class="MuiTouchRipple-child MuiTouchRipple-childPulsate"
       />
     </span>
     <span
@@ -205,7 +205,7 @@ exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion tabl
       style="width: 2.8284271247461903px; height: 2.8284271247461903px; top: -1.4142135623730951px; left: -1.4142135623730951px;"
     >
       <span
-        class="MuiTouchRipple-child MuiTouchRipple-childLeaving"
+        class="MuiTouchRipple-child"
       />
     </span>
     <span
@@ -250,7 +250,7 @@ exports[`SubtestsResultsView Component Tests for mann-whitney-u testVersion tabl
       style="width: 2.8284271247461903px; height: 2.8284271247461903px; top: -1.4142135623730951px; left: -1.4142135623730951px;"
     >
       <span
-        class="MuiTouchRipple-child MuiTouchRipple-childLeaving"
+        class="MuiTouchRipple-child"
       />
     </span>
     <span
@@ -1904,7 +1904,7 @@ exports[`SubtestsResultsView Component Tests table sorting can sort the table an
       style="width: 2.8284271247461903px; height: 2.8284271247461903px; top: -1.4142135623730951px; left: -1.4142135623730951px;"
     >
       <span
-        class="MuiTouchRipple-child MuiTouchRipple-childLeaving"
+        class="MuiTouchRipple-child"
       />
     </span>
     <span
@@ -1957,7 +1957,7 @@ exports[`SubtestsResultsView Component Tests table sorting can sort the table an
       style="width: 1px; height: 1px; top: -0.5px; left: -0.5px;"
     >
       <span
-        class="MuiTouchRipple-child MuiTouchRipple-childLeaving MuiTouchRipple-childPulsate"
+        class="MuiTouchRipple-child MuiTouchRipple-childPulsate"
       />
     </span>
     <span
@@ -2054,7 +2054,7 @@ exports[`SubtestsResultsView Component Tests table sorting can sort the table an
       style="width: 2.8284271247461903px; height: 2.8284271247461903px; top: -1.4142135623730951px; left: -1.4142135623730951px;"
     >
       <span
-        class="MuiTouchRipple-child MuiTouchRipple-childLeaving"
+        class="MuiTouchRipple-child"
       />
     </span>
     <span
@@ -2143,7 +2143,7 @@ exports[`SubtestsResultsView Component Tests table sorting can sort the table an
       style="width: 2.8284271247461903px; height: 2.8284271247461903px; top: -1.4142135623730951px; left: -1.4142135623730951px;"
     >
       <span
-        class="MuiTouchRipple-child MuiTouchRipple-childLeaving"
+        class="MuiTouchRipple-child"
       />
     </span>
     <span

--- a/src/components/CompareResults/AdvancedColumnsMenu.tsx
+++ b/src/components/CompareResults/AdvancedColumnsMenu.tsx
@@ -23,6 +23,7 @@ import {
   SIGNIFICANCE,
   serializeAdvancedColumns,
 } from '../../utils/advancedColumnsUrl';
+import { currentUrlParams } from '../../utils/tableStatePersistence';
 
 // The advanced statistics columns are toggled independently — any combination
 // can be shown. The option values reuse the URL keys so the dropdown, the URL
@@ -38,7 +39,7 @@ function AdvancedColumnsMenu() {
   const dispatch = useAppDispatch();
   const mode = useAppSelector((state) => state.theme.mode);
   const advancedColumns = useAdvancedColumns();
-  const [rawSearchParams, updateRawSearchParams] = useRawSearchParams();
+  const [, updateRawSearchParams] = useRawSearchParams();
   // Track the Select's open state so the tooltip can be suppressed while the
   // dropdown is open — otherwise it renders over (and hides) the checkboxes.
   const [menuOpen, setMenuOpen] = useState(false);
@@ -54,7 +55,9 @@ function AdvancedColumnsMenu() {
     dispatch(updateShowCles(next.cles));
     dispatch(updateShowSignificance(next.significance));
 
-    const params = new URLSearchParams(rawSearchParams);
+    // Build from the live URL so toggling columns doesn't drop params written
+    // out-of-band (e.g. the `initialized` marker and cookie-seeded filter/sort).
+    const params = currentUrlParams();
     const value = serializeAdvancedColumns(next);
     if (value) {
       params.set(ADVANCED_COLUMNS_PARAM, value);

--- a/src/components/CompareResults/ResultsMain.tsx
+++ b/src/components/CompareResults/ResultsMain.tsx
@@ -23,6 +23,7 @@ import { Colors, FontsRaw, FontSizeRaw, Spacing } from '../../styles';
 import pencilDark from '../../theme/img/pencil-dark.svg';
 import pencil from '../../theme/img/pencil.svg';
 import type { TestVersion } from '../../types/types';
+import { currentUrlParams } from '../../utils/tableStatePersistence';
 import EditTitleInput from '../CompareResults/EditTitleInput';
 import ToggleReplicatesButton from '../Shared/ToggleReplicatesButton';
 
@@ -116,8 +117,11 @@ function ResultsMain() {
   };
 
   const onSaveButtonClick = () => {
-    rawSearchParams.set('title', comparisonTitleName);
-    updateRawSearchParams(rawSearchParams);
+    // Build from the live URL so we don't drop params written out-of-band
+    // (e.g. the `initialized` marker and cookie-seeded filter/sort).
+    const params = currentUrlParams();
+    params.set('title', comparisonTitleName);
+    updateRawSearchParams(params);
     showEditComparisonTitleInput(false);
   };
 

--- a/src/components/CompareResults/ResultsMain.tsx
+++ b/src/components/CompareResults/ResultsMain.tsx
@@ -24,6 +24,7 @@ import { Colors, FontsRaw, FontSizeRaw, Spacing } from '../../styles';
 import pencilDark from '../../theme/img/pencil-dark.svg';
 import pencil from '../../theme/img/pencil.svg';
 import type { TestVersion } from '../../types/types';
+import { currentUrlParams } from '../../utils/tableStatePersistence';
 import EditTitleInput from '../CompareResults/EditTitleInput';
 import ToggleReplicatesButton from '../Shared/ToggleReplicatesButton';
 
@@ -121,8 +122,11 @@ function ResultsMain() {
   };
 
   const onSaveButtonClick = () => {
-    rawSearchParams.set('title', comparisonTitleName);
-    updateRawSearchParams(rawSearchParams);
+    // Build from the live URL so we don't drop params written out-of-band
+    // (e.g. the `initialized` marker and cookie-seeded filter/sort).
+    const params = currentUrlParams();
+    params.set('title', comparisonTitleName);
+    updateRawSearchParams(params);
     showEditComparisonTitleInput(false);
   };
 

--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -11,6 +11,7 @@ import TableContent from './TableContent';
 import TableHeader from './TableHeader';
 import { MANN_WHITNEY_U } from '../../common/constants';
 import useAdvancedColumns from '../../hooks/useAdvancedColumns';
+import useInitializeTableStateFromCookies from '../../hooks/useInitializeTableStateFromCookies';
 import useRawSearchParams from '../../hooks/useRawSearchParams';
 import useSeedAdvancedColumnsFromUrl from '../../hooks/useSeedAdvancedColumnsFromUrl';
 import useTableFilters from '../../hooks/useTableFilters';
@@ -49,6 +50,10 @@ export default function ResultsTable() {
       ),
     [testVersion, advancedColumns],
   );
+
+  // On a fresh (uninitialized) URL, seed filter/sort from cookies into the URL
+  // and mark it initialized, so shared links reproduce the same view.
+  useInitializeTableStateFromCookies(columnsConfig);
 
   // This is our custom hook that manages table filters
   // and provides methods for clearing and toggling them.

--- a/src/components/CompareResults/ResultsTable.tsx
+++ b/src/components/CompareResults/ResultsTable.tsx
@@ -21,6 +21,7 @@ import {
   getColumnsConfiguration,
   toGridTemplateColumns,
 } from '../../utils/rowTemplateColumns';
+import { currentUrlParams } from '../../utils/tableStatePersistence';
 
 type CombinedLoaderReturnValue = LoaderReturnValue | OverTimeLoaderReturnValue;
 export default function ResultsTable() {
@@ -33,7 +34,7 @@ export default function ResultsTable() {
     testVersion,
   } = useLoaderData<CombinedLoaderReturnValue>();
 
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [, setSearchParams] = useSearchParams();
 
   // This is our custom hook that updates the search params without a rerender.
   const [rawSearchParams, updateRawSearchParams] = useRawSearchParams();
@@ -70,29 +71,36 @@ export default function ResultsTable() {
   );
   const [expandAll, setExpandAll] = useState(false);
 
+  // These writers build from the *live* URL (currentUrlParams) rather than a
+  // render-time snapshot, so they preserve params written out-of-band — most
+  // importantly the `initialized` marker and cookie-seeded filter/sort — that a
+  // stale snapshot would drop (see useRawSearchParams / tableStatePersistence).
   const onFrameworkChange = (newFrameworkId: Framework['id']) => {
     setFrameworkIdVal(newFrameworkId);
-    searchParams.set('framework', newFrameworkId.toString());
-    setSearchParams(searchParams);
+    const params = currentUrlParams();
+    params.set('framework', newFrameworkId.toString());
+    setSearchParams(params);
   };
 
   const onSearchTermChange = (newSearchTerm: string) => {
     setSearchTerm(newSearchTerm);
+    const params = currentUrlParams();
     if (newSearchTerm) {
-      rawSearchParams.set('search', newSearchTerm);
+      params.set('search', newSearchTerm);
     } else {
-      rawSearchParams.delete('search');
+      params.delete('search');
     }
-    updateRawSearchParams(rawSearchParams);
+    updateRawSearchParams(params);
   };
 
   const onTestVersionChange = (testVersion: TestVersion): void => {
     setTestVersionVal(testVersion);
-    searchParams.set('test_version', testVersion);
+    const params = currentUrlParams();
+    params.set('test_version', testVersion);
     if (testVersion !== MANN_WHITNEY_U) {
-      searchParams.delete('replicates');
+      params.delete('replicates');
     }
-    setSearchParams(searchParams);
+    setSearchParams(params);
   };
 
   const rowGridTemplateColumns = toGridTemplateColumns(columnsConfig);

--- a/src/components/CompareResults/SubtestsResults/SubtestsResultsMain.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsResultsMain.tsx
@@ -29,6 +29,7 @@ import type {
   CompareResultsItem,
   SubtestsRevisionsHeader,
 } from '../../../types/state';
+import { currentUrlParams } from '../../../utils/tableStatePersistence';
 import ToggleReplicatesButton from '../../Shared/ToggleReplicatesButton';
 import {
   RetriggerButton,
@@ -141,12 +142,17 @@ function SubtestsResultsMain({ view }: SubtestsResultsMainProps) {
 
   const onSearchTermChange = (newSearchTerm: string) => {
     setSearchTerm(newSearchTerm);
+    // Build from the live URL (not the memoized rawSearchParams snapshot) so we
+    // don't clobber params written out-of-band after mount — the `initialized`
+    // marker and cookie-seeded filter/sort that let a shared URL supersede the
+    // recipient's cookies (see useRawSearchParams / tableStatePersistence).
+    const params = currentUrlParams();
     if (newSearchTerm) {
-      rawSearchParams.set('search', newSearchTerm);
+      params.set('search', newSearchTerm);
     } else {
-      rawSearchParams.delete('search');
+      params.delete('search');
     }
-    updateRawSearchParams(rawSearchParams);
+    updateRawSearchParams(params);
   };
 
   return (

--- a/src/components/CompareResults/SubtestsResults/SubtestsResultsTable.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsResultsTable.tsx
@@ -9,6 +9,7 @@ import NoResultsFound from '.././NoResultsFound';
 import TableHeader from '.././TableHeader';
 import { STUDENT_T } from '../../../common/constants';
 import useAdvancedColumns from '../../../hooks/useAdvancedColumns';
+import useInitializeTableStateFromCookies from '../../../hooks/useInitializeTableStateFromCookies';
 import useSeedAdvancedColumnsFromUrl from '../../../hooks/useSeedAdvancedColumnsFromUrl';
 import useTableFilters, { filterResults } from '../../../hooks/useTableFilters';
 import useTableSort, { sortResults } from '../../../hooks/useTableSort';
@@ -88,6 +89,11 @@ function SubtestsResultsTable({
       getColumnsConfiguration(true, testVersion ?? STUDENT_T, advancedColumns),
     [testVersion, advancedColumns],
   );
+
+  // On a fresh (uninitialized) URL, seed filter/sort from cookies into the URL
+  // and mark it initialized, so shared links reproduce the same view.
+  useInitializeTableStateFromCookies(columnsConfiguration);
+
   // This is our custom hook that manages table filters
   // and provides methods for clearing and toggling them.
   const { tableFilters, onClearFilter, onToggleFilter } =

--- a/src/hooks/useInitializeTableStateFromCookies.ts
+++ b/src/hooks/useInitializeTableStateFromCookies.ts
@@ -1,0 +1,74 @@
+import { useEffect } from 'react';
+
+import useRawSearchParams from './useRawSearchParams';
+import type {
+  CompareResultsTableConfig,
+  CompareMannWhitneyResultsTableConfig,
+} from '../types/types';
+import { getCookie } from '../utils/cookies';
+import {
+  INITIALIZED_PARAM,
+  SORT_PARAM,
+  SORT_COOKIE,
+  filterParam,
+  filterCookie,
+  isTableStateInitialized,
+  currentUrlParams,
+} from '../utils/tableStatePersistence';
+
+// On the first load of an *uninitialized* results URL (e.g. arriving from the
+// search form), copy the remembered filter/sort cookies into the URL and stamp
+// it as initialized. From then on the URL fully describes the view, so sharing
+// it reproduces the same result for everyone — the recipient's cookies are
+// ignored because the URL is initialized (see useTableFilters/useTableSort).
+//
+// This runs exactly once and only mutates the URL via history.replaceState
+// (through useRawSearchParams), so it never triggers a re-render or a loader
+// refetch. It intentionally has no effect on an already-initialized URL.
+const useInitializeTableStateFromCookies = (
+  columnsConfiguration:
+    | CompareResultsTableConfig
+    | CompareMannWhitneyResultsTableConfig,
+) => {
+  const [, updateRawSearchParams] = useRawSearchParams();
+
+  useEffect(() => {
+    if (isTableStateInitialized(window.location.search)) {
+      return;
+    }
+
+    const params = currentUrlParams();
+
+    // Only seed a value from a cookie when the URL doesn't already specify it,
+    // so an explicit URL param always wins over the cookie.
+    for (const column of columnsConfiguration) {
+      if (!('filter' in column)) {
+        continue;
+      }
+      const param = filterParam(column.key);
+      if (!params.has(param)) {
+        const cookieValue = getCookie(filterCookie(column.key));
+        if (cookieValue) {
+          params.set(param, cookieValue);
+        }
+      }
+    }
+
+    if (!params.has(SORT_PARAM)) {
+      const sortCookie = getCookie(SORT_COOKIE);
+      if (sortCookie) {
+        params.set(SORT_PARAM, sortCookie);
+      }
+    }
+
+    // Stamp the marker even when there were no cookies, so a filter-free view
+    // is still "initialized" and can't pick up cookies on this or another
+    // browser later.
+    params.set(INITIALIZED_PARAM, '1');
+    updateRawSearchParams(params);
+    // Mount-only: the URL is materialised once and the data hooks have already
+    // seeded their state from the same cookies during the first render.
+  }, []);
+};
+
+export default useInitializeTableStateFromCookies;

--- a/src/hooks/useTableFilters.ts
+++ b/src/hooks/useTableFilters.ts
@@ -12,6 +12,12 @@ import type {
   CompareMannWhitneyResultsTableColumn,
 } from '../types/types';
 import { getCookie, setCookie, deleteCookie } from '../utils/cookies';
+import {
+  filterParam,
+  filterCookie,
+  isTableStateInitialized,
+  currentUrlParams,
+} from '../utils/tableStatePersistence';
 
 // This hook handles the state that handles table filtering, and also takes care
 // of handling the URL parameters that mirror this state.
@@ -65,6 +71,10 @@ const useTableFilters = (
 
   // This function collects the table filters from the search params. It will
   // only be called once at mount time.
+  // Cookies are only consulted for an uninitialized URL; an initialized URL is
+  // the single source of truth so a shared link reproduces the same view.
+  const initialized = isTableStateInitialized(window.location.search);
+
   const getInitialTableFilters = () => {
     const result: Map<string, Set<string>> = new Map();
     for (const columnConfiguration of columnsConfiguration) {
@@ -75,8 +85,8 @@ const useTableFilters = (
       const { key: columnKey, possibleValues } = columnConfiguration;
 
       const paramValue =
-        rawSearchParams.get('filter_' + columnKey) ??
-        getCookie('perfcompare_filter_' + columnKey);
+        rawSearchParams.get(filterParam(columnKey)) ??
+        (initialized ? null : getCookie(filterCookie(columnKey)));
       if (paramValue) {
         const configuredValuesSet = new Set(
           paramValue.split(',').map((item) => item.trim()),
@@ -101,9 +111,10 @@ const useTableFilters = (
   const [tableFilters, setTableFilters] = useState(getInitialTableFilters);
 
   const onClearFilter = (columnId: string) => {
-    rawSearchParams.delete(`filter_${columnId}`);
-    updateRawSearchParams(rawSearchParams);
-    deleteCookie(`perfcompare_filter_${columnId}`);
+    const params = currentUrlParams();
+    params.delete(filterParam(columnId));
+    updateRawSearchParams(params);
+    deleteCookie(filterCookie(columnId));
 
     setTableFilters((oldFilters) => {
       const newFilters = new Map(oldFilters);
@@ -123,14 +134,15 @@ const useTableFilters = (
       return;
     }
 
+    const params = currentUrlParams();
     if (filters.size < columnConfiguration.possibleValues.length) {
-      rawSearchParams.set(`filter_${columnId}`, [...filters].join(','));
-      setCookie(`perfcompare_filter_${columnId}`, [...filters].join(','));
+      params.set(filterParam(columnId), [...filters].join(','));
+      setCookie(filterCookie(columnId), [...filters].join(','));
     } else {
-      rawSearchParams.delete(`filter_${columnId}`);
-      deleteCookie(`perfcompare_filter_${columnId}`);
+      params.delete(filterParam(columnId));
+      deleteCookie(filterCookie(columnId));
     }
-    updateRawSearchParams(rawSearchParams);
+    updateRawSearchParams(params);
 
     setTableFilters((oldFilters) => {
       const newFilters = new Map(oldFilters);

--- a/src/hooks/useTableSort.ts
+++ b/src/hooks/useTableSort.ts
@@ -8,6 +8,12 @@ import type {
   SortFunc,
 } from '../types/types';
 import { getCookie, setCookie, deleteCookie } from '../utils/cookies';
+import {
+  SORT_PARAM,
+  SORT_COOKIE,
+  isTableStateInitialized,
+  currentUrlParams,
+} from '../utils/tableStatePersistence';
 
 // This hook handles the state that handles table sorting, and also takes care
 // of handling the URL parameters that mirror this state.
@@ -25,8 +31,13 @@ const useTableSort = (
   // This is our custom hook that updates the search params without a rerender.
   const [rawSearchParams, updateRawSearchParams] = useRawSearchParams();
 
+  // Cookies are only consulted for an uninitialized URL; an initialized URL is
+  // the single source of truth so a shared link reproduces the same view.
+  const initialized = isTableStateInitialized(window.location.search);
   const sortFromUrl =
-    rawSearchParams.get('sort') ?? getCookie('perfcompare_sort') ?? '';
+    rawSearchParams.get(SORT_PARAM) ??
+    (initialized ? null : getCookie(SORT_COOKIE)) ??
+    '';
   const [columnId, direction] = useMemo(() => {
     const [columnId, direction] = sortFromUrl.split('|');
     if (!columnId) {
@@ -57,18 +68,19 @@ const useTableSort = (
     columnId: string,
     newSortDirection: 'asc' | 'desc' | null,
   ) => {
+    const params = currentUrlParams();
     if (newSortDirection === null) {
       setSortColumn(null);
       setSortDirection(null);
-      rawSearchParams.delete('sort');
-      deleteCookie('perfcompare_sort');
+      params.delete(SORT_PARAM);
+      deleteCookie(SORT_COOKIE);
     } else {
       setSortColumn(columnId);
       setSortDirection(newSortDirection);
-      rawSearchParams.set('sort', columnId + '|' + newSortDirection);
-      setCookie('perfcompare_sort', columnId + '|' + newSortDirection);
+      params.set(SORT_PARAM, columnId + '|' + newSortDirection);
+      setCookie(SORT_COOKIE, columnId + '|' + newSortDirection);
     }
-    updateRawSearchParams(rawSearchParams);
+    updateRawSearchParams(params);
   };
 
   return { sortDirection, sortColumn, onToggleSort };

--- a/src/utils/tableStatePersistence.ts
+++ b/src/utils/tableStatePersistence.ts
@@ -1,0 +1,39 @@
+// Central definitions for how the results table's filter/sort state is
+// persisted, so the query-param and cookie keys live in exactly one place.
+//
+// The state lives in two layers:
+// * the URL (`filter_<col>`, `sort`) — the shareable source of truth;
+// * cookies (`perfcompare_filter_<col>`, `perfcompare_sort`) — a per-browser
+//   memory of the last-used values.
+//
+// A URL is considered "initialized" once the app has materialised the table
+// state into it (marker below). Cookies are only ever *read* for an
+// *uninitialized* URL; an initialized URL is the single source of truth, so a
+// shared link reproduces the same view for everyone regardless of their
+// cookies. Cookies are still *written* on every change, so the memory survives
+// for the next fresh visit.
+
+// Marker that flags a URL as "initialized" (see above).
+export const INITIALIZED_PARAM = 'initialized';
+
+// URL query-parameter keys.
+export const SORT_PARAM = 'sort';
+export const filterParam = (columnKey: string) => `filter_${columnKey}`;
+
+// Cookie keys.
+export const SORT_COOKIE = 'perfcompare_sort';
+export const filterCookie = (columnKey: string) =>
+  `perfcompare_filter_${columnKey}`;
+
+// Whether the URL already carries the initialized marker.
+export function isTableStateInitialized(search: string): boolean {
+  return new URLSearchParams(search).has(INITIALIZED_PARAM);
+}
+
+// Read the *live* URL params. Writes must start from this rather than a
+// memoized snapshot, otherwise params added out-of-band (e.g. the initialized
+// marker, seeded once on mount) would be clobbered by a later filter/sort
+// change.
+export function currentUrlParams(): URLSearchParams {
+  return new URLSearchParams(window.location.search);
+}


### PR DESCRIPTION
[Bug 2058240](https://bugzilla.mozilla.org/show_bug.cgi?id=2058240)

[Deploy Link](https://deploy-preview-1076--mozilla-perfcompare.netlify.app/compare-results?baseRev=f4adac7285060421005f0c3e730b43d5fc7eaaa2&baseRepo=try&newRev=ec8c1e75812cf175d8a10b63974cf7b7c5f4588b&newRepo=try&framework=13&advanced_columns=cliffs_delta&initialized=1)

Filters and sort were persisted to both the URL and cookies, and read as `urlParam ?? cookie` per column. So opening a shared link fell back to the recipient's own cookies for any column/sort not spelled out in the URL — the same URL showed different results for different people.

Introduce an explicit "initialized" URL marker:

- On the first load of an uninitialized URL, seed the remembered filter/sort cookies into the URL and stamp it `initialized=1` (via `replaceState`, so no rerender or loader refetch).

- Once initialized, filters/sort are read only from the URL — a missing param means the default, never a cookie. Cookies are still written on change so the memory survives for the next fresh visit.

Also read the live URL params when writing filter/sort changes, instead of a memoized snapshot, so an out-of-band param (the seeded marker) isn't clobbered and dropped by a later toggle.

Centralize the query-param/cookie keys and the marker helpers in `tableStatePersistence.ts`. Add tests covering: a fresh URL seeds from cookies and gains the marker, an initialized URL ignores cookies, and the marker survives a filter toggle.

Co-Authored-By: Claude Opus 4.8