### PR TITLE
Bug-2063430: Add a profile comparison dialog for speedometer3 results

### DIFF
--- a/src/__tests__/CompareResults/ProfileCompare.test.tsx
+++ b/src/__tests__/CompareResults/ProfileCompare.test.tsx
@@ -1,0 +1,165 @@
+import fetchMock from '@fetch-mock/jest';
+import userEvent from '@testing-library/user-event';
+
+import { ProfileCompareButton } from '../../components/CompareResults/ProfileCompare/ProfileCompareButton';
+import type { CompareResultsItem } from '../../types/state';
+import getTestData from '../utils/fixtures';
+import { render, screen, waitFor, within } from '../utils/test-utils';
+
+// A minimal speedometer3 row derived from an existing fixture. We only need
+// the fields that ProfileCompareButton / Dialog reads.
+function makeSpeedometer3Row(
+  overrides: Partial<CompareResultsItem> = {},
+): CompareResultsItem {
+  const base = getTestData().testCompareData[0];
+  return {
+    ...base,
+    suite: 'speedometer3',
+    header_name: 'browsertime speedometer3 opt',
+    base_repository_name: 'try',
+    new_repository_name: 'try',
+    base_rev: 'b45e818c8db40353dae549cd7235c8210c58802b',
+    new_rev: 'f00ba7f00ba7f00ba7f00ba7f00ba7f00ba7f00b',
+    base_retriggerable_job_ids: [111, 222],
+    new_retriggerable_job_ids: [333, 444],
+    base_runs: [412.3, 415.8],
+    new_runs: [425.5, 431.7],
+    ...overrides,
+  };
+}
+
+function mockJobInfo(repo: string, jobId: number, taskId: string, retryId = 0) {
+  fetchMock.get(
+    `begin:https://treeherder.mozilla.org/api/project/${repo}/jobs/${jobId}/`,
+    { taskcluster_metadata: { task_id: taskId, retry_id: retryId } },
+  );
+}
+
+function mockArtifacts(taskId: string, runId: number, names: string[]) {
+  fetchMock.get(
+    `https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/${taskId}/runs/${runId}/artifacts`,
+    { artifacts: names.map((name) => ({ name })) },
+  );
+}
+
+function mockTaskStatus(taskId: string, workerId: string, runId = 0) {
+  fetchMock.get(
+    `https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/${taskId}/status`,
+    // Wrap in `body` so fetch-mock doesn't interpret the response's top-level
+    // `status` key as an HTTP status code.
+    { body: { status: { runs: [{ runId, state: 'completed', workerId }] } } },
+  );
+}
+
+describe('ProfileCompareButton', () => {
+  afterEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('shows runs with worker IDs, sorted by score, with the median preselected', async () => {
+    // Base has three profiled runs (out-of-order scores) so we can verify
+    // both sort-by-score and median preselection. New has two profiled runs
+    // (one job with no profile is filtered out).
+    const row = makeSpeedometer3Row({
+      base_retriggerable_job_ids: [111, 222, 555],
+      new_retriggerable_job_ids: [333, 444],
+      base_runs: [415.8, 412.3, 418.2],
+      new_runs: [425.5, 431.7],
+    });
+
+    mockJobInfo('try', 111, 'TASKBASE1');
+    mockJobInfo('try', 222, 'TASKBASE2');
+    mockJobInfo('try', 555, 'TASKBASE3');
+    mockJobInfo('try', 333, 'TASKNEW1');
+    mockJobInfo('try', 444, 'TASKNEW2');
+
+    const profile = 'public/test_info/profile_speedometer3_compact.jslb.gz';
+    mockArtifacts('TASKBASE1', 0, [profile, 'public/logs/live.log']);
+    mockArtifacts('TASKBASE2', 0, [profile]);
+    mockArtifacts('TASKBASE3', 0, [profile]);
+    mockArtifacts('TASKNEW1', 0, [profile]);
+    // No profile on this run — should be filtered out.
+    mockArtifacts('TASKNEW2', 0, ['public/logs/live.log']);
+
+    mockTaskStatus('TASKBASE1', 'worker-b1');
+    mockTaskStatus('TASKBASE2', 'worker-b2');
+    mockTaskStatus('TASKBASE3', 'worker-b3');
+    mockTaskStatus('TASKNEW1', 'worker-n1');
+    mockTaskStatus('TASKNEW2', 'worker-n2');
+
+    render(<ProfileCompareButton result={row} />);
+
+    const openButton = await screen.findByTitle(
+      'open profile comparison for this result',
+    );
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await user.click(openButton);
+
+    const dialog = await screen.findByRole('dialog');
+    // Wait for the dialog to be populated.
+    await waitFor(() =>
+      expect(
+        within(dialog).getByText(/Run 1.*score.*412\.3/),
+      ).toBeInTheDocument(),
+    );
+
+    // Base runs should appear sorted by score ascending:
+    // 412.3 (worker-b2), 415.8 (worker-b1), 418.2 (worker-b3).
+    // New runs should appear sorted: 425.5 (worker-n1), 431.7 — actually
+    // the only profiled new runs are TASKNEW1 (425.5). TASKNEW2 has no
+    // profile artifact so isn't shown.
+    const allLabels = within(dialog).getAllByText(/Run \d.*score/);
+    // 3 base + 1 new = 4
+    expect(allLabels).toHaveLength(4);
+
+    // Worker IDs should be visible.
+    expect(within(dialog).getByText(/worker-b2/)).toBeInTheDocument();
+    expect(within(dialog).getByText(/worker-n1/)).toBeInTheDocument();
+
+    // Median of base is index 1 (415.8, worker-b1). Only one new run so
+    // that's preselected. The compare button should be enabled immediately.
+    const activeCompareBtn = within(dialog).getByRole('link', {
+      name: 'Open profile comparison',
+    });
+    expect(activeCompareBtn).toHaveAttribute(
+      'href',
+      expect.stringContaining('TASKBASE1'),
+    );
+    expect(activeCompareBtn).toHaveAttribute(
+      'href',
+      expect.stringContaining('TASKNEW1'),
+    );
+  });
+
+  it('shows an empty-state message when no runs have profile artifacts', async () => {
+    mockJobInfo('try', 111, 'TASKBASE1');
+    mockJobInfo('try', 222, 'TASKBASE2');
+    mockJobInfo('try', 333, 'TASKNEW1');
+    mockJobInfo('try', 444, 'TASKNEW2');
+
+    mockArtifacts('TASKBASE1', 0, ['public/logs/live.log']);
+    mockArtifacts('TASKBASE2', 0, ['public/logs/live.log']);
+    mockArtifacts('TASKNEW1', 0, ['public/logs/live.log']);
+    mockArtifacts('TASKNEW2', 0, ['public/logs/live.log']);
+
+    mockTaskStatus('TASKBASE1', 'worker-b1');
+    mockTaskStatus('TASKBASE2', 'worker-b2');
+    mockTaskStatus('TASKNEW1', 'worker-n1');
+    mockTaskStatus('TASKNEW2', 'worker-n2');
+
+    render(<ProfileCompareButton result={makeSpeedometer3Row()} />);
+
+    const openButton = await screen.findByTitle(
+      'open profile comparison for this result',
+    );
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await user.click(openButton);
+
+    const dialog = await screen.findByRole('dialog');
+    const emptyMessages = await within(dialog).findAllByText(
+      'No profile artifacts found.',
+    );
+    // Both sides show the empty message.
+    expect(emptyMessages).toHaveLength(2);
+  });
+});

