### PR TITLE
Bug-1982588: Align breadcrumbs and replicates button in Subtests View

### DIFF
--- a/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
+++ b/src/__tests__/CompareResults/__snapshots__/SubtestsResultsView.test.tsx.snap
@@ -499,10 +499,10 @@ exports[`SubtestsResultsView Component Tests should render the subtests results 
           >
             <header>
               <div
-                class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row MuiGrid-spacing-xs-1 css-1ewzjrk-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-cv4vpp-MuiGrid-root"
               >
                 <nav
-                  class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-12zd3mg-MuiTypography-root-MuiBreadcrumbs-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-233p9k-MuiTypography-root-MuiBreadcrumbs-root"
                 >
                   <ol
                     class="MuiBreadcrumbs-ol css-1uwp4ue-MuiBreadcrumbs-ol"
@@ -2391,10 +2391,10 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
           >
             <header>
               <div
-                class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row MuiGrid-spacing-xs-1 css-1ewzjrk-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-cv4vpp-MuiGrid-root"
               >
                 <nav
-                  class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-12zd3mg-MuiTypography-root-MuiBreadcrumbs-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-233p9k-MuiTypography-root-MuiBreadcrumbs-root"
                 >
                   <ol
                     class="MuiBreadcrumbs-ol css-1uwp4ue-MuiBreadcrumbs-ol"
@@ -3932,10 +3932,10 @@ exports[`SubtestsViewCompareOverTime Component Tests in mann-whitney-u testVersi
           >
             <header>
               <div
-                class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row MuiGrid-spacing-xs-1 css-1ewzjrk-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-cv4vpp-MuiGrid-root"
               >
                 <nav
-                  class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-12zd3mg-MuiTypography-root-MuiBreadcrumbs-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-233p9k-MuiTypography-root-MuiBreadcrumbs-root"
                 >
                   <ol
                     class="MuiBreadcrumbs-ol css-1uwp4ue-MuiBreadcrumbs-ol"
@@ -5473,10 +5473,10 @@ exports[`SubtestsViewCompareOverTime Component Tests renders over-time view when
           >
             <header>
               <div
-                class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row MuiGrid-spacing-xs-1 css-1ewzjrk-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-cv4vpp-MuiGrid-root"
               >
                 <nav
-                  class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-12zd3mg-MuiTypography-root-MuiBreadcrumbs-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-233p9k-MuiTypography-root-MuiBreadcrumbs-root"
                 >
                   <ol
                     class="MuiBreadcrumbs-ol css-1uwp4ue-MuiBreadcrumbs-ol"
@@ -7014,10 +7014,10 @@ exports[`SubtestsViewCompareOverTime Component Tests should render the subtests 
           >
             <header>
               <div
-                class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row MuiGrid-spacing-xs-1 css-1ewzjrk-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row css-cv4vpp-MuiGrid-root"
               >
                 <nav
-                  class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-12zd3mg-MuiTypography-root-MuiBreadcrumbs-root"
+                  class="MuiTypography-root MuiTypography-body1 MuiBreadcrumbs-root css-233p9k-MuiTypography-root-MuiBreadcrumbs-root"
                 >
                   <ol
                     class="MuiBreadcrumbs-ol css-1uwp4ue-MuiBreadcrumbs-ol"

--- a/src/components/CompareResults/SubtestsResults/SubtestsBreadcrumbs.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsBreadcrumbs.tsx
@@ -53,12 +53,7 @@ function SubtestsBreadcrumbs({ view }: SubtestsBreadcrumbsProps) {
       : getPreviousCompareOverTimeURL();
 
   return (
-    <Breadcrumbs
-      separator={<ChevronLeftIcon fontSize='small' />}
-      sx={{
-        marginBottom: 3,
-      }}
-    >
+    <Breadcrumbs separator={<ChevronLeftIcon fontSize='small' />}>
       <span role='presentation'></span>
       <Link href='/'>Home</Link>
       <Link href={allResultsURL}>All results</Link>

--- a/src/components/CompareResults/SubtestsResults/SubtestsResultsMain.tsx
+++ b/src/components/CompareResults/SubtestsResults/SubtestsResultsMain.tsx
@@ -138,6 +138,16 @@ function SubtestsResultsMain({ view }: SubtestsResultsMainProps) {
       marginBottom: Spacing.Medium,
       fontSize: '16px',
     }),
+    replicates: style({
+      marginRight: '10px',
+    }),
+  };
+
+  const titleContainerSx = {
+    alignItems: 'center',
+    gap: '9px',
+    margin: `0 0 ${Spacing.Medium}px 0`,
+    justifyContent: 'space-between',
   };
 
   const onSearchTermChange = (newSearchTerm: string) => {
@@ -158,14 +168,14 @@ function SubtestsResultsMain({ view }: SubtestsResultsMainProps) {
   return (
     <Container className={styles.container} data-testid='subtests-main'>
       <header>
-        <Grid container spacing={1}>
+        <Grid container sx={titleContainerSx}>
           <SubtestsBreadcrumbs view={view} />
+          {testVersion === STUDENT_T && (
+            <Grid component='h2' className={styles.replicates}>
+              <ToggleReplicatesButton />
+            </Grid>
+          )}
         </Grid>
-        {testVersion === STUDENT_T && (
-          <Grid sx={{ marginRight: '10px' }}>
-            <ToggleReplicatesButton />
-          </Grid>
-        )}
         {displayMannWhitneyUWarning && (
           <Alert
             severity='warning'


### PR DESCRIPTION
### Changes Introduced
- Breadcrumbs and ToggleReplicatesButton now share one Grid with space-between / alignItems: center in SubtestsResultsMain.tsx (same pattern as Results View). 
- Breadcrumb marginBottom: 3 was removed so they line up. 
- Button still only shows for STUDENT_T. Snapshots updated. PR title/body include the bug number and target fork main, not mozilla/*

Please review: @beatrice-acasandrei @esanuandra @kala-moz 

Fixes [Bug-1982588](https://bugzilla.mozilla.org/show_bug.cgi?id=1982588)