### PR TITLE
Bug-1995794: Disable retrigger dropdown when there are no runs

### DIFF
--- a/src/__tests__/CompareResults/Retrigger.test.tsx
+++ b/src/__tests__/CompareResults/Retrigger.test.tsx
@@ -267,6 +267,63 @@ describe('Retrigger', () => {
 
     expect(new MockedHooks().triggerHook).toHaveBeenCalled();
   });
+
+  async function openRetriggerConfigModal(
+    compareResult: typeof result = result,
+  ) {
+    setUpUserCredentials();
+    render(<RetriggerButton result={compareResult} variant='icon' />);
+
+    const openModalButton = await screen.findByRole('button', {
+      name: 'retrigger jobs',
+    });
+
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await user.click(openModalButton);
+
+    return {
+      baseSelect: await screen.findByLabelText('Base'),
+      newSelect: await screen.findByLabelText('New'),
+    };
+  }
+
+  it('should disable the Base dropdown when there are no base retriggerable jobs', async () => {
+    const { baseSelect, newSelect } = await openRetriggerConfigModal({
+      ...result,
+      base_retriggerable_job_ids: [],
+    });
+
+    // MUI Select uses a combobox div with aria-disabled rather than native disabled.
+    expect(baseSelect).toHaveAttribute('aria-disabled', 'true');
+    expect(baseSelect).toHaveTextContent('0');
+    expect(newSelect).not.toHaveAttribute('aria-disabled', 'true');
+    expect(newSelect).toHaveTextContent('5');
+  });
+
+  it('should disable the New dropdown when there are no new retriggerable jobs', async () => {
+    const { baseSelect, newSelect } = await openRetriggerConfigModal({
+      ...result,
+      new_retriggerable_job_ids: [],
+    });
+
+    expect(baseSelect).not.toHaveAttribute('aria-disabled', 'true');
+    expect(baseSelect).toHaveTextContent('5');
+    expect(newSelect).toHaveAttribute('aria-disabled', 'true');
+    expect(newSelect).toHaveTextContent('0');
+  });
+
+  it('should disable both dropdowns when there are no retriggerable jobs', async () => {
+    const { baseSelect, newSelect } = await openRetriggerConfigModal({
+      ...result,
+      base_retriggerable_job_ids: [],
+      new_retriggerable_job_ids: [],
+    });
+
+    expect(baseSelect).toHaveAttribute('aria-disabled', 'true');
+    expect(baseSelect).toHaveTextContent('0');
+    expect(newSelect).toHaveAttribute('aria-disabled', 'true');
+    expect(newSelect).toHaveTextContent('0');
+  });
 });
 
 describe('Retrigger in Subtests view', () => {

--- a/src/components/CompareResults/Retrigger/RetriggerButton.tsx
+++ b/src/components/CompareResults/Retrigger/RetriggerButton.tsx
@@ -210,6 +210,8 @@ export function RetriggerButton({ result, variant }: RetriggerButtonProps) {
         open={status === 'retrigger-modal'}
         onClose={() => setStatus('pending')}
         onRetriggerClick={onRetriggerConfirm}
+        hasBaseJobs={baseRetriggerableJobIds.length > 0}
+        hasNewJobs={newRetriggerableJobIds.length > 0}
       />
     </>
   );

--- a/src/components/CompareResults/Retrigger/RetriggerConfigModal.tsx
+++ b/src/components/CompareResults/Retrigger/RetriggerConfigModal.tsx
@@ -16,17 +16,20 @@ const retriggerStrings = Strings.components.retrigger.config;
 function RetriggerCountSelect({
   prefix,
   label,
+  disabled = false,
 }: {
   prefix: string;
   label: string;
+  disabled?: boolean;
 }) {
   return (
-    <FormControl sx={{ width: '100%' }}>
+    <FormControl sx={{ width: '100%' }} disabled={disabled}>
       <InputLabel id={`${prefix}-retrigger-count-label`}>{label}</InputLabel>
       <Select
         labelId={`${prefix}-retrigger-count-label`}
         name={`${prefix}-retrigger-count`}
-        defaultValue={5}
+        defaultValue={disabled ? 0 : 5}
+        disabled={disabled}
         label={label}
         sx={{ height: 32 }}
       >
@@ -44,6 +47,8 @@ type RetriggerModalProps = {
   open: boolean;
   onClose: () => unknown;
   onRetriggerClick: (times: { baseTimes: number; newTimes: number }) => unknown;
+  hasBaseJobs: boolean;
+  hasNewJobs: boolean;
 };
 
 export function RetriggerConfigModal(props: RetriggerModalProps) {
@@ -77,10 +82,18 @@ export function RetriggerConfigModal(props: RetriggerModalProps) {
           }}
         >
           <Grid size={3}>
-            <RetriggerCountSelect prefix='base' label='Base' />
+            <RetriggerCountSelect
+              prefix='base'
+              label='Base'
+              disabled={!props.hasBaseJobs}
+            />
           </Grid>
           <Grid size={3}>
-            <RetriggerCountSelect prefix='new' label='New' />
+            <RetriggerCountSelect
+              prefix='new'
+              label='New'
+              disabled={!props.hasNewJobs}
+            />
           </Grid>
           <Grid
             size='auto'


### PR DESCRIPTION
Disable the Base and New retrigger count selects independently when there are no retriggerable job ids for that side, and default a disabled select to 0 so it does not look like jobs will start.

<img width="1280" height="800" alt="retrigger_modal_new_dropdown_disabled" src="https://github.com/user-attachments/assets/2b2f5534-7139-4ee2-b62e-8707a9446494" />


@kala-moz @beatrice-acasandrei 