--- a/src/__tests__/CompareResults/ProfileCompareUrls.test.ts
+++ b/src/__tests__/CompareResults/ProfileCompareUrls.test.ts
@@ -1,0 +1,41 @@
+import {
+  buildCompareBenchmarkUrl,
+  buildSingleProfileUrl,
+  buildTaskArtifactUrl,
+  SPEEDOMETER3_PROFILE_ARTIFACT,
+} from '../../components/CompareResults/ProfileCompare/urls';
+
+describe('ProfileCompare url helpers', () => {
+  it('builds a Taskcluster artifact URL', () => {
+    expect(
+      buildTaskArtifactUrl(
+        'eSFQ0OC9R665QYfdgtWgKA',
+        0,
+        SPEEDOMETER3_PROFILE_ARTIFACT,
+      ),
+    ).toBe(
+      'https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/eSFQ0OC9R665QYfdgtWgKA/runs/0/artifacts/public/test_info/profile_speedometer3_compact.jslb.gz',
+    );
+  });
+
+  it('builds a single-profile URL that decodes to the raw artifact URL', () => {
+    const url = buildSingleProfileUrl('eSFQ0OC9R665QYfdgtWgKA', 0);
+    expect(url).toBe(
+      'https://profiler.firefox.com/from-url/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FeSFQ0OC9R665QYfdgtWgKA%2Fruns%2F0%2Fartifacts%2Fpublic%2Ftest_info%2Fprofile_speedometer3_compact.jslb.gz',
+    );
+  });
+
+  it('builds a compare-benchmark URL with both profiles', () => {
+    const base = buildSingleProfileUrl('CVdpkviXTEyAJH37VBMTGQ', 0);
+    const cmp = buildSingleProfileUrl('IUYZmFShTXSjbSgQqRQ0JQ', 0);
+    const url = buildCompareBenchmarkUrl(base, cmp);
+    // The `profiles[]` parameter should appear twice and the inner URLs
+    // should be double-encoded (the outer URLSearchParams encoding wrapping
+    // the from-url URL, which itself contains an encoded task artifact URL).
+    expect(url).toBe(
+      'https://deploy-preview-6012--perf-html.netlify.app/compare-benchmark/?' +
+        'profiles%5B%5D=https%3A%2F%2Fprofiler.firefox.com%2Ffrom-url%2Fhttps%253A%252F%252Ffirefox-ci-tc.services.mozilla.com%252Fapi%252Fqueue%252Fv1%252Ftask%252FCVdpkviXTEyAJH37VBMTGQ%252Fruns%252F0%252Fartifacts%252Fpublic%252Ftest_info%252Fprofile_speedometer3_compact.jslb.gz' +
+        '&profiles%5B%5D=https%3A%2F%2Fprofiler.firefox.com%2Ffrom-url%2Fhttps%253A%252F%252Ffirefox-ci-tc.services.mozilla.com%252Fapi%252Fqueue%252Fv1%252Ftask%252FIUYZmFShTXSjbSgQqRQ0JQ%252Fruns%252F0%252Fartifacts%252Fpublic%252Ftest_info%252Fprofile_speedometer3_compact.jslb.gz',
+    );
+  });
+});

