### PR TITLE
Bug-1995794: Disable retrigger dropdown when there are no runs

### DIFF
--- a/src/__tests__/CompareResults/Retrigger.test.tsx
+++ b/src/__tests__/CompareResults/Retrigger.test.tsx
@@ -127,6 +127,25 @@ describe('Retrigger', () => {
     mockedGetLocationOrigin.mockImplementation(() => 'http://localhost:3000');
   });
 
+  async function openRetriggerConfigModal(
+    compareResult: typeof result = result,
+  ) {
+    setUpUserCredentials();
+    render(<RetriggerButton result={compareResult} variant='icon' />);
+
+    const openModalButton = await screen.findByRole('button', {
+      name: 'retrigger jobs',
+    });
+
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await user.click(openModalButton);
+
+    return {
+      baseSelect: await screen.findByLabelText('Base'),
+      newSelect: await screen.findByLabelText('New'),
+    };
+  }
+
   it('should display Sign In modal when there are no credentials', async () => {
     render(<RetriggerButton result={result} variant='icon' />);
 
@@ -268,25 +287,6 @@ describe('Retrigger', () => {
     expect(new MockedHooks().triggerHook).toHaveBeenCalled();
   });
 
-  async function openRetriggerConfigModal(
-    compareResult: typeof result = result,
-  ) {
-    setUpUserCredentials();
-    render(<RetriggerButton result={compareResult} variant='icon' />);
-
-    const openModalButton = await screen.findByRole('button', {
-      name: 'retrigger jobs',
-    });
-
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-    await user.click(openModalButton);
-
-    return {
-      baseSelect: await screen.findByLabelText('Base'),
-      newSelect: await screen.findByLabelText('New'),
-    };
-  }
-
   it('should disable the Base dropdown when there are no base retriggerable jobs', async () => {
     const { baseSelect, newSelect } = await openRetriggerConfigModal({
       ...result,
@@ -298,6 +298,7 @@ describe('Retrigger', () => {
     expect(baseSelect).toHaveTextContent('0');
     expect(newSelect).not.toHaveAttribute('aria-disabled', 'true');
     expect(newSelect).toHaveTextContent('5');
+    expect(screen.getByRole('button', { name: 'Retrigger' })).toBeEnabled();
   });
 
   it('should disable the New dropdown when there are no new retriggerable jobs', async () => {
@@ -310,6 +311,7 @@ describe('Retrigger', () => {
     expect(baseSelect).toHaveTextContent('5');
     expect(newSelect).toHaveAttribute('aria-disabled', 'true');
     expect(newSelect).toHaveTextContent('0');
+    expect(screen.getByRole('button', { name: 'Retrigger' })).toBeEnabled();
   });
 
   it('should disable both dropdowns when there are no retriggerable jobs', async () => {
@@ -323,6 +325,7 @@ describe('Retrigger', () => {
     expect(baseSelect).toHaveTextContent('0');
     expect(newSelect).toHaveAttribute('aria-disabled', 'true');
     expect(newSelect).toHaveTextContent('0');
+    expect(screen.getByRole('button', { name: 'Retrigger' })).toBeDisabled();
   });
 });
 

--- a/src/__tests__/CompareResults/Retrigger.test.tsx
+++ b/src/__tests__/CompareResults/Retrigger.test.tsx
@@ -267,6 +267,63 @@ describe('Retrigger', () => {
 
     expect(new MockedHooks().triggerHook).toHaveBeenCalled();
   });
+
+  async function openRetriggerConfigModal(
+    compareResult: typeof result = result,
+  ) {
+    setUpUserCredentials();
+    render(<RetriggerButton result={compareResult} variant='icon' />);
+
+    const openModalButton = await screen.findByRole('button', {
+      name: 'retrigger jobs',
+    });
+
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await user.click(openModalButton);
+
+    return {
+      baseSelect: await screen.findByLabelText('Base'),
+      newSelect: await screen.findByLabelText('New'),
+    };
+  }
+
+  it('should disable the Base dropdown when there are no base retriggerable jobs', async () => {
+    const { baseSelect, newSelect } = await openRetriggerConfigModal({
+      ...result,
+      base_retriggerable_job_ids: [],
+    });
+
+    // MUI Select uses a combobox div with aria-disabled rather than native disabled.
+    expect(baseSelect).toHaveAttribute('aria-disabled', 'true');
+    expect(baseSelect).toHaveTextContent('0');
+    expect(newSelect).not.toHaveAttribute('aria-disabled', 'true');
+    expect(newSelect).toHaveTextContent('5');
+  });
+
+  it('should disable the New dropdown when there are no new retriggerable jobs', async () => {
+    const { baseSelect, newSelect } = await openRetriggerConfigModal({
+      ...result,
+      new_retriggerable_job_ids: [],
+    });
+
+    expect(baseSelect).not.toHaveAttribute('aria-disabled', 'true');
+    expect(baseSelect).toHaveTextContent('5');
+    expect(newSelect).toHaveAttribute('aria-disabled', 'true');
+    expect(newSelect).toHaveTextContent('0');
+  });
+
+  it('should disable both dropdowns when there are no retriggerable jobs', async () => {
+    const { baseSelect, newSelect } = await openRetriggerConfigModal({
+      ...result,
+      base_retriggerable_job_ids: [],
+      new_retriggerable_job_ids: [],
+    });
+
+    expect(baseSelect).toHaveAttribute('aria-disabled', 'true');
+    expect(baseSelect).toHaveTextContent('0');
+    expect(newSelect).toHaveAttribute('aria-disabled', 'true');
+    expect(newSelect).toHaveTextContent('0');
+  });
 });
 
 describe('Retrigger in Subtests view', () => {

--- a/src/components/CompareResults/Retrigger/RetriggerButton.tsx
+++ b/src/components/CompareResults/Retrigger/RetriggerButton.tsx
@@ -210,6 +210,8 @@ export function RetriggerButton({ result, variant }: RetriggerButtonProps) {
         open={status === 'retrigger-modal'}
         onClose={() => setStatus('pending')}
         onRetriggerClick={onRetriggerConfirm}
+        hasBaseJobs={baseRetriggerableJobIds.length > 0}
+        hasNewJobs={newRetriggerableJobIds.length > 0}
       />
     </>
   );

--- a/src/components/CompareResults/Retrigger/RetriggerConfigModal.tsx
+++ b/src/components/CompareResults/Retrigger/RetriggerConfigModal.tsx
@@ -16,17 +16,20 @@ const retriggerStrings = Strings.components.retrigger.config;
 function RetriggerCountSelect({
   prefix,
   label,
+  disabled = false,
 }: {
   prefix: string;
   label: string;
+  disabled?: boolean;
 }) {
   return (
-    <FormControl sx={{ width: '100%' }}>
+    <FormControl sx={{ width: '100%' }} disabled={disabled}>
       <InputLabel id={`${prefix}-retrigger-count-label`}>{label}</InputLabel>
       <Select
         labelId={`${prefix}-retrigger-count-label`}
         name={`${prefix}-retrigger-count`}
-        defaultValue={5}
+        defaultValue={disabled ? 0 : 5}
+        disabled={disabled}
         label={label}
         sx={{ height: 32 }}
       >
@@ -44,6 +47,8 @@ type RetriggerModalProps = {
   open: boolean;
   onClose: () => unknown;
   onRetriggerClick: (times: { baseTimes: number; newTimes: number }) => unknown;
+  hasBaseJobs: boolean;
+  hasNewJobs: boolean;
 };
 
 export function RetriggerConfigModal(props: RetriggerModalProps) {
@@ -77,10 +82,18 @@ export function RetriggerConfigModal(props: RetriggerModalProps) {
           }}
         >
           <Grid size={3}>
-            <RetriggerCountSelect prefix='base' label='Base' />
+            <RetriggerCountSelect
+              prefix='base'
+              label='Base'
+              disabled={!props.hasBaseJobs}
+            />
           </Grid>
           <Grid size={3}>
-            <RetriggerCountSelect prefix='new' label='New' />
+            <RetriggerCountSelect
+              prefix='new'
+              label='New'
+              disabled={!props.hasNewJobs}
+            />
           </Grid>
           <Grid
             size='auto'

--- a/src/components/CompareResults/Retrigger/RetriggerConfigModal.tsx
+++ b/src/components/CompareResults/Retrigger/RetriggerConfigModal.tsx
@@ -25,11 +25,15 @@ function RetriggerCountSelect({
   return (
     <FormControl sx={{ width: '100%' }} disabled={disabled}>
       <InputLabel id={`${prefix}-retrigger-count-label`}>{label}</InputLabel>
+      {/*
+        defaultValue is safe here because CenteredModal unmounts when closed,
+        so the select remounts with a fresh default each time the modal opens.
+        FormControl's disabled state is passed to Select via context.
+      */}
       <Select
         labelId={`${prefix}-retrigger-count-label`}
         name={`${prefix}-retrigger-count`}
         defaultValue={disabled ? 0 : 5}
-        disabled={disabled}
         label={label}
         sx={{ height: 32 }}
       >
@@ -101,7 +105,12 @@ export function RetriggerConfigModal(props: RetriggerModalProps) {
               ml: 'auto',
             }}
           >
-            <Button type='submit'>{retriggerStrings.submitButton}</Button>
+            <Button
+              type='submit'
+              disabled={!props.hasBaseJobs && !props.hasNewJobs}
+            >
+              {retriggerStrings.submitButton}
+            </Button>
           </Grid>
         </Grid>
       </form>


### PR DESCRIPTION
Disable the Base and New retrigger count selects independently when there are no retriggerable job ids for that side, and default a disabled select to 0 so it does not look like jobs will start.

@beatrice-acasandrei @kala-moz 