### PR TITLE
Removed silverman and kde warnings

### DIFF
--- a/src/__tests__/CompareResults/RevisionRowExpandable.test.tsx
+++ b/src/__tests__/CompareResults/RevisionRowExpandable.test.tsx
@@ -73,15 +73,11 @@ describe('RevisionRowExpandable for mann-whitney-u testVersion', () => {
       />,
     );
 
-    const expectedWarning1 =
-      'Less than 2 datapoints or no standard variance for a meaningful fit Kernel Density Estimator (KDE) with an ISJ bandwidth to Base.';
     const shapiroWarning =
       'Shapiro-Wilk test cannot be run on Base with fewer than 3 data points.';
     const shapiroWarning2 =
       'Shapiro-Wilk test cannot be run on New with fewer than 3 data points.';
 
-    const warning1 = await screen.findByText(expectedWarning1);
-    expect(warning1).toBeInTheDocument();
     const swWarning = await screen.findByText(shapiroWarning);
     expect(swWarning).toBeInTheDocument();
     const swWarning2 = await screen.findByText(shapiroWarning2);

--- a/src/__tests__/utils/fixtures.ts
+++ b/src/__tests__/utils/fixtures.ts
@@ -452,7 +452,6 @@ const getTestData = () => {
 
       is_new_better: null,
       direction_of_change: 'improvement',
-      kde_warnings: [],
     },
     {
       base_rev: 'coconut',
@@ -543,7 +542,6 @@ const getTestData = () => {
       is_new_better: null,
       direction_of_change: 'regression',
       shapiro_wilk_test_base: null,
-      kde_warnings: [],
     },
     {
       base_rev: 'coconut',
@@ -627,7 +625,6 @@ const getTestData = () => {
       },
       is_new_better: null,
       direction_of_change: null,
-      kde_warnings: [],
     },
     {
       base_rev: 'coconut',
@@ -710,7 +707,6 @@ const getTestData = () => {
       },
       is_new_better: null,
       direction_of_change: null,
-      kde_warnings: [],
     },
   ];
 
@@ -1301,11 +1297,6 @@ const getTestData = () => {
       effect_size: '',
       cles_explanation: '',
     },
-    silverman_warnings: [],
-    kde_warnings: [
-      'Less than 2 datapoints or no standard variance for a meaningful fit Kernel Density Estimator (KDE) with an ISJ bandwidth to Base.',
-      'Less than 2 datapoints or no standard variance for a meaningful fit Kernel Density Estimator (KDE) with an ISJ bandwidth to New.',
-    ],
     new_is_better: null,
   };
 
@@ -1398,7 +1389,6 @@ const getTestData = () => {
       },
       cliffs_delta: 0.02,
       cliffs_interpretation: 'negligible',
-      kde_warnings: [],
       cles: {
         cles: 0.6,
         cles_direction: '',
@@ -1506,7 +1496,6 @@ const getTestData = () => {
         effect_size: '',
         cles_explanation: '',
       },
-      kde_warnings: [],
       is_new_better: null,
       direction_of_change: 'improvement',
     },
@@ -1596,7 +1585,6 @@ const getTestData = () => {
         effect_size: '',
         cles_explanation: '',
       },
-      kde_warnings: [],
       is_new_better: null,
       direction_of_change: null,
     },
@@ -1686,7 +1674,6 @@ const getTestData = () => {
         effect_size: '',
         cles_explanation: '',
       },
-      kde_warnings: [],
       is_new_better: null,
       direction_of_change: null,
     },
@@ -1776,7 +1763,6 @@ const getTestData = () => {
         effect_size: '',
         cles_explanation: '',
       },
-      kde_warnings: [],
       is_new_better: null,
       direction_of_change: null,
     },

--- a/src/components/CompareResults/StatisticsWarnings.tsx
+++ b/src/components/CompareResults/StatisticsWarnings.tsx
@@ -32,9 +32,7 @@ export const StatisticsWarnings = ({
   // Combine all warnings into a single list
   const warnings: string[] = [
     ...(result?.shapiro_wilk_warnings ?? []),
-    ...(result?.silverman_warnings ?? []),
     ...(result?.ks_warning ? [result?.ks_warning] : []),
-    ...(result?.kde_warnings ?? []),
   ];
   return (
     <>

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -185,8 +185,6 @@ export type MannWhitneyResultsItem = {
   cliffs_delta: number;
   cliffs_interpretation: string;
   cles?: CLESItem; // CLES: Common Language Effect Size, statistical effect interpretation from Mann-Whitney U
-  kde_warnings: string[];
-  silverman_warnings?: string[] | null; // silverman warnings about multimodal data
   is_new_better: boolean | null; // is the new revision better than the base revision
   direction_of_change: 'no change' | 'improvement' | 'regression' | null;
   new_is_better: boolean | null;


### PR DESCRIPTION
This PR resolves this [bug 2059493: Clean up components in perfcompare frontend using the unnecessary silverman_kde data](https://bugzilla.mozilla.org/show_bug.cgi?id=2059493)