### PR TITLE
Bug-2023219: Show the full Mann-Whitney warning on the subtests page

### DIFF
--- a/src/__tests__/CompareResults/SubtestsResultsView.test.tsx
+++ b/src/__tests__/CompareResults/SubtestsResultsView.test.tsx
@@ -13,6 +13,7 @@ import getTestData from '../utils/fixtures';
 import {
   renderWithRouter,
   screen,
+  within,
   enableAdvancedColumns,
 } from '../utils/test-utils';
 
@@ -480,6 +481,34 @@ describe('SubtestsResultsView Component Tests for mann-whitney-u testVersion', (
     await user.click(expandRowButton[1]);
     const openedSubtests = await screen.findAllByText(/Normality Test/i);
     expect(openedSubtests).toHaveLength(2);
+  });
+
+  it('shows the Mann-Whitney-U warning banner in full and lets the user dismiss it with the X', async () => {
+    const { subtestsMannWhitneyResult } = getTestData();
+    setup({
+      element: (
+        <SubtestsResultsView title={Strings.metaData.pageTitle.subtests} />
+      ),
+      route: '/subtests-compare-results/',
+      search:
+        '?baseRev=f49863193c13c1def4db2dd3ea9c5d6bd9d517a7&baseRepo=mozilla-central&newRev=2cb6128d7dca8c9a9266b3505d64d55ac1bcc8a8&newRepo=mozilla-central&framework=1&baseParentSignature=4774487&newParentSignature=4774487&test_version=mann-whitney-u',
+      subtestsResult: subtestsMannWhitneyResult,
+    });
+
+    const warning = await screen.findByText(/experimental stage/i);
+    const banner = warning.closest('.MuiAlert-root') as HTMLElement;
+    expect(banner).toBeInTheDocument();
+    expect(
+      screen.getByText(/may not reflect what performance alerts/i),
+    ).toBeInTheDocument();
+
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await user.click(within(banner).getByRole('button', { name: /close/i }));
+
+    expect(screen.queryByText(/experimental stage/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/may not reflect what performance alerts/i),
+    ).not.toBeInTheDocument();
   });
 
   it('should make blobUrl available when "Download JSON" button is clicked', async () => {

--- a/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/ResultsTable.test.tsx.snap
@@ -935,7 +935,7 @@ exports[`Results Table Should match snapshot 1`] = `
                 class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-cv4vpp-MuiGrid-root"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standardWarning MuiAlert-standard f1q43ty0 css-gb7yta-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standardWarning MuiAlert-standard css-7lymnx-MuiPaper-root-MuiAlert-root"
                   role="alert"
                   style="--Paper-shadow: none;"
                 >
@@ -3972,7 +3972,7 @@ exports[`Results Table for MannWhitneyResultsItem for mann-whitney-u testVersion
                 class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-cv4vpp-MuiGrid-root"
               >
                 <div
-                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standardWarning MuiAlert-standard f1q43ty0 css-gb7yta-MuiPaper-root-MuiAlert-root"
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standardWarning MuiAlert-standard css-7lymnx-MuiPaper-root-MuiAlert-root"
                   role="alert"
                   style="--Paper-shadow: none;"
                 >

--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -570,64 +570,68 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
                 </nav>
               </div>
               <div
-                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standardWarning MuiAlert-standard f12anyom css-gb7yta-MuiPaper-root-MuiAlert-root"
-                role="alert"
-                style="--Paper-shadow: none;"
+                class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-1tu7fz5-MuiGrid-root"
               >
                 <div
-                  class="MuiAlert-icon css-vab54s-MuiAlert-icon"
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standardWarning MuiAlert-standard css-7lymnx-MuiPaper-root-MuiAlert-root"
+                  role="alert"
+                  style="--Paper-shadow: none;"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-6gorna-MuiSvgIcon-root"
-                    data-testid="ReportProblemOutlinedIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="MuiAlert-message css-zioonp-MuiAlert-message"
-                >
-                  The Mann-Whitney comparison technique is still in the experimental stage. If you encounter any issues, have suggestions for improvements, or wish to provide feedback, please
-                   
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-17o977x-MuiTypography-root-MuiLink-root"
-                    href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Testing&component=PerfCompare&status_whiteboard=[pcf]"
-                    target="_blank"
-                  >
-                    report it on Bugzilla
-                  </a>
-                  . 
-                   
-                  The performance comparison shown here may not reflect what performance alerts are generated in CI. Conversely, a performance comparison from a generated alert in CI may not reflect the changes shown here. For a comparison that currently reflects our CI detection system, select the Student-T Test option.
-                   
-                </div>
-                <div
-                  class="MuiAlert-action css-rgppqo-MuiAlert-action"
-                >
-                  <button
-                    aria-label="Close"
-                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall css-ak37b0-MuiButtonBase-root-MuiIconButton-root"
-                    tabindex="0"
-                    title="Close"
-                    type="button"
+                  <div
+                    class="MuiAlert-icon css-vab54s-MuiAlert-icon"
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                      data-testid="CloseIcon"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-6gorna-MuiSvgIcon-root"
+                      data-testid="ReportProblemOutlinedIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
                     >
                       <path
-                        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                        d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
                       />
                     </svg>
-                  </button>
+                  </div>
+                  <div
+                    class="MuiAlert-message css-zioonp-MuiAlert-message"
+                  >
+                    The Mann-Whitney comparison technique is still in the experimental stage. If you encounter any issues, have suggestions for improvements, or wish to provide feedback, please
+                     
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-17o977x-MuiTypography-root-MuiLink-root"
+                      href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Testing&component=PerfCompare&status_whiteboard=[pcf]"
+                      target="_blank"
+                    >
+                      report it on Bugzilla
+                    </a>
+                    . 
+                     
+                    The performance comparison shown here may not reflect what performance alerts are generated in CI. Conversely, a performance comparison from a generated alert in CI may not reflect the changes shown here. For a comparison that currently reflects our CI detection system, select the Student-T Test option.
+                     
+                  </div>
+                  <div
+                    class="MuiAlert-action css-rgppqo-MuiAlert-action"
+                  >
+                    <button
+                      aria-label="Close"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall css-ak37b0-MuiButtonBase-root-MuiIconButton-root"
+                      tabindex="0"
+                      title="Close"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                        data-testid="CloseIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
               </div>
               <div
@@ -2464,64 +2468,68 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </nav>
               </div>
               <div
-                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standardWarning MuiAlert-standard f12anyom css-gb7yta-MuiPaper-root-MuiAlert-root"
-                role="alert"
-                style="--Paper-shadow: none;"
+                class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-1tu7fz5-MuiGrid-root"
               >
                 <div
-                  class="MuiAlert-icon css-vab54s-MuiAlert-icon"
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standardWarning MuiAlert-standard css-7lymnx-MuiPaper-root-MuiAlert-root"
+                  role="alert"
+                  style="--Paper-shadow: none;"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-6gorna-MuiSvgIcon-root"
-                    data-testid="ReportProblemOutlinedIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="MuiAlert-message css-zioonp-MuiAlert-message"
-                >
-                  The Mann-Whitney comparison technique is still in the experimental stage. If you encounter any issues, have suggestions for improvements, or wish to provide feedback, please
-                   
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-17o977x-MuiTypography-root-MuiLink-root"
-                    href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Testing&component=PerfCompare&status_whiteboard=[pcf]"
-                    target="_blank"
-                  >
-                    report it on Bugzilla
-                  </a>
-                  . 
-                   
-                  The performance comparison shown here may not reflect what performance alerts are generated in CI. Conversely, a performance comparison from a generated alert in CI may not reflect the changes shown here. For a comparison that currently reflects our CI detection system, select the Student-T Test option.
-                   
-                </div>
-                <div
-                  class="MuiAlert-action css-rgppqo-MuiAlert-action"
-                >
-                  <button
-                    aria-label="Close"
-                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall css-ak37b0-MuiButtonBase-root-MuiIconButton-root"
-                    tabindex="0"
-                    title="Close"
-                    type="button"
+                  <div
+                    class="MuiAlert-icon css-vab54s-MuiAlert-icon"
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                      data-testid="CloseIcon"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-6gorna-MuiSvgIcon-root"
+                      data-testid="ReportProblemOutlinedIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
                     >
                       <path
-                        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                        d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
                       />
                     </svg>
-                  </button>
+                  </div>
+                  <div
+                    class="MuiAlert-message css-zioonp-MuiAlert-message"
+                  >
+                    The Mann-Whitney comparison technique is still in the experimental stage. If you encounter any issues, have suggestions for improvements, or wish to provide feedback, please
+                     
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-17o977x-MuiTypography-root-MuiLink-root"
+                      href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Testing&component=PerfCompare&status_whiteboard=[pcf]"
+                      target="_blank"
+                    >
+                      report it on Bugzilla
+                    </a>
+                    . 
+                     
+                    The performance comparison shown here may not reflect what performance alerts are generated in CI. Conversely, a performance comparison from a generated alert in CI may not reflect the changes shown here. For a comparison that currently reflects our CI detection system, select the Student-T Test option.
+                     
+                  </div>
+                  <div
+                    class="MuiAlert-action css-rgppqo-MuiAlert-action"
+                  >
+                    <button
+                      aria-label="Close"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall css-ak37b0-MuiButtonBase-root-MuiIconButton-root"
+                      tabindex="0"
+                      title="Close"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                        data-testid="CloseIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
               </div>
               <div
@@ -2656,7 +2664,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                           aria-invalid="false"
                           aria-label="Search by title"
                           class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-3v3un6-MuiInputBase-input-MuiOutlinedInput-input"
-                          id="_r_sn_"
+                          id="_r_u2_"
                           placeholder="Filter results"
                           type="search"
                           value=""
@@ -3156,7 +3164,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_sv_"
+                    aria-controls="_r_ua_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -3310,7 +3318,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_t2_"
+                    aria-controls="_r_ud_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -3451,7 +3459,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_t5_"
+                    aria-controls="_r_ug_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -3592,7 +3600,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_t8_"
+                    aria-controls="_r_uj_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -3746,7 +3754,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_tb_"
+                    aria-controls="_r_um_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -4007,64 +4015,68 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                 </nav>
               </div>
               <div
-                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standardWarning MuiAlert-standard f12anyom css-gb7yta-MuiPaper-root-MuiAlert-root"
-                role="alert"
-                style="--Paper-shadow: none;"
+                class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-1tu7fz5-MuiGrid-root"
               >
                 <div
-                  class="MuiAlert-icon css-vab54s-MuiAlert-icon"
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standardWarning MuiAlert-standard css-7lymnx-MuiPaper-root-MuiAlert-root"
+                  role="alert"
+                  style="--Paper-shadow: none;"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-6gorna-MuiSvgIcon-root"
-                    data-testid="ReportProblemOutlinedIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="MuiAlert-message css-zioonp-MuiAlert-message"
-                >
-                  The Mann-Whitney comparison technique is still in the experimental stage. If you encounter any issues, have suggestions for improvements, or wish to provide feedback, please
-                   
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-17o977x-MuiTypography-root-MuiLink-root"
-                    href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Testing&component=PerfCompare&status_whiteboard=[pcf]"
-                    target="_blank"
-                  >
-                    report it on Bugzilla
-                  </a>
-                  . 
-                   
-                  The performance comparison shown here may not reflect what performance alerts are generated in CI. Conversely, a performance comparison from a generated alert in CI may not reflect the changes shown here. For a comparison that currently reflects our CI detection system, select the Student-T Test option.
-                   
-                </div>
-                <div
-                  class="MuiAlert-action css-rgppqo-MuiAlert-action"
-                >
-                  <button
-                    aria-label="Close"
-                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall css-ak37b0-MuiButtonBase-root-MuiIconButton-root"
-                    tabindex="0"
-                    title="Close"
-                    type="button"
+                  <div
+                    class="MuiAlert-icon css-vab54s-MuiAlert-icon"
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                      data-testid="CloseIcon"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-6gorna-MuiSvgIcon-root"
+                      data-testid="ReportProblemOutlinedIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
                     >
                       <path
-                        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                        d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
                       />
                     </svg>
-                  </button>
+                  </div>
+                  <div
+                    class="MuiAlert-message css-zioonp-MuiAlert-message"
+                  >
+                    The Mann-Whitney comparison technique is still in the experimental stage. If you encounter any issues, have suggestions for improvements, or wish to provide feedback, please
+                     
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-17o977x-MuiTypography-root-MuiLink-root"
+                      href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Testing&component=PerfCompare&status_whiteboard=[pcf]"
+                      target="_blank"
+                    >
+                      report it on Bugzilla
+                    </a>
+                    . 
+                     
+                    The performance comparison shown here may not reflect what performance alerts are generated in CI. Conversely, a performance comparison from a generated alert in CI may not reflect the changes shown here. For a comparison that currently reflects our CI detection system, select the Student-T Test option.
+                     
+                  </div>
+                  <div
+                    class="MuiAlert-action css-rgppqo-MuiAlert-action"
+                  >
+                    <button
+                      aria-label="Close"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall css-ak37b0-MuiButtonBase-root-MuiIconButton-root"
+                      tabindex="0"
+                      title="Close"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                        data-testid="CloseIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
               </div>
               <div
@@ -4199,7 +4211,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                           aria-invalid="false"
                           aria-label="Search by title"
                           class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart MuiInputBase-inputAdornedEnd css-3v3un6-MuiInputBase-input-MuiOutlinedInput-input"
-                          id="_r_q0_"
+                          id="_r_rb_"
                           placeholder="Filter results"
                           type="search"
                           value=""
@@ -4699,7 +4711,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_q8_"
+                    aria-controls="_r_rj_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -4853,7 +4865,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_qb_"
+                    aria-controls="_r_rm_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -4994,7 +5006,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_qe_"
+                    aria-controls="_r_rp_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -5135,7 +5147,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_qh_"
+                    aria-controls="_r_rs_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -5289,7 +5301,7 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
                   role="cell"
                 >
                   <button
-                    aria-controls="_r_qk_"
+                    aria-controls="_r_rv_"
                     aria-expanded="false"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeSmall css-1pgb59k-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
@@ -5550,64 +5562,68 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
                 </nav>
               </div>
               <div
-                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standardWarning MuiAlert-standard f12anyom css-gb7yta-MuiPaper-root-MuiAlert-root"
-                role="alert"
-                style="--Paper-shadow: none;"
+                class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-1tu7fz5-MuiGrid-root"
               >
                 <div
-                  class="MuiAlert-icon css-vab54s-MuiAlert-icon"
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standardWarning MuiAlert-standard css-7lymnx-MuiPaper-root-MuiAlert-root"
+                  role="alert"
+                  style="--Paper-shadow: none;"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-6gorna-MuiSvgIcon-root"
-                    data-testid="ReportProblemOutlinedIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="MuiAlert-message css-zioonp-MuiAlert-message"
-                >
-                  The Mann-Whitney comparison technique is still in the experimental stage. If you encounter any issues, have suggestions for improvements, or wish to provide feedback, please
-                   
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-17o977x-MuiTypography-root-MuiLink-root"
-                    href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Testing&component=PerfCompare&status_whiteboard=[pcf]"
-                    target="_blank"
-                  >
-                    report it on Bugzilla
-                  </a>
-                  . 
-                   
-                  The performance comparison shown here may not reflect what performance alerts are generated in CI. Conversely, a performance comparison from a generated alert in CI may not reflect the changes shown here. For a comparison that currently reflects our CI detection system, select the Student-T Test option.
-                   
-                </div>
-                <div
-                  class="MuiAlert-action css-rgppqo-MuiAlert-action"
-                >
-                  <button
-                    aria-label="Close"
-                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall css-ak37b0-MuiButtonBase-root-MuiIconButton-root"
-                    tabindex="0"
-                    title="Close"
-                    type="button"
+                  <div
+                    class="MuiAlert-icon css-vab54s-MuiAlert-icon"
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                      data-testid="CloseIcon"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-6gorna-MuiSvgIcon-root"
+                      data-testid="ReportProblemOutlinedIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
                     >
                       <path
-                        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                        d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
                       />
                     </svg>
-                  </button>
+                  </div>
+                  <div
+                    class="MuiAlert-message css-zioonp-MuiAlert-message"
+                  >
+                    The Mann-Whitney comparison technique is still in the experimental stage. If you encounter any issues, have suggestions for improvements, or wish to provide feedback, please
+                     
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-17o977x-MuiTypography-root-MuiLink-root"
+                      href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Testing&component=PerfCompare&status_whiteboard=[pcf]"
+                      target="_blank"
+                    >
+                      report it on Bugzilla
+                    </a>
+                    . 
+                     
+                    The performance comparison shown here may not reflect what performance alerts are generated in CI. Conversely, a performance comparison from a generated alert in CI may not reflect the changes shown here. For a comparison that currently reflects our CI detection system, select the Student-T Test option.
+                     
+                  </div>
+                  <div
+                    class="MuiAlert-action css-rgppqo-MuiAlert-action"
+                  >
+                    <button
+                      aria-label="Close"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall css-ak37b0-MuiButtonBase-root-MuiIconButton-root"
+                      tabindex="0"
+                      title="Close"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                        data-testid="CloseIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
               </div>
               <div
@@ -7093,64 +7109,68 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
                 </nav>
               </div>
               <div
-                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standardWarning MuiAlert-standard f12anyom css-gb7yta-MuiPaper-root-MuiAlert-root"
-                role="alert"
-                style="--Paper-shadow: none;"
+                class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-1tu7fz5-MuiGrid-root"
               >
                 <div
-                  class="MuiAlert-icon css-vab54s-MuiAlert-icon"
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standardWarning MuiAlert-standard css-7lymnx-MuiPaper-root-MuiAlert-root"
+                  role="alert"
+                  style="--Paper-shadow: none;"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-6gorna-MuiSvgIcon-root"
-                    data-testid="ReportProblemOutlinedIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="MuiAlert-message css-zioonp-MuiAlert-message"
-                >
-                  The Mann-Whitney comparison technique is still in the experimental stage. If you encounter any issues, have suggestions for improvements, or wish to provide feedback, please
-                   
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-17o977x-MuiTypography-root-MuiLink-root"
-                    href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Testing&component=PerfCompare&status_whiteboard=[pcf]"
-                    target="_blank"
-                  >
-                    report it on Bugzilla
-                  </a>
-                  . 
-                   
-                  The performance comparison shown here may not reflect what performance alerts are generated in CI. Conversely, a performance comparison from a generated alert in CI may not reflect the changes shown here. For a comparison that currently reflects our CI detection system, select the Student-T Test option.
-                   
-                </div>
-                <div
-                  class="MuiAlert-action css-rgppqo-MuiAlert-action"
-                >
-                  <button
-                    aria-label="Close"
-                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall css-ak37b0-MuiButtonBase-root-MuiIconButton-root"
-                    tabindex="0"
-                    title="Close"
-                    type="button"
+                  <div
+                    class="MuiAlert-icon css-vab54s-MuiAlert-icon"
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
-                      data-testid="CloseIcon"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-6gorna-MuiSvgIcon-root"
+                      data-testid="ReportProblemOutlinedIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
                     >
                       <path
-                        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                        d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
                       />
                     </svg>
-                  </button>
+                  </div>
+                  <div
+                    class="MuiAlert-message css-zioonp-MuiAlert-message"
+                  >
+                    The Mann-Whitney comparison technique is still in the experimental stage. If you encounter any issues, have suggestions for improvements, or wish to provide feedback, please
+                     
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-17o977x-MuiTypography-root-MuiLink-root"
+                      href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Testing&component=PerfCompare&status_whiteboard=[pcf]"
+                      target="_blank"
+                    >
+                      report it on Bugzilla
+                    </a>
+                    . 
+                     
+                    The performance comparison shown here may not reflect what performance alerts are generated in CI. Conversely, a performance comparison from a generated alert in CI may not reflect the changes shown here. For a comparison that currently reflects our CI detection system, select the Student-T Test option.
+                     
+                  </div>
+                  <div
+                    class="MuiAlert-action css-rgppqo-MuiAlert-action"
+                  >
+                    <button
+                      aria-label="Close"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall css-ak37b0-MuiButtonBase-root-MuiIconButton-root"
+                      tabindex="0"
+                      title="Close"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-54rgmy-MuiSvgIcon-root"
+                        data-testid="CloseIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
               </div>
               <div

--- a/src/components/CompareResults/ResultsMain.tsx
+++ b/src/components/CompareResults/ResultsMain.tsx
@@ -1,8 +1,6 @@
 import { useRef, useEffect, useState } from 'react';
 
 import { Button, Grid } from '@mui/material';
-import Alert from '@mui/material/Alert';
-import Link from '@mui/material/Link';
 import { Container } from '@mui/system';
 import { useLoaderData } from 'react-router';
 import { style } from 'typestyle';
@@ -11,19 +9,13 @@ import HowToReadResults from './HowToReadResults';
 import type { LoaderReturnValue } from './loader';
 import type { LoaderReturnValue as OverTimeLoaderReturnValue } from './overTimeLoader';
 import ResultsTable from './ResultsTable';
-import {
-  STUDENT_T,
-  MANN_WHITNEY_U,
-  RESULTS_TABLE_MAX_WIDTH,
-} from '../../common/constants';
-import { useAppSelector, useAppDispatch } from '../../hooks/app';
+import { TestVersionWarning } from './TestVersionWarning';
+import { STUDENT_T, RESULTS_TABLE_MAX_WIDTH } from '../../common/constants';
+import { useAppSelector } from '../../hooks/app';
 import useRawSearchParams from '../../hooks/useRawSearchParams';
-import { updateShowMannWhitneyWarning } from '../../reducers/ColumnPrefsSlice';
-import { Strings } from '../../resources/Strings';
 import { Colors, FontsRaw, FontSizeRaw, Spacing } from '../../styles';
 import pencilDark from '../../theme/img/pencil-dark.svg';
 import pencil from '../../theme/img/pencil.svg';
-import type { TestVersion } from '../../types/types';
 import EditTitleInput from '../CompareResults/EditTitleInput';
 import ToggleReplicatesButton from '../Shared/ToggleReplicatesButton';
 
@@ -33,19 +25,11 @@ function ResultsMain() {
   const loaderData = useLoaderData<CombinedLoaderReturnValue>();
   const testVersion = loaderData.testVersion;
   const themeMode = useAppSelector((state) => state.theme.mode);
-  const dispatch = useAppDispatch();
-  const showMannWhitneyWarning = useAppSelector(
-    (state) => state.columnPrefs.showMannWhitneyWarning,
-  );
 
   const themeColor100 =
     themeMode === 'light' ? Colors.Background300 : Colors.Background100Dark;
 
   const styles = {
-    alert: style({
-      width: '100%',
-      fontSize: '16px',
-    }),
     container: style({
       backgroundColor: themeColor100,
       margin: '0 auto',
@@ -133,30 +117,6 @@ function ResultsMain() {
     />
   );
 
-  const testWarnings: Record<TestVersion, React.JSX.Element> = {
-    'mann-whitney-u': (
-      <Alert
-        severity='warning'
-        className={styles.alert}
-        onClose={() => dispatch(updateShowMannWhitneyWarning(false))}
-      >
-        {Strings.components.mannWhitneyUWarning.text}{' '}
-        <Link
-          href={Strings.components.mannWhitneyUWarning.href}
-          target='_blank'
-        >
-          {Strings.components.mannWhitneyUWarning.linkText}
-        </Link>
-        {'. '} {Strings.components.mannWhitneyUWarning.text2}{' '}
-      </Alert>
-    ),
-    'student-t': (
-      <Alert severity='warning' className={styles.alert}>
-        {Strings.components.studentTTestWarning.text}
-      </Alert>
-    ),
-  };
-
   return (
     <Container
       maxWidth={false}
@@ -203,11 +163,7 @@ function ResultsMain() {
         </Grid>
 
         <Grid container sx={titleContainerSx}>
-          {testVersion === STUDENT_T
-            ? testWarnings[STUDENT_T]
-            : showMannWhitneyWarning
-              ? testWarnings[MANN_WHITNEY_U]
-              : null}
+          <TestVersionWarning testVersion={testVersion} />
         </Grid>
       </header>
       <HowToReadResults />

--- a/src/components/CompareResults/SubtestsResults/SubtestsResultsMain.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsResultsMain.tsx
@@ -14,6 +14,7 @@ import SearchInput from '.././SearchInput';
 import {
   subtestsView,
   subtestsOverTimeView,
+  MANN_WHITNEY_U,
   STUDENT_T,
   RESULTS_TABLE_MAX_WIDTH,
 } from '../../../common/constants';
@@ -30,9 +31,9 @@ import {
   RetriggerButton,
   DisabledRetriggerButton,
 } from '../Retrigger/RetriggerButton';
-import { TestVersionWarning } from '../TestVersionWarning';
 import { LoaderReturnValue } from '../subtestsLoader';
 import { LoaderReturnValue as OvertimeLoaderReturnValue } from '../subtestsOverTimeLoader';
+import { TestVersionWarning } from '../TestVersionWarning';
 
 type SubtestsResultsHeaderProps = {
   loadedResults: CompareResultsItem[];
@@ -146,7 +147,7 @@ function SubtestsResultsMain({ view }: SubtestsResultsMainProps) {
           </Grid>
         )}
         <Grid container sx={{ margin: `0 0 ${Spacing.Medium}px 0` }}>
-          <TestVersionWarning testVersion={testVersion} />
+          <TestVersionWarning testVersion={testVersion ?? MANN_WHITNEY_U} />
         </Grid>
         <Suspense
           fallback={

--- a/src/components/CompareResults/SubtestsResults/SubtestsResultsMain.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsResultsMain.tsx
@@ -1,8 +1,6 @@
 import { useState, Suspense } from 'react';
 
 import { Grid, Skeleton, Stack } from '@mui/material';
-import Alert from '@mui/material/Alert';
-import Link from '@mui/material/Link';
 import { Container } from '@mui/system';
 import { useLoaderData, Await } from 'react-router';
 import { style } from 'typestyle';
@@ -16,13 +14,11 @@ import SearchInput from '.././SearchInput';
 import {
   subtestsView,
   subtestsOverTimeView,
-  MANN_WHITNEY_U,
   STUDENT_T,
   RESULTS_TABLE_MAX_WIDTH,
 } from '../../../common/constants';
-import { useAppSelector, useAppDispatch } from '../../../hooks/app';
+import { useAppSelector } from '../../../hooks/app';
 import useRawSearchParams from '../../../hooks/useRawSearchParams';
-import { updateShowMannWhitneyWarning } from '../../../reducers/ColumnPrefsSlice';
 import { Strings } from '../../../resources/Strings';
 import { Colors, Spacing } from '../../../styles';
 import type {
@@ -34,6 +30,7 @@ import {
   RetriggerButton,
   DisabledRetriggerButton,
 } from '../Retrigger/RetriggerButton';
+import { TestVersionWarning } from '../TestVersionWarning';
 import { LoaderReturnValue } from '../subtestsLoader';
 import { LoaderReturnValue as OvertimeLoaderReturnValue } from '../subtestsOverTimeLoader';
 
@@ -108,13 +105,6 @@ type CombinedLoaderReturnValue = LoaderReturnValue | OvertimeLoaderReturnValue;
 function SubtestsResultsMain({ view }: SubtestsResultsMainProps) {
   const { results, replicates, testVersion } =
     useLoaderData<CombinedLoaderReturnValue>();
-  const dispatch = useAppDispatch();
-  const showMannWhitneyWarning = useAppSelector(
-    (state) => state.columnPrefs.showMannWhitneyWarning,
-  );
-  const displayMannWhitneyUWarning =
-    testVersion === MANN_WHITNEY_U && showMannWhitneyWarning;
-
   const themeMode = useAppSelector((state) => state.theme.mode);
 
   // This is our custom hook that updates the search params without a rerender.
@@ -131,11 +121,6 @@ function SubtestsResultsMain({ view }: SubtestsResultsMainProps) {
       margin: '0 auto',
       marginBottom: '80px',
       maxWidth: RESULTS_TABLE_MAX_WIDTH,
-    }),
-    title: style({
-      margin: 0,
-      marginBottom: Spacing.Medium,
-      fontSize: '16px',
     }),
   };
 
@@ -160,22 +145,9 @@ function SubtestsResultsMain({ view }: SubtestsResultsMainProps) {
             <ToggleReplicatesButton />
           </Grid>
         )}
-        {displayMannWhitneyUWarning && (
-          <Alert
-            severity='warning'
-            className={styles.title}
-            onClose={() => dispatch(updateShowMannWhitneyWarning(false))}
-          >
-            {Strings.components.mannWhitneyUWarning.text}{' '}
-            <Link
-              href={Strings.components.mannWhitneyUWarning.href}
-              target='_blank'
-            >
-              {Strings.components.mannWhitneyUWarning.linkText}
-            </Link>
-            {'. '} {Strings.components.mannWhitneyUWarning.text2}{' '}
-          </Alert>
-        )}
+        <Grid container sx={{ margin: `0 0 ${Spacing.Medium}px 0` }}>
+          <TestVersionWarning testVersion={testVersion} />
+        </Grid>
         <Suspense
           fallback={
             <>

--- a/src/components/CompareResults/TestVersionWarning.tsx
+++ b/src/components/CompareResults/TestVersionWarning.tsx
@@ -41,10 +41,7 @@ export function TestVersionWarning({ testVersion }: TestVersionWarningProps) {
       onClose={() => dispatch(updateShowMannWhitneyWarning(false))}
     >
       {Strings.components.mannWhitneyUWarning.text}{' '}
-      <Link
-        href={Strings.components.mannWhitneyUWarning.href}
-        target='_blank'
-      >
+      <Link href={Strings.components.mannWhitneyUWarning.href} target='_blank'>
         {Strings.components.mannWhitneyUWarning.linkText}
       </Link>
       {'. '} {Strings.components.mannWhitneyUWarning.text2}{' '}

--- a/src/components/CompareResults/TestVersionWarning.tsx
+++ b/src/components/CompareResults/TestVersionWarning.tsx
@@ -1,0 +1,53 @@
+import Alert from '@mui/material/Alert';
+import Link from '@mui/material/Link';
+
+import { STUDENT_T } from '../../common/constants';
+import { useAppDispatch, useAppSelector } from '../../hooks/app';
+import { updateShowMannWhitneyWarning } from '../../reducers/ColumnPrefsSlice';
+import { Strings } from '../../resources/Strings';
+import type { TestVersion } from '../../types/types';
+
+const alertSx = {
+  width: '100%',
+  fontSize: '16px',
+};
+
+type TestVersionWarningProps = {
+  testVersion: TestVersion;
+};
+
+export function TestVersionWarning({ testVersion }: TestVersionWarningProps) {
+  const dispatch = useAppDispatch();
+  const showMannWhitneyWarning = useAppSelector(
+    (state) => state.columnPrefs.showMannWhitneyWarning,
+  );
+
+  if (testVersion === STUDENT_T) {
+    return (
+      <Alert severity='warning' sx={alertSx}>
+        {Strings.components.studentTTestWarning.text}
+      </Alert>
+    );
+  }
+
+  if (!showMannWhitneyWarning) {
+    return null;
+  }
+
+  return (
+    <Alert
+      severity='warning'
+      sx={alertSx}
+      onClose={() => dispatch(updateShowMannWhitneyWarning(false))}
+    >
+      {Strings.components.mannWhitneyUWarning.text}{' '}
+      <Link
+        href={Strings.components.mannWhitneyUWarning.href}
+        target='_blank'
+      >
+        {Strings.components.mannWhitneyUWarning.linkText}
+      </Link>
+      {'. '} {Strings.components.mannWhitneyUWarning.text2}{' '}
+    </Alert>
+  );
+}


### PR DESCRIPTION
The Mann-Whitney experimental warning was duplicated in `ResultsMain` and `SubtestsResultsMain`. On the subtests page the alert used title styles without `width: 100%`, so the second sentence (CI detection vs this comparison) was clipped.

This change extracts a shared `TestVersionWarning` with a full-width alert and uses it on both pages, so the complete message and dismiss control match. Jest snapshots are updated via `npm run fix-all`.

Screenshots:
Results Page:
<img width="1918" height="777" alt="image" src="https://github.com/user-attachments/assets/9f6d27f0-8ba5-4127-9984-c9e231f58cb4" />

Subtests Page
<img width="1877" height="547" alt="image" src="https://github.com/user-attachments/assets/4b735131-40ef-408e-b25d-6be17b10cf19" />


Fixes [Bug-2023219](https://bugzilla.mozilla.org/show_bug.cgi?id=2023219)

@kala-moz @beatrice-acasandrei 