### PR TITLE
Simplified View Follow-up: reduce size of cols and link subtest pills to subtests page

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/OverTimeResultsView.test.tsx.snap
@@ -446,7 +446,7 @@ exports[`Results View The table should match snapshot and other elements should 
       </div>
     </div>
     <div
-      class="f1ogd8ft f1l733lh table-header"
+      class="flb4c18 f1l733lh table-header"
       data-testid="table-header"
       role="row"
     >
@@ -778,7 +778,7 @@ exports[`Results View The table should match snapshot and other elements should 
               class="revision-block fw0pvlu"
             >
               <div
-                class="revisionRow fxapxfk f1dlt78d MuiBox-root css-18x56hc"
+                class="revisionRow fxapxfk f1dlt78d MuiBox-root css-m7w6pu"
                 role="row"
               >
                 <div
@@ -968,7 +968,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow fxapxfk f1dlt78d MuiBox-root css-18x56hc"
+                class="revisionRow fxapxfk f1dlt78d MuiBox-root css-m7w6pu"
                 role="row"
               >
                 <div
@@ -1159,7 +1159,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow fxapxfk f1dlt78d MuiBox-root css-18x56hc"
+                class="revisionRow fxapxfk f1dlt78d MuiBox-root css-m7w6pu"
                 role="row"
               >
                 <div
@@ -1350,7 +1350,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow fxapxfk f1dlt78d MuiBox-root css-18x56hc"
+                class="revisionRow fxapxfk f1dlt78d MuiBox-root css-m7w6pu"
                 role="row"
               >
                 <div

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -1546,7 +1546,7 @@ exports[`Results Table Should match snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="f1ogd8ft f1l733lh table-header"
+                  class="flb4c18 f1l733lh table-header"
                   data-testid="table-header"
                   role="row"
                 >
@@ -1878,7 +1878,7 @@ exports[`Results Table Should match snapshot 1`] = `
                           class="revision-block fw0pvlu"
                         >
                           <div
-                            class="revisionRow fxapxfk f1dlt78d MuiBox-root css-18x56hc"
+                            class="revisionRow fxapxfk f1dlt78d MuiBox-root css-m7w6pu"
                             role="row"
                           >
                             <div
@@ -2068,7 +2068,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </div>
                           </div>
                           <div
-                            class="revisionRow fxapxfk f1dlt78d MuiBox-root css-18x56hc"
+                            class="revisionRow fxapxfk f1dlt78d MuiBox-root css-m7w6pu"
                             role="row"
                           >
                             <div
@@ -2259,7 +2259,7 @@ exports[`Results Table Should match snapshot 1`] = `
                             </div>
                           </div>
                           <div
-                            class="revisionRow fxapxfk f1dlt78d MuiBox-root css-18x56hc"
+                            class="revisionRow fxapxfk f1dlt78d MuiBox-root css-m7w6pu"
                             role="row"
                           >
                             <div
@@ -2537,7 +2537,7 @@ exports[`Results Table Should match snapshot 1`] = `
                           class="revision-block fw0pvlu"
                         >
                           <div
-                            class="revisionRow fxapxfk f1dlt78d MuiBox-root css-18x56hc"
+                            class="revisionRow fxapxfk f1dlt78d MuiBox-root css-m7w6pu"
                             role="row"
                           >
                             <div
@@ -4560,7 +4560,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                   </div>
                 </div>
                 <div
-                  class="f2f94gn f1l733lh table-header"
+                  class="f1d31dwl f1l733lh table-header"
                   data-testid="table-header"
                   role="row"
                 >
@@ -4956,7 +4956,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                           class="revision-block fw0pvlu"
                         >
                           <div
-                            class="revisionRow fxapxfk f1dlt78d MuiBox-root css-lkxut"
+                            class="revisionRow fxapxfk f1dlt78d MuiBox-root css-ypd37h"
                             role="row"
                           >
                             <div
@@ -5176,7 +5176,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                             </div>
                           </div>
                           <div
-                            class="revisionRow fxapxfk f1dlt78d MuiBox-root css-lkxut"
+                            class="revisionRow fxapxfk f1dlt78d MuiBox-root css-ypd37h"
                             role="row"
                           >
                             <div
@@ -5397,7 +5397,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                             </div>
                           </div>
                           <div
-                            class="revisionRow fxapxfk f1dlt78d MuiBox-root css-lkxut"
+                            class="revisionRow fxapxfk f1dlt78d MuiBox-root css-ypd37h"
                             role="row"
                           >
                             <div
@@ -5687,7 +5687,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                           class="revision-block fw0pvlu"
                         >
                           <div
-                            class="revisionRow fxapxfk f1dlt78d MuiBox-root css-lkxut"
+                            class="revisionRow fxapxfk f1dlt78d MuiBox-root css-ypd37h"
                             role="row"
                           >
                             <div
@@ -6493,7 +6493,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
       </span>
     </div>
     <div
-      class="revisionRow fxapxfk f1dlt78d MuiBox-root css-lkxut"
+      class="revisionRow fxapxfk f1dlt78d MuiBox-root css-ypd37h"
       role="row"
     >
       <div
@@ -6753,7 +6753,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
       </span>
     </div>
     <div
-      class="revisionRow fxapxfk f1dlt78d MuiBox-root css-lkxut"
+      class="revisionRow fxapxfk f1dlt78d MuiBox-root css-ypd37h"
       role="row"
     >
       <div

--- a/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsView.test.tsx.snap
@@ -1559,7 +1559,7 @@ exports[`Results View The table should match snapshot and other elements should 
       </div>
     </div>
     <div
-      class="f1ogd8ft f1l733lh table-header"
+      class="flb4c18 f1l733lh table-header"
       data-testid="table-header"
       role="row"
     >
@@ -1891,7 +1891,7 @@ exports[`Results View The table should match snapshot and other elements should 
               class="revision-block fw0pvlu"
             >
               <div
-                class="revisionRow fxapxfk f1dlt78d MuiBox-root css-18x56hc"
+                class="revisionRow fxapxfk f1dlt78d MuiBox-root css-m7w6pu"
                 role="row"
               >
                 <div
@@ -2081,7 +2081,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow fxapxfk f1dlt78d MuiBox-root css-18x56hc"
+                class="revisionRow fxapxfk f1dlt78d MuiBox-root css-m7w6pu"
                 role="row"
               >
                 <div
@@ -2272,7 +2272,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow fxapxfk f1dlt78d MuiBox-root css-18x56hc"
+                class="revisionRow fxapxfk f1dlt78d MuiBox-root css-m7w6pu"
                 role="row"
               >
                 <div
@@ -2463,7 +2463,7 @@ exports[`Results View The table should match snapshot and other elements should 
                 </div>
               </div>
               <div
-                class="revisionRow fxapxfk f1dlt78d MuiBox-root css-18x56hc"
+                class="revisionRow fxapxfk f1dlt78d MuiBox-root css-m7w6pu"
                 role="row"
               >
                 <div

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -898,7 +898,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
               role="table"
             >
               <div
-                class="fl0cu5d f1l733lh table-header"
+                class="f1aoth2s f1l733lh table-header"
                 data-testid="table-header"
                 role="row"
               >
@@ -1106,7 +1106,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 />
               </div>
               <div
-                class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1m727ht"
+                class="revisionRow f1wg244b f1dlt78d MuiBox-root css-m5eak"
                 role="row"
               >
                 <div
@@ -1259,7 +1259,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1m727ht"
+                class="revisionRow f1wg244b f1dlt78d MuiBox-root css-m5eak"
                 role="row"
               >
                 <div
@@ -1398,7 +1398,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1m727ht"
+                class="revisionRow f1wg244b f1dlt78d MuiBox-root css-m5eak"
                 role="row"
               >
                 <div
@@ -1537,7 +1537,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1m727ht"
+                class="revisionRow f1wg244b f1dlt78d MuiBox-root css-m5eak"
                 role="row"
               >
                 <div
@@ -1676,7 +1676,7 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </div>
               </div>
               <div
-                class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1m727ht"
+                class="revisionRow f1wg244b f1dlt78d MuiBox-root css-m5eak"
                 role="row"
               >
                 <div
@@ -2758,7 +2758,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
               role="table"
             >
               <div
-                class="fl0cu5d f1l733lh table-header"
+                class="f1aoth2s f1l733lh table-header"
                 data-testid="table-header"
                 role="row"
               >
@@ -2966,7 +2966,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 />
               </div>
               <div
-                class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1m727ht"
+                class="revisionRow f1wg244b f1dlt78d MuiBox-root css-m5eak"
                 role="row"
               >
                 <div
@@ -3126,7 +3126,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1m727ht"
+                class="revisionRow f1wg244b f1dlt78d MuiBox-root css-m5eak"
                 role="row"
               >
                 <div
@@ -3280,7 +3280,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1m727ht"
+                class="revisionRow f1wg244b f1dlt78d MuiBox-root css-m5eak"
                 role="row"
               >
                 <div
@@ -3421,7 +3421,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1m727ht"
+                class="revisionRow f1wg244b f1dlt78d MuiBox-root css-m5eak"
                 role="row"
               >
                 <div
@@ -3562,7 +3562,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1m727ht"
+                class="revisionRow f1wg244b f1dlt78d MuiBox-root css-m5eak"
                 role="row"
               >
                 <div
@@ -4275,7 +4275,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
               role="table"
             >
               <div
-                class="fl0cu5d f1l733lh table-header"
+                class="f1aoth2s f1l733lh table-header"
                 data-testid="table-header"
                 role="row"
               >
@@ -4483,7 +4483,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 />
               </div>
               <div
-                class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1m727ht"
+                class="revisionRow f1wg244b f1dlt78d MuiBox-root css-m5eak"
                 role="row"
               >
                 <div
@@ -4643,7 +4643,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1m727ht"
+                class="revisionRow f1wg244b f1dlt78d MuiBox-root css-m5eak"
                 role="row"
               >
                 <div
@@ -4797,7 +4797,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1m727ht"
+                class="revisionRow f1wg244b f1dlt78d MuiBox-root css-m5eak"
                 role="row"
               >
                 <div
@@ -4938,7 +4938,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1m727ht"
+                class="revisionRow f1wg244b f1dlt78d MuiBox-root css-m5eak"
                 role="row"
               >
                 <div
@@ -5079,7 +5079,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </div>
               </div>
               <div
-                class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1m727ht"
+                class="revisionRow f1wg244b f1dlt78d MuiBox-root css-m5eak"
                 role="row"
               >
                 <div
@@ -5792,7 +5792,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
               role="table"
             >
               <div
-                class="fl0cu5d f1l733lh table-header"
+                class="f1aoth2s f1l733lh table-header"
                 data-testid="table-header"
                 role="row"
               >
@@ -6000,7 +6000,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                 />
               </div>
               <div
-                class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1m727ht"
+                class="revisionRow f1wg244b f1dlt78d MuiBox-root css-m5eak"
                 role="row"
               >
                 <div
@@ -6160,7 +6160,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                 </div>
               </div>
               <div
-                class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1m727ht"
+                class="revisionRow f1wg244b f1dlt78d MuiBox-root css-m5eak"
                 role="row"
               >
                 <div
@@ -6314,7 +6314,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                 </div>
               </div>
               <div
-                class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1m727ht"
+                class="revisionRow f1wg244b f1dlt78d MuiBox-root css-m5eak"
                 role="row"
               >
                 <div
@@ -6455,7 +6455,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                 </div>
               </div>
               <div
-                class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1m727ht"
+                class="revisionRow f1wg244b f1dlt78d MuiBox-root css-m5eak"
                 role="row"
               >
                 <div
@@ -6596,7 +6596,7 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                 </div>
               </div>
               <div
-                class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1m727ht"
+                class="revisionRow f1wg244b f1dlt78d MuiBox-root css-m5eak"
                 role="row"
               >
                 <div
@@ -7309,7 +7309,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
               role="table"
             >
               <div
-                class="fl0cu5d f1l733lh table-header"
+                class="f1aoth2s f1l733lh table-header"
                 data-testid="table-header"
                 role="row"
               >
@@ -7517,7 +7517,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 />
               </div>
               <div
-                class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1m727ht"
+                class="revisionRow f1wg244b f1dlt78d MuiBox-root css-m5eak"
                 role="row"
               >
                 <div
@@ -7670,7 +7670,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1m727ht"
+                class="revisionRow f1wg244b f1dlt78d MuiBox-root css-m5eak"
                 role="row"
               >
                 <div
@@ -7809,7 +7809,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1m727ht"
+                class="revisionRow f1wg244b f1dlt78d MuiBox-root css-m5eak"
                 role="row"
               >
                 <div
@@ -7948,7 +7948,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1m727ht"
+                class="revisionRow f1wg244b f1dlt78d MuiBox-root css-m5eak"
                 role="row"
               >
                 <div
@@ -8087,7 +8087,7 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </div>
               </div>
               <div
-                class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1m727ht"
+                class="revisionRow f1wg244b f1dlt78d MuiBox-root css-m5eak"
                 role="row"
               >
                 <div

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsRevisionRow.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsRevisionRow.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`SubtestsRevisionRow Component renders browser name when base and new ap
 <body>
   <div>
     <div
-      class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1uflkrc"
+      class="revisionRow f1wg244b f1dlt78d MuiBox-root css-1uflkrc"
       role="row"
     >
       <div
@@ -183,7 +183,7 @@ exports[`SubtestsRevisionRow Component renders doesnt render browser name when b
 <body>
   <div>
     <div
-      class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1uflkrc"
+      class="revisionRow f1wg244b f1dlt78d MuiBox-root css-1uflkrc"
       role="row"
     >
       <div
@@ -337,7 +337,7 @@ exports[`SubtestsRevisionRow Component renders the component with correct data 1
 <body>
   <div>
     <div
-      class="revisionRow f19vd5kt f1dlt78d MuiBox-root css-1uflkrc"
+      class="revisionRow f1wg244b f1dlt78d MuiBox-root css-1uflkrc"
       role="row"
     >
       <div

--- a/src/common/testVersions/mannWhitney.tsx
+++ b/src/common/testVersions/mannWhitney.tsx
@@ -305,14 +305,14 @@ export const mannWhitneyStrategy = {
       ? {
           name: 'Subtests',
           key: 'subtests',
-          gridWidth: '1.5fr',
+          gridWidth: '1.25fr',
           sortFunction: defaultSortFunction,
         }
       : {
           name: 'Platform',
           filter: true,
           key: 'platform',
-          gridWidth: '1.5fr',
+          gridWidth: '1.25fr',
           possibleValues: PLATFORM_FILTER_VALUES,
           matchesFunction(result: MannWhitneyResultsItem, valueKey: string) {
             const label = this.possibleValues.find(
@@ -329,15 +329,15 @@ export const mannWhitneyStrategy = {
       {
         name: 'Base',
         key: 'base',
-        gridWidth: '1fr',
+        gridWidth: '.75fr',
         tooltip: tooltipBaseMean,
       },
       { key: 'comparisonSign', gridWidth: '0.25fr' },
-      { name: 'New', key: 'new', gridWidth: '1fr', tooltip: tooltipNewMean },
+      { name: 'New', key: 'new', gridWidth: '.75fr', tooltip: tooltipNewMean },
       {
         name: 'Δ Median',
         key: 'median-diff',
-        gridWidth: '1.5fr',
+        gridWidth: '1fr',
         sortFunction(
           resultA: MannWhitneyResultsItem,
           resultB: MannWhitneyResultsItem,
@@ -358,7 +358,7 @@ export const mannWhitneyStrategy = {
         name: 'Status',
         filter: true,
         key: 'status',
-        gridWidth: '1.5fr',
+        gridWidth: '1fr',
         possibleValues: [
           { label: 'No changes', key: 'none' },
           { label: 'Improvement', key: 'improvement' },
@@ -395,7 +395,7 @@ export const mannWhitneyStrategy = {
               name: 'Magnitude',
               filter: true,
               key: 'magnitude',
-              gridWidth: '1.55fr',
+              gridWidth: '1.25fr',
               possibleValues: [
                 { label: 'Negligible', key: 'negligible' },
                 { label: 'Small', key: 'small' },
@@ -448,7 +448,7 @@ export const mannWhitneyStrategy = {
             {
               name: 'CLES',
               key: 'effects',
-              gridWidth: '1.25fr',
+              gridWidth: '1fr',
               sortFunction(
                 resultA: MannWhitneyResultsItem,
                 resultB: MannWhitneyResultsItem,
@@ -473,7 +473,7 @@ export const mannWhitneyStrategy = {
               name: anyAdvanced ? 'Sig' : 'Significance',
               key: 'significance',
               filter: true,
-              gridWidth: '1.25fr',
+              gridWidth: '1fr',
               tooltip: tooltipSignificance,
               possibleValues: [
                 // Plain-language labels matching the cell text; the keys still

--- a/src/components/CompareResults/RevisionRow.tsx
+++ b/src/components/CompareResults/RevisionRow.tsx
@@ -139,21 +139,20 @@ const loadingMessage = style({
   padding: `0 0 ${Spacing.xSmall}px`,
 });
 
-const regressionPill = style({
+const pillStyle = {
   display: 'inline-flex',
   alignItems: 'center',
   borderRadius: '4px',
   padding: '2px 8px',
   fontSize: '0.75rem',
-});
+  cursor: 'pointer',
+  color: 'inherit',
+  textDecoration: 'none',
+};
 
-const improvementPill = style({
-  display: 'inline-flex',
-  alignItems: 'center',
-  borderRadius: '4px',
-  padding: '2px 8px',
-  fontSize: '0.75rem',
-});
+const regressionPill = style(pillStyle);
+
+const improvementPill = style(pillStyle);
 
 const platformIcons: Record<PlatformShortName, ReactNode> = {
   Linux: <LinuxIcon />,
@@ -413,6 +412,10 @@ function RevisionRow(props: RevisionRowProps) {
           <div className={subtestCountsRow}>
             {subtestCounts.regressionCount > 0 && (
               <Box
+                component='a'
+                href={subtestsCompareLink}
+                target='_blank'
+                rel='noreferrer'
                 sx={{ backgroundColor: 'status.regression' }}
                 className={regressionPill}
               >
@@ -424,6 +427,10 @@ function RevisionRow(props: RevisionRowProps) {
             )}
             {subtestCounts.improvementCount > 0 && (
               <Box
+                component='a'
+                href={subtestsCompareLink}
+                target='_blank'
+                rel='noreferrer'
                 sx={{ backgroundColor: 'status.improvement' }}
                 className={improvementPill}
               >

--- a/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsRevisionRow.tsx
@@ -47,7 +47,7 @@ const revisionRow = style({
     '.subtests': {
       borderRadius: '4px 0 0 4px',
       paddingLeft: Spacing.Medium, // Synchronize with its header
-      maxWidth: '150px',
+      maxWidth: '200px',
       wordBreak: 'break-word',
     },
 


### PR DESCRIPTION
This is a quick follow-up PR to the simplified view PR. Two changes: reduce size of the Result Table's colS and link the subtest pills to the subtest page. 