--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -346,7 +346,7 @@ exports[`Results View The table should match snapshot and other elements should 
       </div>
     </div>
     <div
-      class="fdtnfac f1l733lh"
+      class="ftvoz88 f1l733lh"
       data-testid="table-header"
       role="row"
     >
@@ -742,7 +742,7 @@ exports[`Results View The table should match snapshot and other elements should 
               class="revision-block fw0pvlu"
             >
               <div
-                class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
+                class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1v96cc6"
                 role="row"
               >
                 <div
@@ -940,7 +940,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
+                class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1v96cc6"
                 role="row"
               >
                 <div
@@ -1139,7 +1139,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
+                class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1v96cc6"
                 role="row"
               >
                 <div
@@ -1338,7 +1338,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
+                class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1v96cc6"
                 role="row"
               >
                 <div

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -1319,7 +1319,7 @@ exports[`Results Table Should match snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="fdtnfac f1l733lh"
+                  class="ftvoz88 f1l733lh"
                   data-testid="table-header"
                   role="row"
                 >
@@ -1715,7 +1715,7 @@ exports[`Results Table Should match snapshot 1`] = `
                           class="revision-block fw0pvlu"
                         >
                           <div
-                            class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
+                            class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1v96cc6"
                             role="row"
                           >
                             <div
@@ -1913,7 +1913,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </div>
                           </div>
                           <div
-                            class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
+                            class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1v96cc6"
                             role="row"
                           >
                             <div
@@ -2112,7 +2112,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </div>
                           </div>
                           <div
-                            class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
+                            class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1v96cc6"
                             role="row"
                           >
                             <div
@@ -2398,7 +2398,7 @@ exports[`Results Table Should match snapshot 1`] = `
                           class="revision-block fw0pvlu"
                         >
                           <div
-                            class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
+                            class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1v96cc6"
                             role="row"
                           >
                             <div
@@ -4202,7 +4202,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                   </div>
                 </div>
                 <div
-                  class="fdtnfac f1l733lh"
+                  class="ftvoz88 f1l733lh"
                   data-testid="table-header"
                   role="row"
                 >
@@ -4598,7 +4598,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                           class="revision-block fw0pvlu"
                         >
                           <div
-                            class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
+                            class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1v96cc6"
                             role="row"
                           >
                             <div
@@ -4809,7 +4809,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                             </div>
                           </div>
                           <div
-                            class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
+                            class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1v96cc6"
                             role="row"
                           >
                             <div
@@ -5021,7 +5021,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                             </div>
                           </div>
                           <div
-                            class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
+                            class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1v96cc6"
                             role="row"
                           >
                             <div
@@ -5320,7 +5320,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                           class="revision-block fw0pvlu"
                         >
                           <div
-                            class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
+                            class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1v96cc6"
                             role="row"
                           >
                             <div
@@ -6135,7 +6135,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
       </span>
     </div>
     <div
-      class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
+      class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1v96cc6"
       role="row"
     >
       <div
@@ -6386,7 +6386,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
       </span>
     </div>
     <div
-      class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
+      class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1v96cc6"
       role="row"
     >
       <div
@@ -6700,7 +6700,7 @@ exports[`Results Table should render different blocks when rendering several rev
       </span>
     </div>
     <div
-      class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1auw4i3"
+      class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-5lef8y"
       role="row"
     >
       <div
@@ -6946,7 +6946,7 @@ exports[`Results Table should render different blocks when rendering several rev
       </span>
     </div>
     <div
-      class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1auw4i3"
+      class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-5lef8y"
       role="row"
     >
       <div

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -1501,7 +1501,7 @@ exports[`Results View The table should match snapshot and other elements should 
       </div>
     </div>
     <div
-      class="fdtnfac f1l733lh"
+      class="ftvoz88 f1l733lh"
       data-testid="table-header"
       role="row"
     >
@@ -1897,7 +1897,7 @@ exports[`Results View The table should match snapshot and other elements should 
               class="revision-block fw0pvlu"
             >
               <div
-                class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
+                class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1v96cc6"
                 role="row"
               >
                 <div
@@ -2095,7 +2095,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
+                class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1v96cc6"
                 role="row"
               >
                 <div
@@ -2294,7 +2294,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
+                class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1v96cc6"
                 role="row"
               >
                 <div
@@ -2493,7 +2493,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1woqe0l"
+                class="revisionRow f1wmgkbg f1dlt78d MuiBox-root css-1v96cc6"
                 role="row"
               >
                 <div

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -840,7 +840,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
               role="table"
             >
               <div
-                class="f1itjsvw f1l733lh"
+                class="fvxdzjf f1l733lh"
                 data-testid="table-header"
                 role="row"
               >
@@ -1112,7 +1112,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 />
               </div>
               <div
-                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1aq9s7l"
                 role="row"
               >
                 <div
@@ -1274,7 +1274,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1aq9s7l"
                 role="row"
               >
                 <div
@@ -1422,7 +1422,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1aq9s7l"
                 role="row"
               >
                 <div
@@ -1570,7 +1570,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1aq9s7l"
                 role="row"
               >
                 <div
@@ -1718,7 +1718,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1aq9s7l"
                 role="row"
               >
                 <div
@@ -2751,7 +2751,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
               role="table"
             >
               <div
-                class="f1itjsvw f1l733lh"
+                class="fvxdzjf f1l733lh"
                 data-testid="table-header"
                 role="row"
               >
@@ -3023,7 +3023,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 />
               </div>
               <div
-                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1aq9s7l"
                 role="row"
               >
                 <div
@@ -3187,7 +3187,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1aq9s7l"
                 role="row"
               >
                 <div
@@ -3363,7 +3363,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1aq9s7l"
                 role="row"
               >
                 <div
@@ -3526,7 +3526,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1aq9s7l"
                 role="row"
               >
                 <div
@@ -3689,7 +3689,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1aq9s7l"
                 role="row"
               >
                 <div
@@ -4353,7 +4353,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
               role="table"
             >
               <div
-                class="f1itjsvw f1l733lh"
+                class="fvxdzjf f1l733lh"
                 data-testid="table-header"
                 role="row"
               >
@@ -4625,7 +4625,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 />
               </div>
               <div
-                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1aq9s7l"
                 role="row"
               >
                 <div
@@ -4789,7 +4789,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1aq9s7l"
                 role="row"
               >
                 <div
@@ -4965,7 +4965,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1aq9s7l"
                 role="row"
               >
                 <div
@@ -5128,7 +5128,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1aq9s7l"
                 role="row"
               >
                 <div
@@ -5291,7 +5291,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1aq9s7l"
                 role="row"
               >
                 <div
@@ -5955,7 +5955,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
               role="table"
             >
               <div
-                class="f1itjsvw f1l733lh"
+                class="fvxdzjf f1l733lh"
                 data-testid="table-header"
                 role="row"
               >
@@ -6227,7 +6227,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                 />
               </div>
               <div
-                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1aq9s7l"
                 role="row"
               >
                 <div
@@ -6391,7 +6391,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                 </div>
               </div>
               <div
-                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1aq9s7l"
                 role="row"
               >
                 <div
@@ -6567,7 +6567,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                 </div>
               </div>
               <div
-                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1aq9s7l"
                 role="row"
               >
                 <div
@@ -6730,7 +6730,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                 </div>
               </div>
               <div
-                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1aq9s7l"
                 role="row"
               >
                 <div
@@ -6893,7 +6893,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                 </div>
               </div>
               <div
-                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1aq9s7l"
                 role="row"
               >
                 <div
@@ -7557,7 +7557,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
               role="table"
             >
               <div
-                class="f1itjsvw f1l733lh"
+                class="fvxdzjf f1l733lh"
                 data-testid="table-header"
                 role="row"
               >
@@ -7829,7 +7829,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 />
               </div>
               <div
-                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1aq9s7l"
                 role="row"
               >
                 <div
@@ -7991,7 +7991,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1aq9s7l"
                 role="row"
               >
                 <div
@@ -8139,7 +8139,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1aq9s7l"
                 role="row"
               >
                 <div
@@ -8287,7 +8287,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1aq9s7l"
                 role="row"
               >
                 <div
@@ -8435,7 +8435,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-185znds"
+                class="revisionRow f146qxgq f1dlt78d MuiBox-root css-1aq9s7l"
                 role="row"
               >
                 <div

--- a/src/common/testVersions/mannWhitney.tsx
+++ b/src/common/testVersions/mannWhitney.tsx
@@ -7,6 +7,7 @@ import Box from '@mui/material/Box';
 
 import { MannWhitneyCompareMetrics } from '../../components/CompareResults/MannWhitneyCompareMetrics';
 import PValCliffsDeltaComp from '../../components/CompareResults/PValCliffsDeltaComp';
+import { rowButtonsGridWidth } from '../../components/CompareResults/rowButtonSlots';
 import { StatisticsWarnings } from '../../components/CompareResults/StatisticsWarnings';
 import { FontSize } from '../../styles';
 import {
@@ -119,8 +120,6 @@ export const mannWhitneyStrategy = {
             return getPlatformShortName(result.platform) === label;
           },
         };
-
-    const colWidthMultiply = isSubtestTable ? 1 : 2.5;
 
     return [
       platformConfig,
@@ -245,7 +244,7 @@ export const mannWhitneyStrategy = {
         gridWidth: '1fr',
         tooltip: tooltipTotalRuns,
       },
-      { key: 'buttons', gridWidth: `calc(${colWidthMultiply} * 34px)` },
+      { key: 'buttons', gridWidth: rowButtonsGridWidth(isSubtestTable) },
       { key: 'expand', gridWidth: '34px' },
     ] as TableConfig;
   },

--- a/src/common/testVersions/studentT.tsx
+++ b/src/common/testVersions/studentT.tsx
@@ -6,6 +6,7 @@ import ThumbUpIcon from '@mui/icons-material/ThumbUp';
 import Box from '@mui/material/Box';
 
 import Distribution from '../../components/CompareResults/Distribution';
+import { rowButtonsGridWidth } from '../../components/CompareResults/rowButtonSlots';
 import { Strings } from '../../resources/Strings';
 import { FontSize } from '../../styles';
 import { CombinedResultsItemType, CompareResultsItem } from '../../types/state';
@@ -63,7 +64,6 @@ export const studentTStrategy = {
           },
         };
 
-    const colWidthMultiply = isSubtestTable ? 1 : 3.5;
     const confidenceGridWidth = isSubtestTable ? '1.8fr' : '1.5fr';
 
     return [
@@ -146,7 +146,7 @@ export const studentTStrategy = {
         gridWidth: '1fr',
         tooltip: tooltipTotalRuns,
       },
-      { key: 'buttons', gridWidth: `calc(${colWidthMultiply} * 34px)` },
+      { key: 'buttons', gridWidth: rowButtonsGridWidth(isSubtestTable) },
       { key: 'expand', gridWidth: '34px' },
     ] as TableConfig;
   },

--- a/src/components/CompareResults/ProfileCompare/ProfileCompareButton.tsx
+++ b/src/components/CompareResults/ProfileCompare/ProfileCompareButton.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+
+import AssessmentIcon from '@mui/icons-material/Assessment';
+import { IconButton } from '@mui/material';
+
+import { ProfileCompareDialog } from './ProfileCompareDialog';
+import { CompareResultsItem } from '../../../types/state';
+
+// Rows for which we support profile comparison. Currently only speedometer3.
+export function supportsProfileCompare(suite: string): boolean {
+  return suite === 'speedometer3';
+}
+
+export function ProfileCompareButton({
+  result,
+}: {
+  result: CompareResultsItem;
+}) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  return (
+    <>
+      <IconButton
+        title='open profile comparison for this result'
+        color='primary'
+        size='small'
+        onClick={() => setDialogOpen(true)}
+      >
+        <AssessmentIcon />
+      </IconButton>
+      <ProfileCompareDialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        result={result}
+      />
+    </>
+  );
+}

--- a/src/components/CompareResults/ProfileCompare/ProfileCompareDialog.tsx
+++ b/src/components/CompareResults/ProfileCompare/ProfileCompareDialog.tsx
@@ -1,0 +1,299 @@
+import { useEffect, useState } from 'react';
+
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  FormControlLabel,
+  IconButton,
+  Link,
+  Radio,
+  RadioGroup,
+  Typography,
+} from '@mui/material';
+
+import {
+  buildCompareBenchmarkUrl,
+  buildSingleProfileUrl,
+  SPEEDOMETER3_PROFILE_ARTIFACT,
+} from './urls';
+import {
+  fetchTaskArtifacts,
+  fetchTaskStatus,
+} from '../../../logic/taskcluster';
+import { fetchJobInformationFromJobId } from '../../../logic/treeherder';
+import { CompareResultsItem } from '../../../types/state';
+import { formatNumber } from '../../../utils/format';
+import { CenteredModal } from '../Retrigger/CenteredModal';
+
+type RunInfo = {
+  jobId: number;
+  taskId: string;
+  runId: number;
+  value: number;
+  workerId?: string;
+};
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'loaded'; base: RunInfo[]; newRuns: RunInfo[] }
+  | { kind: 'error'; message: string };
+
+const TC_ROOT_URL = 'https://firefox-ci-tc.services.mozilla.com';
+
+async function loadRunsWithProfiles(
+  repo: string,
+  jobIds: number[],
+  values: number[],
+): Promise<RunInfo[]> {
+  // Ordering guarantee: values[i] is the score from the job with id jobIds[i].
+  // See treeherder/webapp/api/performance_data.py:_get_grouped_perf_data.
+  const jobInfos = await Promise.all(
+    jobIds.map((jobId) => fetchJobInformationFromJobId(repo, jobId)),
+  );
+  const details = await Promise.all(
+    jobInfos.map(async (jobInfo) => {
+      const { task_id: taskId, retry_id: runId } = jobInfo.taskcluster_metadata;
+      const [artifacts, status] = await Promise.all([
+        fetchTaskArtifacts(TC_ROOT_URL, taskId, runId).catch(() => []),
+        fetchTaskStatus(TC_ROOT_URL, taskId).catch(() => null),
+      ]);
+      return { artifacts, status };
+    }),
+  );
+
+  const runs: RunInfo[] = [];
+  jobInfos.forEach((jobInfo, i) => {
+    const { artifacts, status } = details[i];
+    const hasProfile = artifacts.some(
+      (artifact) => artifact.name === SPEEDOMETER3_PROFILE_ARTIFACT,
+    );
+    if (!hasProfile) return;
+    const { task_id: taskId, retry_id: runId } = jobInfo.taskcluster_metadata;
+    const workerId = status?.runs.find((r) => r.runId === runId)?.workerId;
+    runs.push({
+      jobId: jobIds[i],
+      taskId,
+      runId,
+      value: values[i],
+      workerId,
+    });
+  });
+  runs.sort((a, b) => a.value - b.value);
+  return runs;
+}
+
+function RunList({
+  side,
+  runs,
+  selectedIndex,
+  onSelectedIndexChange,
+}: {
+  side: 'base' | 'new';
+  runs: RunInfo[];
+  selectedIndex: number | null;
+  onSelectedIndexChange: (index: number) => void;
+}) {
+  if (runs.length === 0) {
+    return (
+      <Typography color='text.secondary' sx={{ fontStyle: 'italic', px: 1 }}>
+        No profile artifacts found.
+      </Typography>
+    );
+  }
+  return (
+    <RadioGroup
+      name={`${side}-profile-selection`}
+      value={selectedIndex === null ? '' : String(selectedIndex)}
+      onChange={(e) => onSelectedIndexChange(Number(e.target.value))}
+    >
+      {runs.map((run, index) => (
+        <Box
+          key={run.jobId}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            py: 0.25,
+          }}
+        >
+          <FormControlLabel
+            value={String(index)}
+            control={<Radio size='small' />}
+            label={
+              <Typography component='span' sx={{ whiteSpace: 'nowrap' }}>
+                Run {index + 1} — score {formatNumber(run.value)}
+                {run.workerId && (
+                  <Typography
+                    component='span'
+                    variant='caption'
+                    color='text.secondary'
+                    sx={{ ml: 1 }}
+                  >
+                    ({run.workerId})
+                  </Typography>
+                )}
+              </Typography>
+            }
+            sx={{ flexGrow: 1, m: 0 }}
+          />
+          <IconButton
+            size='small'
+            title='View this profile in profiler.firefox.com'
+            component={Link}
+            href={buildSingleProfileUrl(run.taskId, run.runId)}
+            target='_blank'
+            rel='noreferrer'
+          >
+            <OpenInNewIcon fontSize='small' />
+          </IconButton>
+        </Box>
+      ))}
+    </RadioGroup>
+  );
+}
+
+type ProfileCompareDialogProps = {
+  open: boolean;
+  onClose: () => void;
+  result: CompareResultsItem;
+};
+
+export function ProfileCompareDialog({
+  open,
+  onClose,
+  result,
+}: ProfileCompareDialogProps) {
+  const [state, setState] = useState<LoadState>({ kind: 'loading' });
+  const [selectedBase, setSelectedBase] = useState<number | null>(null);
+  const [selectedNew, setSelectedNew] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setState({ kind: 'loading' });
+    setSelectedBase(null);
+    setSelectedNew(null);
+
+    Promise.all([
+      loadRunsWithProfiles(
+        result.base_repository_name,
+        result.base_retriggerable_job_ids,
+        result.base_runs,
+      ),
+      loadRunsWithProfiles(
+        result.new_repository_name,
+        result.new_retriggerable_job_ids,
+        result.new_runs,
+      ),
+    ]).then(
+      ([base, newRuns]) => {
+        if (cancelled) return;
+        setState({ kind: 'loaded', base, newRuns });
+        if (base.length > 0) setSelectedBase(Math.floor(base.length / 2));
+        if (newRuns.length > 0) setSelectedNew(Math.floor(newRuns.length / 2));
+      },
+      (error: unknown) => {
+        if (cancelled) return;
+        const message = error instanceof Error ? error.message : String(error);
+        setState({ kind: 'error', message });
+      },
+    );
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, result]);
+
+  const canCompare =
+    state.kind === 'loaded' &&
+    selectedBase !== null &&
+    selectedNew !== null &&
+    state.base[selectedBase] !== undefined &&
+    state.newRuns[selectedNew] !== undefined;
+
+  const compareUrl = canCompare
+    ? buildCompareBenchmarkUrl(
+        buildSingleProfileUrl(
+          state.base[selectedBase].taskId,
+          state.base[selectedBase].runId,
+        ),
+        buildSingleProfileUrl(
+          state.newRuns[selectedNew].taskId,
+          state.newRuns[selectedNew].runId,
+        ),
+      )
+    : undefined;
+
+  return (
+    <CenteredModal
+      open={open}
+      onClose={onClose}
+      ariaLabelledby='profile-compare-modal-title'
+      paperStyle={{ minWidth: 900 }}
+    >
+      <Typography id='profile-compare-modal-title' component='h2' variant='h2'>
+        Profile comparison
+      </Typography>
+      <Typography color='text.secondary'>
+        {result.header_name} — {result.platform}
+      </Typography>
+
+      {state.kind === 'loading' && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress />
+        </Box>
+      )}
+
+      {state.kind === 'error' && (
+        <Alert severity='error'>Failed to load runs: {state.message}</Alert>
+      )}
+
+      {state.kind === 'loaded' && (
+        <Box sx={{ display: 'flex', gap: 4 }}>
+          <Box sx={{ flex: 1 }}>
+            <Typography variant='h3' component='h3' sx={{ mb: 1 }}>
+              Base ({result.base_rev.slice(0, 12)})
+            </Typography>
+            <RunList
+              side='base'
+              runs={state.base}
+              selectedIndex={selectedBase}
+              onSelectedIndexChange={setSelectedBase}
+            />
+          </Box>
+          <Box sx={{ flex: 1 }}>
+            <Typography variant='h3' component='h3' sx={{ mb: 1 }}>
+              New ({result.new_rev.slice(0, 12)})
+            </Typography>
+            <RunList
+              side='new'
+              runs={state.newRuns}
+              selectedIndex={selectedNew}
+              onSelectedIndexChange={setSelectedNew}
+            />
+          </Box>
+        </Box>
+      )}
+
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 2 }}>
+        {canCompare ? (
+          <Button
+            variant='contained'
+            href={compareUrl!}
+            target='_blank'
+            rel='noreferrer'
+          >
+            Open profile comparison
+          </Button>
+        ) : (
+          <Button variant='contained' disabled>
+            Open profile comparison
+          </Button>
+        )}
+      </Box>
+    </CenteredModal>
+  );
+}

--- a/src/components/CompareResults/ProfileCompare/urls.ts
+++ b/src/components/CompareResults/ProfileCompare/urls.ts
@@ -1,0 +1,46 @@
+// TODO: Point this at https://profiler.firefox.com/compare-benchmark/ once
+// the feature lands in production (see the PR at
+// https://github.com/firefox-devtools/profiler/pull/6012).
+const COMPARE_BENCHMARK_BASE_URL =
+  'https://deploy-preview-6012--perf-html.netlify.app';
+
+const PROFILER_BASE_URL = 'https://profiler.firefox.com';
+const TC_ARTIFACT_BASE_URL = 'https://firefox-ci-tc.services.mozilla.com';
+
+// The name of the compact-profile artifact that the browsertime speedometer3
+// task uploads. We match on this exact name to decide whether a run is
+// eligible for profile comparison.
+export const SPEEDOMETER3_PROFILE_ARTIFACT =
+  'public/test_info/profile_speedometer3_compact.jslb.gz';
+
+export function buildTaskArtifactUrl(
+  taskId: string,
+  runId: number,
+  artifactPath: string,
+): string {
+  return `${TC_ARTIFACT_BASE_URL}/api/queue/v1/task/${taskId}/runs/${runId}/artifacts/${artifactPath}`;
+}
+
+// Builds a profiler.firefox.com URL that loads a single profile from a
+// Taskcluster artifact. The resulting URL is safe to use as an `href`.
+export function buildSingleProfileUrl(
+  taskId: string,
+  runId: number,
+  artifactPath: string = SPEEDOMETER3_PROFILE_ARTIFACT,
+): string {
+  const artifactUrl = buildTaskArtifactUrl(taskId, runId, artifactPath);
+  return `${PROFILER_BASE_URL}/from-url/${encodeURIComponent(artifactUrl)}`;
+}
+
+// Builds a URL for the profiler's benchmark-comparison view, comparing the
+// two given profiler-URLs (each already a from-url URL). URLSearchParams is
+// deliberately used so the encoding matches profiler.firefox.com's parser.
+export function buildCompareBenchmarkUrl(
+  baseProfileUrl: string,
+  newProfileUrl: string,
+): string {
+  const params = new URLSearchParams();
+  params.append('profiles[]', baseProfileUrl);
+  params.append('profiles[]', newProfileUrl);
+  return `${COMPARE_BENCHMARK_BASE_URL}/compare-benchmark/?${params.toString()}`;
+}

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -8,6 +8,10 @@ import { IconButton, Box } from '@mui/material';
 import Tooltip from '@mui/material/Tooltip';
 import { style } from 'typestyle';
 
+import {
+  ProfileCompareButton,
+  supportsProfileCompare,
+} from './ProfileCompare/ProfileCompareButton';
 import { RetriggerButton } from './Retrigger/RetriggerButton';
 import RevisionRowExpandable from './RevisionRowExpandable';
 import { compareView, compareOverTimeView } from '../../common/constants';
@@ -340,6 +344,13 @@ function RevisionRow(props: RevisionRowProps) {
                 >
                   <SubtestsIcon />
                 </IconButton>
+              </div>
+            </div>
+          )}
+          {supportsProfileCompare(result.suite) && (
+            <div className='profile-compare' role='cell'>
+              <div className='profile-compare-button-container'>
+                <ProfileCompareButton result={result as CompareResultsItem} />
               </div>
             </div>
           )}

--- a/src/components/CompareResults/rowButtonSlots.ts
+++ b/src/components/CompareResults/rowButtonSlots.ts
@@ -1,0 +1,27 @@
+// Geometry for the `.row-buttons` grid cell in RevisionRow and
+// SubtestsRevisionRow.
+//
+// Every row is its own CSS grid, and TableHeader builds a matching one, so the
+// cell has to be sized identically for all of them: wide enough for the most
+// buttons any single row can show, even though most rows show fewer. Buttons
+// are right-aligned inside the cell, so the surplus shows up as blank space to
+// their left instead of as a ragged right edge.
+//
+// Keep the slot counts below in sync with the buttons rendered in the
+// `.row-buttons` cell of each row component.
+const BUTTON_SLOT_WIDTH_PX = 34;
+
+// RevisionRow: subtests link (only when the result has subtests), profile
+// comparison (only for suites supportsProfileCompare() accepts), graph link,
+// and retrigger.
+const REVISION_ROW_BUTTON_SLOTS = 4;
+
+// SubtestsRevisionRow: graph link only.
+const SUBTESTS_ROW_BUTTON_SLOTS = 1;
+
+export function rowButtonsGridWidth(isSubtestTable: boolean): string {
+  const slots = isSubtestTable
+    ? SUBTESTS_ROW_BUTTON_SLOTS
+    : REVISION_ROW_BUTTON_SLOTS;
+  return `${slots * BUTTON_SLOT_WIDTH_PX}px`;
+}

--- a/src/logic/taskcluster.ts
+++ b/src/logic/taskcluster.ts
@@ -172,6 +172,47 @@ type Action = {
   name: string;
 };
 
+type TaskArtifact = {
+  name: string;
+  storageType: string;
+  contentType: string;
+};
+
+// Lists the artifacts produced by a given run of a Taskcluster task. Used by
+// the profile-comparison dialog to check which runs have a profile artifact.
+export async function fetchTaskArtifacts(
+  rootUrl: string,
+  taskId: string,
+  runId: number,
+): Promise<TaskArtifact[]> {
+  const url = `${rootUrl}/api/queue/v1/task/${taskId}/runs/${runId}/artifacts`;
+  const response = await fetch(url);
+  await checkTaskclusterResponse(response);
+  const json = (await response.json()) as { artifacts: TaskArtifact[] };
+  return json.artifacts;
+}
+
+export type TaskRunStatus = {
+  runId: number;
+  state: string;
+  workerGroup?: string;
+  workerId?: string;
+};
+
+// Fetches Taskcluster task status, which includes per-run worker information.
+export async function fetchTaskStatus(
+  rootUrl: string,
+  taskId: string,
+): Promise<{ runs: TaskRunStatus[] }> {
+  const url = `${rootUrl}/api/queue/v1/task/${taskId}/status`;
+  const response = await fetch(url);
+  await checkTaskclusterResponse(response);
+  const json = (await response.json()) as {
+    status: { runs: TaskRunStatus[] };
+  };
+  return json.status;
+}
+
 export async function fetchActionsFromDecisionTask(
   rootUrl: string,
   decisionTaskId: string,


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=2063430

[Deploy preview](https://deploy-preview-1080--mozilla-perfcompare.netlify.app/compare-lando-results?landoInstance=lando-prod-2025&baseLando=77807&newLando=77809&baseRepo=try&newRepo=try&framework=13)

This lets developers open a profile comparison from PerfCompare. [Example comparison](https://deploy-preview-6012--perf-html.netlify.app/compare-benchmark/?names[]=Baseline&names[]=New&profiles[]=https%3A%2F%2Fprofiler.firefox.com%2Fpublic%2Fva3d6kj6ssgrj2q83hgvggh8469xvnkc6vyxtvr%2Fcalltree%2F%3FglobalTrackOrder%3D0%26thread%3D0%26v%3D17&profiles[]=https%3A%2F%2Fprofiler.firefox.com%2Fpublic%2Fppj9yqcf9hq98ety0b26pgzbc8w02nzsb0hx3r0%2Fcalltree%2F%3FglobalTrackOrder%3D0%26thread%3D0%26v%3D17)