### PR TITLE
Fix for Bug 2060613: PerfCompare statistical analysis has some NaN values in explanations

### DIFF
--- a/src/__tests__/bootstrapCi.test.ts
+++ b/src/__tests__/bootstrapCi.test.ts
@@ -1,0 +1,32 @@
+import { bootstrapMedianDiffCI } from '../utils/bootstrap-ci';
+
+describe('bootstrapMedianDiffCI', () => {
+  it('returns null when either group has fewer than 2 observations', () => {
+    // A single run per side (common for some subtests) has no resampling
+    // variability and the BCa jackknife is undefined — must not yield NaNs.
+    expect(bootstrapMedianDiffCI([8.53], [8.73])).toBeNull();
+    expect(bootstrapMedianDiffCI([], [1, 2, 3])).toBeNull();
+    expect(bootstrapMedianDiffCI([1, 2, 3], [])).toBeNull();
+    expect(bootstrapMedianDiffCI([5], [6])).toBeNull();
+  });
+
+  it('returns a finite interval bracketing the observed difference', () => {
+    const base = [100, 102, 98, 101, 99, 103, 97, 100, 101, 99];
+    const newData = [106, 108, 104, 107, 105, 109, 103, 106, 107, 105];
+    const ci = bootstrapMedianDiffCI(base, newData);
+    expect(ci).not.toBeNull();
+    const { medianDiff, ciLow, ciHigh } = ci!;
+    expect(Number.isFinite(ciLow)).toBe(true);
+    expect(Number.isFinite(ciHigh)).toBe(true);
+    expect(ciLow).toBeLessThanOrEqual(medianDiff);
+    expect(ciHigh).toBeGreaterThanOrEqual(medianDiff);
+  });
+
+  it('is deterministic for a fixed seed', () => {
+    const base = [10, 12, 11, 13, 9, 14, 10, 11];
+    const newData = [14, 16, 15, 17, 13, 18, 14, 15];
+    expect(bootstrapMedianDiffCI(base, newData)).toEqual(
+      bootstrapMedianDiffCI(base, newData),
+    );
+  });
+});

--- a/src/common/testVersions/mannWhitney.tsx
+++ b/src/common/testVersions/mannWhitney.tsx
@@ -405,8 +405,10 @@ export const mannWhitneyStrategy = {
 
     const baseRuns = mwResult.base_runs ?? [];
     const newRuns = mwResult.new_runs ?? [];
+    // A BCa CI needs at least 2 runs per side (see bootstrapMedianDiffCI);
+    // with fewer it returns null and we render no interval rather than NaNs.
     const ci =
-      baseRuns.length > 0 && newRuns.length > 0
+      baseRuns.length >= 2 && newRuns.length >= 2
         ? bootstrapMedianDiffCI(baseRuns, newRuns)
         : null;
     const rawUnit =

--- a/src/utils/bootstrap-ci.ts
+++ b/src/utils/bootstrap-ci.ts
@@ -136,6 +136,12 @@ export type BootstrapCI = {
  *   - Skewness: the interval may need to be asymmetric (a, the acceleration,
  *     estimated via leave-one-out jackknife).
  *
+ * Returns null when either group has fewer than 2 observations: BCa relies on
+ * a leave-one-out jackknife for the acceleration term, which is undefined for a
+ * single observation (leaving it out yields an empty sample), and a one-point
+ * sample carries no resampling variability to form an interval from.
+ *
+ *
  * @param base    - baseline sample values
  * @param newData - new/comparison sample values
  * @param nIter   - bootstrap resamples; 9999 is standard for BCa
@@ -148,7 +154,9 @@ export function bootstrapMedianDiffCI(
   nIter: number = 9999,
   alpha: number = 0.05,
   seed: number = 42,
-): BootstrapCI {
+): BootstrapCI | null {
+  if (base.length < 2 || newData.length < 2) return null;
+
   const rng = mulberry32(seed);
   const baseArr = new Float64Array(base);
   const newArr = new Float64Array(newData);


### PR DESCRIPTION
[Bug 2060613](https://bugzilla.mozilla.org/show_bug.cgi?id=2060613)
[
Deploy preview](https://deploy-preview-1077--mozilla-perfcompare.netlify.app/subtests-compare-results?baseRev=c0493b7512ec2b670eb392e1b1dcd4ca8f1462f1&baseRepo=autoland&newRev=97e167a2a1d5dbc5ece634cb665bfc3ff7d0ba79&newRepo=autoland&framework=1&baseParentSignature=301082&newParentSignature=301082&test_version=mann-whitney-u)

Implemented @padenot 's fix from [draft PR:](https://github.com/mozilla/perfcompare/pull/1065/changes/c9e7815429adcecb4f52b01e95db25679dd9c18e#diff-711876f5d63bb6d8fdab6fb6416637d09cc82673af28e9272ae12b979eb45df7)

BCa's acceleration uses a leave-one-out jackknife, which is undefined for a single observation (leaving it out gives an empty sample). A subtest with one run per side therefore produced a [NaN, NaN] median-difference interval. Return null below two runs per group and omit the interval in the Mann-Whitney blurb. Adds a regression test.